### PR TITLE
Bug #80059: Correct cppcheck warning that could occur when all elements are <= 1

### DIFF
--- a/mysys/testhash.c
+++ b/mysys/testhash.c
@@ -169,6 +169,11 @@ static int do_test()
   for (j=0 ; j < 1000 ; j++)
     if (key1[j] > 1)
       break;
+  if (j >= 1000)
+  {
+    printf("All keys are <= 1\n");
+    goto err;
+  }
   if (key1[j] > 1)
   {
     HASH_SEARCH_STATE state;


### PR DESCRIPTION
cppcheck -DDBUG_VOID_RETURN=return  -"DDBUG_RETURN(a)=return a"  mysys/testhash.c

[mysys/testhash.c:172]: (error) Array 'key1[1000]' accessed at index 1000, which is out of bounds.

same errors occur in 5.6 and 5.7
