### PR TITLE
Bug #74891: default cmake excludes utf8_5624_1 charset, required for main.ctype_ldml

### DIFF
--- a/strings/ctype.c
+++ b/strings/ctype.c
@@ -425,7 +425,7 @@ scan_one_character(const char *s, const char *e, my_wc_t *wc)
     wc[0]= 0;
     return len;
   }
-  else if (s[0] > 0) /* 7-bit character */
+  else if ((int8) s[0] > 0) /* 7-bit character */
   {
     wc[0]= 0;
     return 1;


### PR DESCRIPTION
Fix scan_one_character() to work correctly on architectures where char is
unsigned by default.
