### PR TITLE
Bug#68925: Compatibility issue with mysql history ("\040" instead of …

### DIFF
--- a/cmd-line-utils/libedit/history.c
+++ b/cmd-line-utils/libedit/history.c
@@ -827,7 +827,7 @@ history_save(TYPE(History) *h, const char *fname)
 			}
 			ptr = nptr;
 		}
-		(void) strvis(ptr, str, VIS_WHITE);
+		(void) strvis(ptr, str, VIS_SAFE);
 		(void) fprintf(fp, "%s\n", ptr);
 	}
 oomem:


### PR DESCRIPTION
…space)

Problem: libedit encodes whitespace characters before dumping them to history file.

Fix: Be readline-friendly, do not encode whitespace characters.
