### PR TITLE
Bug #80058: Free creation_ctx in sp_load_for_information_schema where create_string fails

### DIFF
--- a/sql/sp.cc
+++ b/sql/sp.cc
@@ -2279,7 +2279,10 @@ sp_load_for_information_schema(THD *thd, TABLE *proc_table, String *db,
                      returns, strlen(returns), 
                      sp_body, strlen(sp_body),
                      &sp_chistics, &definer_user, &definer_host, sql_mode))
+  {
+    delete creation_ctx;
     return 0;
+  }
 
   thd->lex= &newlex;
   newlex.current_select= NULL; 


### PR DESCRIPTION
Found during static analysis:

cppcheck --force -DDBUG_VOID_RETURN=return  -"DDBUG_RETURN(a)=return a" sql/sp.cc
[sql/sp.cc:2282]: (error) Memory leak: creation_ctx

Also exists in 5.6 and 5.7
