### PR TITLE
add super_connections option

### DIFF
--- a/sql/conn_handler/connection_handler_manager.cc
+++ b/sql/conn_handler/connection_handler_manager.cc
@@ -91,8 +91,8 @@ bool Connection_handler_manager::check_and_incr_conn_count()
   bool connection_accepted= true;
   mysql_mutex_lock(&LOCK_connection_count);
   /*
-    Here we allow max_connections + 1 clients to connect
-    (by checking before we increment by 1).
+    Here we allow max_connections + super_connections clients to connect
+    (by checking before we increment by super_connections).
 
     The last connection is reserved for SUPER users. This is
     checked later during authentication where valid_connection_count()
@@ -106,7 +106,7 @@ bool Connection_handler_manager::check_and_incr_conn_count()
   else
   {
     ++connection_count;
-    if (connection_count > max_used_connections)
+    if (connection_count >= max_used_connections + super_connections)
     {
       max_used_connections= connection_count;
       max_used_connections_time= (ulong)my_time(0);

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -474,6 +474,7 @@ ulong specialflag=0;
 ulong binlog_cache_use= 0, binlog_cache_disk_use= 0;
 ulong binlog_stmt_cache_use= 0, binlog_stmt_cache_disk_use= 0;
 ulong max_connections, max_connect_errors;
+ulong super_connections;
 ulong rpl_stop_slave_timeout= LONG_TIMEOUT;
 my_bool log_bin_use_v1_row_events= 0;
 bool thread_cache_size_specified= false;

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -227,6 +227,7 @@ extern ulong slow_launch_time;
 extern ulong table_cache_size, table_def_size;
 extern ulong table_cache_size_per_instance, table_cache_instances;
 extern MYSQL_PLUGIN_IMPORT ulong max_connections;
+extern ulong super_connections;
 extern ulong max_digest_length;
 extern ulong max_connect_errors, connect_timeout;
 extern my_bool opt_slave_allow_batching;

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -2315,6 +2315,13 @@ static Sys_var_ulong Sys_max_connections(
        /* max_connections is used as a sizing hint by the performance schema. */
        sys_var::PARSE_EARLY);
 
+static Sys_var_ulong Sys_super_connections(
+       "super_connections", "The number of connections reserved for SUPER user",
+       GLOBAL_VAR(super_connections), CMD_LINE(REQUIRED_ARG),
+       VALID_RANGE(1, 100000),
+       DEFAULT(1),
+       BLOCK_SIZE(1));
+
 static Sys_var_ulong Sys_max_connect_errors(
        "max_connect_errors",
        "If there is more than this number of interrupted connections from "


### PR DESCRIPTION
Users with SUPER privileges can use an extra connections when connection count reaches max_connections.
But the number of the reserved connections can not be changed. In some cases, more reserved connections is required for maintenance or other reason.

http://bugs.mysql.com/79606
