### PR TITLE
Check algorithm=innodb on crc32 checksum mismatch before crc32(big endian)

### DIFF
--- a/storage/innobase/page/page0zip.cc
+++ b/storage/innobase/page/page0zip.cc
@@ -5067,11 +5067,6 @@ page_zip_verify_checksum(
 			return(TRUE);
 		}
 
-		if (stored == page_zip_calc_checksum(data, size, curr_algo,
-						     true)) {
-			return(TRUE);
-		}
-
 		if (stored == page_zip_calc_checksum(
 			data, size, SRV_CHECKSUM_ALGORITHM_INNODB)) {
 
@@ -5085,6 +5080,11 @@ page_zip_verify_checksum(
 			}
 #endif	/* UNIV_INNOCHECKSUM */
 
+			return(TRUE);
+		}
+
+		if (stored == page_zip_calc_checksum(data, size, curr_algo,
+						     true)) {
 			return(TRUE);
 		}
 


### PR DESCRIPTION
When a page has had its checksum fail and the algorithm = CRC32,
its most likely because we've updated from 5.6 where the default
was algorithm=innodb. We should test that algorithm innodb on the
page passes before testing the crc32 in big endian way (
page_zip_calc_checksum(..., true)) as its more likely to be true.
