### PR TITLE
Add va_end to mysys/mf_iocache.c matching va_start

### DIFF
--- a/mysys/mf_iocache.c
+++ b/mysys/mf_iocache.c
@@ -1888,6 +1888,7 @@ void die(const char* fmt, ...)
   fprintf(stderr,"Error:");
   vfprintf(stderr, fmt,va_args);
   fprintf(stderr,", errno=%d\n", errno);
+  va_end(va_args);
   exit(1);
 }
 


### PR DESCRIPTION
Found by cppcheck.
[mysys/mf_iocache.c:1929]: (error) va_list 'va_args' was opened but not closed by va_end().
