### PR TITLE
Bug #77577: setup_timers initialization assumes CYCLE timer is always available

### DIFF
--- a/mysql-test/suite/perfschema/r/query_cache.result
+++ b/mysql-test/suite/perfschema/r/query_cache.result
@@ -38,7 +38,7 @@ spins
 NULL
 select * from performance_schema.setup_timers where name='wait';
 NAME	TIMER_NAME
-wait	CYCLE
+wait	{CYCLE_OR_NANOSECOND}
 show status like "Qcache_queries_in_cache";
 Variable_name	Value
 Qcache_queries_in_cache	1
@@ -53,7 +53,7 @@ spins
 NULL
 select * from performance_schema.setup_timers where name='wait';
 NAME	TIMER_NAME
-wait	CYCLE
+wait	{CYCLE_OR_NANOSECOND}
 show status like "Qcache_queries_in_cache";
 Variable_name	Value
 Qcache_queries_in_cache	1

--- a/mysql-test/suite/perfschema/t/query_cache.test
+++ b/mysql-test/suite/perfschema/t/query_cache.test
@@ -34,6 +34,7 @@ show status like "Qcache_hits";
 
 select spins from performance_schema.events_waits_current order by event_name limit 1;
 
+--replace_result CYCLE {CYCLE_OR_NANOSECOND} NANOSECOND {CYCLE_OR_NANOSECOND}
 select * from performance_schema.setup_timers where name='wait';
 
 show status like "Qcache_queries_in_cache";
@@ -42,6 +43,7 @@ show status like "Qcache_hits";
 
 select spins from performance_schema.events_waits_current order by event_name limit 1;
 
+--replace_result CYCLE {CYCLE_OR_NANOSECOND} NANOSECOND {CYCLE_OR_NANOSECOND}
 select * from performance_schema.setup_timers where name='wait';
 
 show status like "Qcache_queries_in_cache";

--- a/storage/perfschema/pfs_timer.cc
+++ b/storage/perfschema/pfs_timer.cc
@@ -186,6 +186,41 @@ void init_timers(void)
     /* Robustness, no known cases. */
     idle_timer= TIMER_NAME_CYCLE;
   }
+
+  /*
+    For WAIT, the cycle timer is used by default. However, it is not available
+    on all architectures. Fall back to the nanosecond timer in this case. It is
+    unlikely that neither cycle nor nanosecond are available, but we continue
+    probing less resolution timers anyway for considency with other events.
+  */
+  if (cycle_to_pico != 0)
+  {
+    /* Normal case. */
+    wait_timer= TIMER_NAME_CYCLE;
+  }
+  else if (nanosec_to_pico != 0)
+  {
+    /* Robustness, no known cases. */
+    wait_timer= TIMER_NAME_NANOSEC;
+  }
+  else if (microsec_to_pico != 0)
+  {
+    /* Robustness, no known cases. */
+    wait_timer= TIMER_NAME_MICROSEC;
+  }
+  else if (millisec_to_pico != 0)
+  {
+    /* Robustness, no known cases. */
+    wait_timer= TIMER_NAME_MILLISEC;
+  }
+  else
+  {
+    /*
+       Will never be reached on any architecture, but must provide a default if
+       no other timers are available.
+    */
+    wait_timer= TIMER_NAME_TICK;
+  }
 }
 
 ulonglong get_timer_raw_value(enum_timer_name timer_name)


### PR DESCRIPTION
Test if the CYCLE timer is actually implemented when using it as the
default timer for wait events. If CYCLE is not available, fall back to
the nanosecond timer (or even less resolution timers, if nanosecond is
also unavailable), similar to how other event timing defaults are
adjusted.
