### PR TITLE
Fix the spelling of preceding, specified, received and additionally

### DIFF
--- a/include/mysql_com.h
+++ b/include/mysql_com.h
@@ -90,7 +90,7 @@ enum enum_server_command
 
 /*
   Length of random string sent by server on handshake; this is also length of
-  obfuscated password, recieved from client
+  obfuscated password, received from client
 */
 #define SCRAMBLE_LENGTH 20
 #define AUTH_PLUGIN_DATA_PART_1_LENGTH 8

--- a/libevent/event.3
+++ b/libevent/event.3
@@ -253,7 +253,7 @@ the type of event which will be either
 or
 .Va EV_WRITE .
 Additionally, an event which has registered interest in more than one of the
-preceeding events, via bitwise-OR to
+preceding events, via bitwise-OR to
 .Fn event_set ,
 can provide its callback function with a bitwise-OR of more than one triggered
 event.

--- a/libmysql/errmsg.c
+++ b/libmysql/errmsg.c
@@ -81,7 +81,7 @@ const char *client_errors[]=
   "Attempt to read a row while there is no result set associated with the statement",
   "This feature is not implemented yet",
   "Lost connection to MySQL server at '%s', system error: %d",
-  "Statement closed indirectly because of a preceeding %s() call",
+  "Statement closed indirectly because of a preceding %s() call",
   "The number of columns in the result set differs from the number of bound buffers. You must reset the statement, rebind the result set columns, and execute the statement again",
   "This handle is already connected. Use a separate handle for each connection.",
   "Authentication plugin '%s' cannot be loaded: %s",

--- a/mysql-test/extra/rpl_tests/rpl_ddl.test
+++ b/mysql-test/extra/rpl_tests/rpl_ddl.test
@@ -98,8 +98,8 @@
 #       --> less switching of AUTOCOMMIT mode on master side.
 #
 #    4. Never use a test object, which was direct or indirect affected by a
-#       preceeding test sequence again.
-#       If one preceeding test sequence hits a (sometimes not visible,
+#       preceding test sequence again.
+#       If one preceding test sequence hits a (sometimes not visible,
 #       because the sql error code of the statement might be 0) bug
 #       and these rules are ignored, a following test sequence might earn ugly
 #       effects like failing 'sync_slave_with_master', crashes of the slave or

--- a/mysql-test/extra/rpl_tests/rpl_row_basic.test
+++ b/mysql-test/extra/rpl_tests/rpl_row_basic.test
@@ -223,7 +223,7 @@ INSERT INTO t7 VALUES (1,3), (2,6), (3,9);
 SELECT * FROM t7 ORDER BY C1;
 
 # since bug#31552/31609 idempotency is not default any longer. In order
-# the preceeding test INSERT INTO t7 to pass the mode is switched
+# the preceding test INSERT INTO t7 to pass the mode is switched
 # temprorarily
 set @@global.slave_exec_mode= 'IDEMPOTENT';
 
@@ -262,7 +262,7 @@ INSERT INTO t8 VALUES (1,2,3), (2,4,6), (3,6,9);
 SELECT * FROM t8 ORDER BY a;
 
 # since bug#31552/31609 idempotency is not default any longer. In order
-# the preceeding test INSERT INTO t8 to pass the mode is switched
+# the preceding test INSERT INTO t8 to pass the mode is switched
 # temprorarily
 set @@global.slave_exec_mode= 'IDEMPOTENT';
 

--- a/mysql-test/include/wait_until_count_sessions.inc
+++ b/mysql-test/include/wait_until_count_sessions.inc
@@ -10,7 +10,7 @@
 #    1. We wait for $current_sessions <= $count_sessions because in the use case
 #       with count_sessions.inc before and wait_until_count_sessions.inc after
 #       the core of the test it could happen that the disconnects of sessions
-#       belonging to the preceeding test are not finished.
+#       belonging to the preceding test are not finished.
 #       sessions at test begin($count_sessions) =  m + n
 #       sessions of the previous test which will be soon disconnected = n (n >= 0)
 #       sessions at test end ($current sessions, assuming the test disconnects

--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -6868,7 +6868,7 @@ Misc options
   start-dirty           Only start the servers (without initialization) for
                         the first specified test case
   user-args             In combination with start* and no test name, drops
-                        arguments to mysqld except those speficied with
+                        arguments to mysqld except those specified with
                         --mysqld (if any)
   wait-all              If --start or --start-dirty option is used, wait for all
                         servers to exit before finishing the process

--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -740,7 +740,7 @@ The following options may be given as the first argument:
  Optional semicolon-separated list of plugins to load,
  where each plugin is identified as name=library, where
  name is the plugin name and library is the plugin library
- in plugin_dir. This option adds to the list speficied by
+ in plugin_dir. This option adds to the list specified by
  --plugin-load in an incremental way. Multiple
  --plugin-load-add are supported.
  -P, --port=#        Port number to use for connection or 0 to default to,

--- a/mysql-test/r/mysqld--help-win.result
+++ b/mysql-test/r/mysqld--help-win.result
@@ -732,7 +732,7 @@ The following options may be given as the first argument:
  Optional semicolon-separated list of plugins to load,
  where each plugin is identified as name=library, where
  name is the plugin name and library is the plugin library
- in plugin_dir. This option adds to the list speficied by
+ in plugin_dir. This option adds to the list specified by
  --plugin-load in an incremental way. Multiple
  --plugin-load-add are supported.
  -P, --port=#        Port number to use for connection or 0 to default to,

--- a/mysql-test/r/ps.result
+++ b/mysql-test/r/ps.result
@@ -638,8 +638,8 @@ insert into t2 values ("1", "1", "sup", "0"), ("2", "1", "sup", "1"),
 ("4", "1", "sup", "0");
 create table t3 (
 id int(11) not null default '0',
-preceeding_id int(11) not null default '0',
-primary key  (id,preceeding_id)
+preceding_id int(11) not null default '0',
+primary key  (id,preceding_id)
 );
 create table t4 (
 user_id varchar(50) not null,
@@ -650,7 +650,7 @@ insert into t4 values("nicke", "imp");
 prepare stmt from
 'select distinct t1.partner_id
 from t1 left join t3 on t1.id = t3.id
-     left join t1 pp on pp.id = t3.preceeding_id
+     left join t1 pp on pp.id = t3.preceding_id
 where
   exists (
     select *

--- a/mysql-test/suite/funcs_1/views/func_view.inc
+++ b/mysql-test/suite/funcs_1/views/func_view.inc
@@ -292,7 +292,7 @@ INSERT INTO t1_values SET
 #               other interesting value
 #     numbers   -> 0
 #     strings, blobs, binaries -> not full length of used data type, "exotic"
-#                                 characters and preceeding and trailing spaces
+#                                 characters and preceding and trailing spaces
 #     FIXME enum, set ??
 INSERT INTO t1_values SET
        my_char_30 = ' ---äÖüß@µ*$-- ',

--- a/mysql-test/suite/funcs_1/views/views_master.inc
+++ b/mysql-test/suite/funcs_1/views/views_master.inc
@@ -545,7 +545,7 @@ let $message= Testcase 3.3.1.7 ;
 #                   view names are accepted, at creation time, alteration time,
 #                   and drop time.
 ###############################################################################
-# Note(mleich): non-qualified view name means a view name without preceeding
+# Note(mleich): non-qualified view name means a view name without preceding
 #               database name
 --disable_warnings
 DROP VIEW  IF EXISTS v1 ;

--- a/mysql-test/suite/rpl/t/rpl_ddl.test
+++ b/mysql-test/suite/rpl/t/rpl_ddl.test
@@ -13,10 +13,10 @@
 #         sequences start.
 #
 #      2. Never use a test object, which was direct or indirect affected by a
-#         preceeding test sequence again.
+#         preceding test sequence again.
 #         Except table d1.t1 where ONLY DML is allowed.
 #
-#         If one preceeding test sequence hits a (sometimes not good visible,
+#         If one preceding test sequence hits a (sometimes not good visible,
 #         because the sql error code of the statement might be 0) bug
 #         and these rules are ignored, a following test sequence might earn ugly
 #         effects like failing 'sync_slave_with_master', crashes of the slave or

--- a/mysql-test/suite/rpl/t/rpl_row_basic_11bugs.test
+++ b/mysql-test/suite/rpl/t/rpl_row_basic_11bugs.test
@@ -240,7 +240,7 @@ INSERT INTO t1 VALUES (1,'master,slave'), (2,'master,slave');
 UPDATE t1 SET a = 5, b = 'slave' WHERE a = 1;
 SELECT * FROM t1 ORDER BY a;
 # since bug#31552/31609 idempotency is not default any longer. In
-# order for the preceeding test UPDATE t1 to pass, the mode is switched
+# order for the preceding test UPDATE t1 to pass, the mode is switched
 # temprorarily
 set @@global.slave_exec_mode= 'IDEMPOTENT';
 --echo **** On Master ****

--- a/mysql-test/suite/rpl_ndb/t/rpl_ndb_ddl.test
+++ b/mysql-test/suite/rpl_ndb/t/rpl_ndb_ddl.test
@@ -18,10 +18,10 @@
 #         sequences start.
 #
 #      2. Never use a test object, which was direct or indirect affected by a
-#         preceeding test sequence again.
+#         preceding test sequence again.
 #         Except table d1.t1 where ONLY DML is allowed.
 #
-#         If one preceeding test sequence hits a (sometimes not good visible,
+#         If one preceding test sequence hits a (sometimes not good visible,
 #         because the sql error code of the statement might be 0) bug
 #         and these rules are ignored, a following test sequence might earn ugly
 #         effects like failing 'sync_slave_with_master', crashes of the slave or

--- a/mysql-test/t/ps.test
+++ b/mysql-test/t/ps.test
@@ -667,8 +667,8 @@ insert into t2 values ("1", "1", "sup", "0"), ("2", "1", "sup", "1"),
 
 create table t3 (
   id int(11) not null default '0',
-  preceeding_id int(11) not null default '0',
-  primary key  (id,preceeding_id)
+  preceding_id int(11) not null default '0',
+  primary key  (id,preceding_id)
 );
 
 create table t4 (
@@ -682,7 +682,7 @@ insert into t4 values("nicke", "imp");
 prepare stmt from
 'select distinct t1.partner_id
 from t1 left join t3 on t1.id = t3.id
-     left join t1 pp on pp.id = t3.preceeding_id
+     left join t1 pp on pp.id = t3.preceding_id
 where
   exists (
     select *

--- a/sql/abstract_query_plan.cc
+++ b/sql/abstract_query_plan.cc
@@ -336,7 +336,7 @@ namespace AQP
       {
         /*
           It means that the decision on which access method to use
-          will be taken late (as rows from the preceeding operation arrive).
+          will be taken late (as rows from the preceding operation arrive).
           This operation is therefor not pushable.
         */
         DBUG_PRINT("info",

--- a/sql/auth/password.c
+++ b/sql/auth/password.c
@@ -301,7 +301,7 @@ void make_scrambled_password(char *to, const char *password)
 
 /*
     Produce an obscure octet sequence from password and random
-    string, recieved from the server. This sequence corresponds to the
+    string, received from the server. This sequence corresponds to the
     password, but password can not be easily restored from it. The sequence
     is then sent to the server for validation. Trailing zero is not stored
     in the buf as it is not needed.
@@ -335,7 +335,7 @@ scramble(char *to, const char *message, const char *password)
 
 /*
     Check that scrambled message corresponds to the password; the function
-    is used by server to check that recieved reply is authentic.
+    is used by server to check that received reply is authentic.
     This function does not check lengths of given strings: message must be
     null-terminated, reply and hash_stage2 must be at least SHA1_HASH_SIZE
     long (if not, something fishy is going on).

--- a/sql/ha_ndbcluster_binlog.cc
+++ b/sql/ha_ndbcluster_binlog.cc
@@ -281,7 +281,7 @@ ndb_binlog_close_shadow_table(NDB_SHARE *share)
 /*
   Open a shadow table for the table given in share.
   - The shadow table is (mainly) used when an event is
-    recieved from the data nodes which need to be written
+    received from the data nodes which need to be written
     to the binlog injector.
 */
 

--- a/sql/ha_ndbcluster_push.cc
+++ b/sql/ha_ndbcluster_push.cc
@@ -1494,7 +1494,7 @@ ndb_pushed_builder_ctx::build_key(const AQP::Table_access* table,
         if (m_join_scope.contain(referred_table_no))
         {
           // Locate the parent operation for this 'join_items[]'.
-          // May refer any of the preceeding parent tables
+          // May refer any of the preceding parent tables
           const NdbQueryOperationDef* const parent_op= m_tables[referred_table_no].m_op;
           DBUG_ASSERT(parent_op != NULL);
 

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -1022,7 +1022,7 @@ typedef struct st_ha_create_information
     For ALTER TABLE defaults to ROW_TYPE_NOT_USED (means "keep the current").
 
     Can be changed either explicitly by the parser.
-    If nothing speficied inherits the value of the original table (if present).
+    If nothing specified inherits the value of the original table (if present).
   */
   enum row_type row_type;
   uint null_bits;                       /* NULL bits at start of record */

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -4904,7 +4904,7 @@ int Query_log_event::do_apply_event(Relay_log_info const *rli,
     if ((error= rows_event_stmt_cleanup(const_cast<Relay_log_info*>(rli), thd)))
     {
       const_cast<Relay_log_info*>(rli)->report(ERROR_LEVEL, error,
-                  "Error in cleaning up after an event preceeding the commit; "
+                  "Error in cleaning up after an event preceding the commit; "
                   "the group log file/position: %s %s",
                   const_cast<Relay_log_info*>(rli)->get_group_master_log_name(),
                   llstr(const_cast<Relay_log_info*>(rli)->get_group_master_log_pos(),

--- a/sql/log_event.h
+++ b/sql/log_event.h
@@ -2345,7 +2345,7 @@ public:
   bool is_valid() const { return query != 0; }
 
   /*
-    Returns number of bytes additionaly written to post header by derived
+    Returns number of bytes additionally written to post header by derived
     events (so far it is only Execute_load_query event).
   */
   virtual ulong get_post_header_size_for_derived() { return 0; }

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -5617,7 +5617,7 @@ struct my_option my_long_options[]=
    "Optional semicolon-separated list of plugins to load, where each plugin is "
    "identified as name=library, where name is the plugin name and library "
    "is the plugin library in plugin_dir. This option adds to the list "
-   "speficied by --plugin-load in an incremental way. "
+   "specified by --plugin-load in an incremental way. "
    "Multiple --plugin-load-add are supported.",
    0, 0, 0,
    GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},

--- a/sql/parse_tree_nodes.h
+++ b/sql/parse_tree_nodes.h
@@ -1225,7 +1225,7 @@ public:
     {
       /*
         Not in trigger assigning value to new row,
-        and option_type preceeding local variable is illegal.
+        and option_type preceding local variable is illegal.
       */
       error(pc, pos);
       return true;

--- a/sql/rpl_utility.cc
+++ b/sql/rpl_utility.cc
@@ -1633,7 +1633,7 @@ bool Deferred_log_events::execute(Relay_log_info *rli)
 void Deferred_log_events::rewind()
 {
   /*
-    Reset preceeding Query log event events which execution was
+    Reset preceding Query log event events which execution was
     deferred because of slave side filtering.
   */
   delete_container_pointers(m_array);

--- a/sql/sql_optimizer.cc
+++ b/sql/sql_optimizer.cc
@@ -1127,7 +1127,7 @@ void JOIN::test_skip_sort()
       }
     }
   }
-  else if (order &&                      // ORDER BY wo/ preceeding GROUP BY
+  else if (order &&                      // ORDER BY wo/ preceding GROUP BY
            (simple_order || skip_sort_order)) // which is possibly skippable
   {
     if (test_if_skip_sort_order(tab, order, m_select_limit, false,

--- a/sql/sql_prepare.cc
+++ b/sql/sql_prepare.cc
@@ -73,7 +73,7 @@ When one supplies long data for a placeholder:
 
   - Server gets the long data in pieces with command type
     'COM_STMT_SEND_LONG_DATA'.
-  - The packet recieved will have the format as:
+  - The packet received will have the format as:
     [COM_STMT_SEND_LONG_DATA:1][STMT_ID:4][parameter_number:2][data]
   - data from the packet is appended to the long data value buffer for this
     placeholder.

--- a/sql/sql_resolver.cc
+++ b/sql/sql_resolver.cc
@@ -2431,7 +2431,7 @@ find_order_in_list(THD *thd, Ref_ptr_array ref_pointer_array, TABLE_LIST *tables
     Item *view_ref= NULL;
     /*
       If we have found field not by its alias in select list but by its
-      original field name, we should additionaly check if we have conflict
+      original field name, we should additionally check if we have conflict
       for this name (in case if we would perform lookup in all tables).
     */
     if (resolution == RESOLVED_BEHIND_ALIAS && !order_item->fixed &&

--- a/sql/sql_rewrite.cc
+++ b/sql/sql_rewrite.cc
@@ -40,7 +40,7 @@
 
 
 /**
-  Append a key/value pair to a string, with an optional preceeding comma.
+  Append a key/value pair to a string, with an optional preceding comma.
   For numeric values.
 
   @param           str                  The string to append to
@@ -72,7 +72,7 @@ bool append_int(String *str, bool comma, const char *txt, size_t len,
 
 /**
   Append a key/value pair to a string if the value is non-NULL,
-  with an optional preceeding comma.
+  with an optional preceding comma.
 
   @param           str                  The string to append to
   @param           comma                Prepend a comma?

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -13351,7 +13351,7 @@ opt_var_ident_type:
         | SESSION_SYM '.' { $$=OPT_SESSION; }
         ;
 
-// Option values with preceeding option_type.
+// Option values with preceding option_type.
 option_value_following_option_type:
           internal_variable_name equal set_expr_or_default
           {
@@ -13359,7 +13359,7 @@ option_value_following_option_type:
           }
         ;
 
-// Option values without preceeding option_type.
+// Option values without preceding option_type.
 option_value_no_option_type:
           internal_variable_name        /*$1*/
           equal                         /*$2*/

--- a/sql/tztime.cc
+++ b/sql/tztime.cc
@@ -2020,7 +2020,7 @@ tz_load_from_open_tables(const String *tz_name, TABLE_LIST *tz_tables)
 
   /*
     At last we are doing the same thing for records in
-    mysql.time_zone_transition table. Here we additionaly need records
+    mysql.time_zone_transition table. Here we additionally need records
     in ascending order by index scan also satisfies us.
   */
   table= tz_tables->table; 

--- a/storage/innobase/include/fsp0file.h
+++ b/storage/innobase/include/fsp0file.h
@@ -445,7 +445,7 @@ private:
 	byte*			m_first_page;
 
 protected:
-	/** Last OS error recieved so it can be reported if needed. */
+	/** Last OS error received so it can be reported if needed. */
 	ulint			m_last_os_error;
 };
 

--- a/storage/myisam/mi_rnext.c
+++ b/storage/myisam/mi_rnext.c
@@ -63,7 +63,7 @@ int mi_rnext(MI_INFO *info, uchar *buf, int inx)
       Normally SQL layer would never request "search next" if
       "search first" failed. But HANDLER may do anything.
 
-      As mi_rnext() without preceeding mi_rkey()/mi_rfirst()
+      As mi_rnext() without preceding mi_rkey()/mi_rfirst()
       equals to mi_rfirst(), we must restore original state
       as if failing mi_rfirst() was not called.
     */

--- a/storage/ndb/include/ndbapi/NdbEventOperation.hpp
+++ b/storage/ndb/include/ndbapi/NdbEventOperation.hpp
@@ -65,7 +65,7 @@ class NdbEventOperationImpl;
  * - Event code does not check table schema version. Make sure to drop events
  * after table is dropped. Will be fixed in later
  * versions.
- * - If a node failure has occured not all events will be recieved
+ * - If a node failure has occured not all events will be received
  * anymore. Drop NdbEventOperation and Create again after nodes are up
  * again. Will be fixed in later versions.
  *

--- a/storage/ndb/mcc/frontend/dojo/dojox/date/relative.js.uncompressed.js
+++ b/storage/ndb/mcc/frontend/dojo/dojox/date/relative.js.uncompressed.js
@@ -45,7 +45,7 @@ dojox.date.relative.format = function(/*Date*/dateObject, /*dojox.date.relative.
 	//		is displayed
 	//
 	//		If the day portion of the date falls within the past week (or the
-	//		week preceeding relativeDate, if present), then the display will show
+	//		week preceding relativeDate, if present), then the display will show
 	//		day of week and time.  This functionality can be turned off by setting
 	//		weekCheck to false.
 	//

--- a/storage/ndb/mcc/frontend/dojo/dojox/drawing/tools/custom/Vector.js.uncompressed.js
+++ b/storage/ndb/mcc/frontend/dojo/dojox/drawing/tools/custom/Vector.js.uncompressed.js
@@ -10,7 +10,7 @@ dojox.drawing.tools.custom.Vector = dojox.drawing.util.oo.declare(
 	//		Creates a Vector Stencil.
 	// description:
 	//		Generally the same as an arrow, except that the arrow
-	//		head is only at the end. There is additionaly functionality
+	//		head is only at the end. There is additionally functionality
 	//		to allow for a 'zero vector' - one with no length.
 	//
 	//

--- a/storage/ndb/mcc/frontend/dojo/dojox/testing/DocTest.js.uncompressed.js
+++ b/storage/ndb/mcc/frontend/dojo/dojox/testing/DocTest.js.uncompressed.js
@@ -94,7 +94,7 @@ dojo.declare(
 			for(var i=0; i<len+1; i++){
 				// Trim the line, so we don't have to worry about leading
 				// spaces or tabs, bla bla ...
-				var l = trim(lines[i] || ""); // The '|| ""' makes sure tests that have no preceeding \n are taken into account too.
+				var l = trim(lines[i] || ""); // The '|| ""' makes sure tests that have no preceding \n are taken into account too.
 				// TODO:
 				//		detect tests that dont match the condition: commands,
 				//		result, empty line. esp the empty line might be missing

--- a/storage/ndb/mcc/frontend/dojo/dojox/xmpp/xmppSession.js.uncompressed.js
+++ b/storage/ndb/mcc/frontend/dojo/dojox/xmpp/xmppSession.js.uncompressed.js
@@ -730,7 +730,7 @@ dojo.extend(dojox.xmpp.xmppSession, {
 					}
 				}
 			}else if(msg.getAttribute('type')=="error"){
-				//console.log("xmppService::storeRoster()  Error recieved on roster get");
+				//console.log("xmppService::storeRoster()  Error received on roster get");
 			}
 
 			////console.log("Roster: ", this.roster);

--- a/storage/ndb/src/kernel/blocks/dbtc/DbtcMain.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtc/DbtcMain.cpp
@@ -14012,7 +14012,7 @@ void Dbtc::releaseAbortResources(Signal* signal)
 
   // MASV let state be CS_ABORTING until all 
   // signals in the "air" have been received. Reset to CS_CONNECTED
-  // will be done when a TCKEYREQ with start flag is recieved
+  // will be done when a TCKEYREQ with start flag is received
   // or releaseApiCon is called
   // apiConnectptr.p->apiConnectstate = CS_CONNECTED;
   apiConnectptr.p->apiConnectstate = CS_ABORTING;

--- a/storage/ndb/src/ndbapi/NdbInfoScanOperation.cpp
+++ b/storage/ndb/src/ndbapi/NdbInfoScanOperation.cpp
@@ -221,7 +221,7 @@ NdbInfoScanOperation::sendDBINFO_SCANREQ(void)
   assert((m_rows_received == 0 && m_rows_confirmed == (Uint32)~0) || // first
          m_rows_received == m_rows_confirmed);                       // subsequent
 
-  // No rows recieved in this batch yet
+  // No rows received in this batch yet
   m_rows_received = 0;
 
   // Number of rows returned by batch is not yet known
@@ -260,7 +260,7 @@ int NdbInfoScanOperation::receive(void)
       if (m_rows_received < m_rows_confirmed)
         DBUG_RETURN(1); // Row available
 
-      // All rows in this batch recieved
+      // All rows in this batch received
       assert(m_rows_received == m_rows_confirmed);
 
       if (m_cursor.size() == 0 && !find_next_node())
@@ -293,7 +293,7 @@ int NdbInfoScanOperation::receive(void)
       if (m_rows_received < m_rows_confirmed)
         continue;  // Continue waiting(for late TRANSID_AI signals)
 
-      // All rows in this batch recieved
+      // All rows in this batch received
       assert(m_rows_received == m_rows_confirmed);
 
       if (m_cursor.size() == 0 && !find_next_node())

--- a/storage/ndb/test/ndbapi/testDict.cpp
+++ b/storage/ndb/test/ndbapi/testDict.cpp
@@ -1372,7 +1372,7 @@ int runStoreFrm(NDBT_Context* ctx, NDBT_Step* step){
     
     // Verfiy the frm data
     if (memcmp(pData, pData2, resultLen) != 0){
-      g_err << "Wrong data recieved" << endl;
+      g_err << "Wrong data received" << endl;
       for (size_t i = 0; i < dataLen; i++){
 	unsigned char c = ((unsigned char*)pData2)[i];
 	g_err << hex << c << ", ";


### PR DESCRIPTION
I am tired of fixing the same bugs in different downstream packages I work with, so I decided to push my fixes directly to the source at Oracle MySQL. This simple spelling fix is my first in a series of multiple fixes.

I hereby grant Oracle full rights regarding this contribution. Please accept my fix!
