### PR TITLE
Bug #79487: Provide non-Windows implementations for LF_BACKOFF

### DIFF
--- a/include/atomic/generic-msvc.h
+++ b/include/atomic/generic-msvc.h
@@ -106,30 +106,4 @@ static inline void my_atomic_storeptr(void * volatile *a, void *v)
   (void)InterlockedExchangePointer(a, v);
 }
 
-
-/*
-  my_yield_processor (equivalent of x86 PAUSE instruction) should be used
-  to improve performance on hyperthreaded CPUs. Intel recommends to use it in
-  spin loops also on non-HT machines to reduce power consumption (see e.g
-  http://softwarecommunity.intel.com/articles/eng/2004.htm)
-
-  Running benchmarks for spinlocks implemented with InterlockedCompareExchange
-  and YieldProcessor shows that much better performance is achieved by calling
-  YieldProcessor in a loop - that is, yielding longer. On Intel boxes setting
-  loop count in the range 200-300 brought best results.
- */
-#define YIELD_LOOPS 200
-
-static inline int my_yield_processor()
-{
-  int i;
-  for (i=0; i<YIELD_LOOPS; i++)
-  {
-    YieldProcessor();
-  }
-  return 1;
-}
-
-#define LF_BACKOFF my_yield_processor()
-
 #endif /* ATOMIC_MSC_INCLUDED */

--- a/include/lf.h
+++ b/include/lf.h
@@ -23,6 +23,8 @@
 
 C_MODE_START
 
+#define LF_BACKOFF my_yield_processor()
+
 /*
   wait-free dynamic array, see lf_dynarray.c
 

--- a/include/my_compiler.h
+++ b/include/my_compiler.h
@@ -104,6 +104,18 @@ inline bool unlikely(bool expr)
 # define MY_ALIGNED(size)
 #endif
 
+/*
+  the macro below defines a compiler barrier, i.e. compiler-specific code to
+  prevent instructions reordering during compile time.
+*/
+#if defined __GNUC__ || defined __SUNPRO_C || defined __SUNPRO_CC
+# define MY_COMPILER_BARRIER() __asm__ __volatile__ ("" ::: "memory")
+#elif defined _MSC_VER
+# define MY_COMPILER_BARRIER() _ReadWriteBarrier()
+#else
+# error No MY_COMPILER_BARRIER() implementation for this compiler!
+#endif
+
 /* Visual Studio requires '__inline' for C code */
 #if !defined(__cplusplus) && defined(_MSC_VER)
 # define inline __inline

--- a/storage/innobase/include/ut0ut.h
+++ b/storage/innobase/include/ut0ut.h
@@ -54,38 +54,26 @@ Created 1/20/1994 Heikki Tuuri
 typedef time_t	ib_time_t;
 
 #ifndef UNIV_HOTBACKUP
-# if defined(HAVE_PAUSE_INSTRUCTION)
-   /* According to the gcc info page, asm volatile means that the
-   instruction has important side-effects and must not be removed.
-   Also asm volatile may trigger a memory barrier (spilling all registers
-   to memory). */
-#  ifdef __SUNPRO_CC
-#   define UT_RELAX_CPU() asm ("pause" )
-#  else
-#   define UT_RELAX_CPU() __asm__ __volatile__ ("pause")
-#  endif /* __SUNPRO_CC */
 
-# elif defined(HAVE_FAKE_PAUSE_INSTRUCTION)
-#  define UT_RELAX_CPU() __asm__ __volatile__ ("rep; nop")
-# elif defined _WIN32
-   /* In the Win32 API, the x86 PAUSE instruction is executed by calling
-   the YieldProcessor macro defined in WinNT.h. It is a CPU architecture-
-   independent way by using YieldProcessor. */
-#  define UT_RELAX_CPU() YieldProcessor()
+#include <my_atomic.h>
+
+# ifdef MY_PAUSE
+#  define UT_RELAX_CPU() MY_PAUSE()
 # else
-#  define UT_RELAX_CPU() do { \
-     volatile lint	volatile_var; \
-     os_compare_and_swap_lint(&volatile_var, 0, 1); \
-   } while (0)
+#  error MY_PAUSE() is undefined
 # endif
 
-# if defined(HAVE_HMT_PRIORITY_INSTRUCTION)
-#  define UT_LOW_PRIORITY_CPU() __asm__ __volatile__ ("or 1,1,1")
-#  define UT_RESUME_PRIORITY_CPU() __asm__ __volatile__ ("or 2,2,2")
-# else
-#  define UT_LOW_PRIORITY_CPU() ((void)0)
-#  define UT_RESUME_PRIORITY_CPU() ((void)0)
-# endif
+#ifdef MY_LOW_PRIORITY_CPU
+#  define UT_LOW_PRIORITY_CPU() MY_LOW_PRIORITY_CPU()
+#else
+#  error MY_LOW_PRIORITY_CPU() is undefined!
+#endif
+
+#ifdef MY_RESUME_PRIORITY_CPU
+#  define UT_RESUME_PRIORITY_CPU() MY_RESUME_PRIORITY_CPU()
+#else
+#  error MY_RESUME_PRIORITY_CPU() is undefined!
+#endif
 
 /*********************************************************************//**
 Delays execution for at most max_wait_us microseconds or returns earlier


### PR DESCRIPTION
Add LF_BACKOFF implementations for GCC and Sun Studio + some minor code
unification with InnoDB.

This obviously needs further unification with InnoDB code (in particular, ut_delay()) and the contributed patch for http://bugs.mysql.com/bug.php?id=74832.

But I understand this patch will not be merged as is anyway, so I tried to make it as isolated as possible, but avoid code duplication with InnoDB at the same time.
