### PR TITLE
Bug #79455: Restore get_sched_indexer_t in 5.7

### DIFF
--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -8601,8 +8601,7 @@ ha_innobase::index_read(
 	case DB_SUCCESS:
 		error = 0;
 		table->status = 0;
-		srv_stats.n_rows_read.add(
-			thd_get_thread_id(m_prebuilt->trx->mysql_thd), 1);
+		srv_stats.n_rows_read.inc();
 		break;
 
 	case DB_RECORD_NOT_FOUND:
@@ -8888,7 +8887,7 @@ ha_innobase::general_fetch(
 	case DB_SUCCESS:
 		error = 0;
 		table->status = 0;
-		srv_stats.n_rows_read.add(thd_get_thread_id(trx->mysql_thd), 1);
+		srv_stats.n_rows_read.inc();
 		break;
 	case DB_RECORD_NOT_FOUND:
 		error = HA_ERR_END_OF_FILE;

--- a/storage/innobase/include/sync0arr.ic
+++ b/storage/innobase/include/sync0arr.ic
@@ -43,7 +43,7 @@ sync_array_get()
 		return(sync_wait_array[0]);
 	}
 
-	return(sync_wait_array[default_indexer_t<>::get_rnd_index()
+	return(sync_wait_array[counter_indexer_t<>::get_rnd_index()
 			       % sync_array_size]);
 }
 

--- a/storage/innobase/row/row0mysql.cc
+++ b/storage/innobase/row/row0mysql.cc
@@ -2626,9 +2626,9 @@ run_again:
 			than protecting the following code with a latch. */
 			dict_table_n_rows_dec(node->table);
 
-			srv_stats.n_rows_deleted.add((size_t)trx->id, 1);
+			srv_stats.n_rows_deleted.inc();
 		} else {
-			srv_stats.n_rows_updated.add((size_t)trx->id, 1);
+			srv_stats.n_rows_updated.inc();
 		}
 
 		row_update_statistics_if_needed(node->table);


### PR DESCRIPTION
This partially reverts the fix for bug bug#20709391 "SCHED_GETCPU() IN
DEFAULT GET_RND_INDEX() COULD NOT GENERATE RANDOM COUNTERS" by
re-introducing get_sched_indexer_t on Linux and Windows and using it (if
available) as the default indexer in ib_counter_t. It also changes
InnoDB row counter updates to use the default indexer rather than
override it with MySQL trx ID.

In sync_array_get() use the counter_indexer_t explicitly, because other
ones are not random enough per comments in the fix for bug #20709391.

This in itself does not introduce any measurable performance
improvements, but is rather a groundwork for further changes.
