### PR TITLE
Bug #79144: No hardware CRC32 implementation for AArch64

### DIFF
--- a/storage/innobase/include/ut0crc32.h
+++ b/storage/innobase/include/ut0crc32.h
@@ -55,6 +55,6 @@ but very slow). */
 extern ut_crc32_func_t	ut_crc32_byte_by_byte;
 
 /** Flag that tells whether the CPU supports CRC32 or not */
-extern bool		ut_crc32_sse2_enabled;
+extern bool		ut_crc32_hw_enabled;
 
 #endif /* ut0crc32_h */

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -1672,7 +1672,7 @@ innobase_start_or_create_for_mysql(void)
 
 	srv_boot();
 
-	ib::info() << (ut_crc32_sse2_enabled ? "Using" : "Not using")
+	ib::info() << (ut_crc32_hw_enabled ? "Using" : "Not using")
 		<< " CPU crc32 instructions";
 
 	if (!srv_read_only_mode) {

--- a/unittest/gunit/innodb/ut0crc32-t.cc
+++ b/unittest/gunit/innodb/ut0crc32-t.cc
@@ -2088,7 +2088,7 @@ init()
 	ut_crc32_init();
 
 	fprintf(stderr, "Using %s, CPU is %s-endian\n",
-		ut_crc32_sse2_enabled
+		ut_crc32_hw_enabled
 		? "hardware CPU crc32 instructions"
 		: "software crc32 implementation",
 #ifdef WORDS_BIGENDIAN


### PR DESCRIPTION
Add support for autodetection and usage of hardware CRC32 instructions on the AArch64 architecture, as well as some minor code generalization via the UNIV_CRC32_HW define.
