### PR TITLE
Bug #79379: Inconsistent innodb_buffer_pool_size handling

### DIFF
--- a/mysql-test/suite/innodb/t/innodb.test
+++ b/mysql-test/suite/innodb/t/innodb.test
@@ -1394,7 +1394,7 @@ drop table t1;
 # Test for testable InnoDB status variables. This test
 # uses previous ones(pages_created, rows_deleted, ...).
 --disable_warnings
---replace_result 1535 {checked_valid} 1536 {checked_valid} 3071 {checked_valid} 3072 {checked_valid} 6144 {checked_valid}
+--replace_result 1535 {checked_valid} 1536 {checked_valid} 3071 {checked_valid} 3072 {checked_valid} 6144 {checked_valid} 1463 {checked_valid}
 SELECT variable_value FROM information_schema.global_status WHERE LOWER(variable_name) = 'innodb_buffer_pool_pages_total';
 --replace_result 4096 {checked_valid} 8192 {checked_valid} 16384 {checked_valid}
 SELECT variable_value FROM information_schema.global_status WHERE LOWER(variable_name) = 'innodb_page_size';

--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -1415,9 +1415,6 @@ buf_chunk_init(
 	/* Round down to a multiple of page size,
 	although it already should be. */
 	mem_size = ut_2pow_round(mem_size, UNIV_PAGE_SIZE);
-	/* Reserve space for the block descriptors. */
-	mem_size += ut_2pow_round((mem_size / UNIV_PAGE_SIZE) * (sizeof *block)
-				  + (UNIV_PAGE_SIZE - 1), UNIV_PAGE_SIZE);
 
 	DBUG_EXECUTE_IF("ib_buf_chunk_init_fails", return(NULL););
 


### PR DESCRIPTION
Remove code reserving extra bytes for the allocated memory block in
buf_chunk_init(). Those extra bytes break the alignment even if the
originally requested chunk is already properly aligned on all
levels. That in turn results in all kinds of inconsistencies with large
OS pages in setting innodb_buffer_pool_size both statically and
dynamically.
