### PR TITLE
Fix for RFE Bug68782

### DIFF
--- a/sql/rpl_slave.cc
+++ b/sql/rpl_slave.cc
@@ -8290,6 +8290,8 @@ static int connect_to_master(THD* thd, MYSQL* mysql, Master_info* mi,
   /* Set MYSQL_PLUGIN_DIR in case master asks for an external authentication plugin */
   else if (opt_plugin_dir_ptr && *opt_plugin_dir_ptr)
     mysql_options(mysql, MYSQL_PLUGIN_DIR, opt_plugin_dir_ptr);
+
+  mysql_options4(mysql, MYSQL_OPT_CONNECT_ATTR_ADD, "program_name", "Slave I/O Thread");
   
   if (!mi->is_start_user_configured())
     sql_print_warning("%s", ER(ER_INSECURE_CHANGE_MASTER));

--- a/sql/rpl_slave.cc
+++ b/sql/rpl_slave.cc
@@ -8292,6 +8292,7 @@ static int connect_to_master(THD* thd, MYSQL* mysql, Master_info* mi,
     mysql_options(mysql, MYSQL_PLUGIN_DIR, opt_plugin_dir_ptr);
 
   mysql_options4(mysql, MYSQL_OPT_CONNECT_ATTR_ADD, "program_name", "Slave I/O Thread");
+  mysql_options4(mysql, MYSQL_OPT_CONNECT_ATTR_ADD, "channel_name", mi->get_channel());
   
   if (!mi->is_start_user_configured())
     sql_print_warning("%s", ER(ER_INSECURE_CHANGE_MASTER));


### PR DESCRIPTION
This adds the channel_name and program_name for the Slave I/O Thread.

https://bugs.mysql.com/bug.php?id=68782

```
master [localhost] {msandbox} ((none)) > select * from performance_schema.session_connect_attrs;
+----------------+-----------------+------------------+------------------+
| PROCESSLIST_ID | ATTR_NAME       | ATTR_VALUE       | ORDINAL_POSITION |
+----------------+-----------------+------------------+------------------+
|              3 | _os             | Linux            |                0 |
|              3 | _client_name    | libmysql         |                1 |
|              3 | _pid            | 3891             |                2 |
|              3 | _client_version | 5.7.7-rc         |                3 |
|              3 | _platform       | x86_64           |                4 |
|              3 | program_name    | Slave I/O Thread |                5 |
|              3 | channel_name    | NULL             |                6 |
|              6 | _os             | Linux            |                0 |
|              6 | _client_name    | libmysql         |                1 |
|              6 | _pid            | 3618             |                2 |
|              6 | _client_version | 5.7.7-rc         |                3 |
|              6 | _platform       | x86_64           |                4 |
|              6 | program_name    | Slave I/O Thread |                5 |
|              6 | channel_name    | testc1           |                6 |
|              7 | _os             | Linux            |                0 |
|              7 | _client_name    | libmysql         |                1 |
|              7 | _pid            | 3939             |                2 |
|              7 | _client_version | 5.7.7-rc         |                3 |
|              7 | _platform       | x86_64           |                4 |
|              7 | program_name    | mysql            |                5 |
+----------------+-----------------+------------------+------------------+
20 rows in set (0.00 sec)
```

I confirm the code being submitted is offered under the terms of the OCA, and that I am authorized to contribute it.
