### PR TITLE
Bug #72259 - Filesystem read-only detector

### DIFF
--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -95,6 +95,7 @@ void my_init_signals();
 bool gtid_server_init();
 void gtid_server_cleanup();
 const char *fixup_enforce_gtid_consistency_command_line(char *value_arg);
+int is_filesystem_read_only(char const* path);
 
 extern "C" MYSQL_PLUGIN_IMPORT CHARSET_INFO *system_charset_info;
 extern MYSQL_PLUGIN_IMPORT CHARSET_INFO *files_charset_info ;


### PR DESCRIPTION
Hello, I'm developer from Baku, Azerbaijan. I became an OCA member next week and i feel good :) I will try to write many usefull codes to develope MySQL in the future. Now I want to write about these changes. My friend found that when the file system is read-only, MySQL does not show exact error message about it. He reported this bug - http://bugs.mysql.com/bug.php?id=72259 . And I decided to fix this bug myself. I wrote a function - int is_filesystem_read_only(char const\* path) - this function detects if filesystem is read-only and return an integer. In mysqld_main function I catch --datadir option, get it's value and path to my new function. If file system is read-only I send an error message like this "Filesystem ([datadir path]) is read-only. Thats all :) I hope you will appreciate my first code for MySQL. Thanks a lot

I confirm the code being submitted is offered under the terms of the OCA, and that I am authorized to contribute it.
