### PR TITLE
mtr: Increase limit on parallel workers in mysql-test-run

### DIFF
--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -1784,9 +1784,12 @@ sub set_build_thread_ports($) {
   if ( lc($opt_build_thread) eq 'auto' ) {
     my $found_free = 0;
     $build_thread = 300;	# Start attempts from here
+    my $build_thread_upper = $build_thread + ($opt_parallel > 49
+                                              ? $opt_parallel
+                                              : 49);
     while (! $found_free)
     {
-      $build_thread= mtr_get_unique_id($build_thread, 349);
+      $build_thread= mtr_get_unique_id($build_thread, $build_thread_upper);
       if ( !defined $build_thread ) {
         mtr_error("Could not get a unique build thread id");
       }


### PR DESCRIPTION
Parallel workers of the mysql-test-run has an artificial limit of 50 workers. On some hardware more CPUs are present. Running on such a hardware bot runs out of unique build thread ids

<pre>
build@2b2bb0db98a7:~/build/mysql-test$ export MTR_MAX_PARALLEL=900
build@2b2bb0db98a7:~/build/mysql-test$ export MTR_PARALLEL=auto
build@2b2bb0db98a7:~/build/mysql-test$ ./mtr 2>&1 | tee /tmp/mtr.log
2015-12-10 03:33:53 0 [Note] /build/build/sql/mysqld (mysqld 5.6.27) starting as process 78806 ...
2015-12-10 03:33:53 78806 [Note] Plugin 'FEDERATED' is disabled.
2015-12-10 03:33:53 78806 [Note] Binlog end
2015-12-10 03:33:53 78806 [Note] Shutting down plugin 'MyISAM'
2015-12-10 03:33:53 78806 [Note] Shutting down plugin 'CSV'
MySQL Version 5.6.27
Checking supported features...
 - SSL connections supported
Using suites: main,sys_vars,binlog,federated,rpl,innodb,innodb_fts,innodb_zip,perfschema,funcs_1,opt_trace,parts,auth_sec
Collecting tests...
 - adding combinations for binlog
 - adding combinations for rpl
Checking leftover processes...
Removing old var directory...
Creating var directory '/build/build/mysql-test/var'...
Installing system database...
Using parallel: 161
worker[2] Using MTR_BUILD_THREAD 300, with reserved ports 13000..13009
worker[3] Using MTR_BUILD_THREAD 304, with reserved ports 13040..13049
worker[4] Using MTR_BUILD_THREAD 303, with reserved ports 13030..13039
worker[14] Using MTR_BUILD_THREAD 305, with reserved ports 13050..13059
worker[6] Using MTR_BUILD_THREAD 302, with reserved ports 13020..13029
worker[1] Using MTR_BUILD_THREAD 301, with reserved ports 13010..13019
worker[15] Using MTR_BUILD_THREAD 306, with reserved ports 13060..13069
...
...
...
worker[38] Using MTR_BUILD_THREAD 348, with reserved ports 13480..13489
worker[35] Using MTR_BUILD_THREAD 345, with reserved ports 13450..13459
worker[44] mysql-test-run: *** ERROR: Could not get a unique build thread id
worker[49] mysql-test-run: *** ERROR: Could not get a unique build thread id
worker[74] mysql-test-run: *** ERROR: Could not get a unique build thread id
worker[75] mysql-test-run: *** ERROR: Could not get a unique build thread id
worker[63] mysql-test-run: *** ERROR: Could not get a unique build thread id
....
</pre>
