### PR TITLE
Since 5.6.25 my_print_defaults mask passwords

### DIFF
--- a/scripts/mysqld_multi.sh
+++ b/scripts/mysqld_multi.sh
@@ -99,6 +99,9 @@ sub main
     push @defaults_options, (shift @ARGV);
   }
 
+  # add -s to uncrypt passwd
+  push @defaults_options, '-s';
+
   foreach (@defaults_options)
   {
     $_ = quote_shell_word($_);


### PR DESCRIPTION
As of MySQL 5.6.25, my_print_defaults masks passwords by defaults. Use -s option to display passwords in cleartext.
