### PR TITLE
innochecksum optimization: crc32 calculated already

### DIFF
--- a/storage/innobase/page/page0zip.cc
+++ b/storage/innobase/page/page0zip.cc
@@ -5032,8 +5032,10 @@ page_zip_verify_checksum(
 
 	if (!strict_check) {
 
-		const uint32_t	crc32 = page_zip_calc_checksum(
-			data, size, SRV_CHECKSUM_ALGORITHM_CRC32);
+		const uint32_t	crc32 =
+			(curr_algo == SRV_CHECKSUM_ALGORITHM_CRC32) ? calc
+			: page_zip_calc_checksum(data, size,
+						 SRV_CHECKSUM_ALGORITHM_CRC32);
 
 		if (is_log_enabled) {
 			fprintf(log_file, "page::%" PRIuMAX ": crc32 checksum:"


### PR DESCRIPTION
If curr_algo == SRV_CHECKSUM_ALGORITHM_CRC32 then calc already contains
the result we want so lets use that.
