### PR TITLE
thr_lock: Only set stack size when stack size is < 64k

### DIFF
--- a/mysys/thr_lock.c
+++ b/mysys/thr_lock.c
@@ -1629,7 +1629,7 @@ int main(int argc __attribute__((unused)),char **argv __attribute__((unused)))
     exit(1);
   }
 #ifndef pthread_attr_setstacksize		/* void return value */
-  if ((error=pthread_attr_setstacksize(&thr_attr,65536L)))
+  if (PTHREAD_STACK_MIN < 65536L && (error=pthread_attr_setstacksize(&thr_attr,65536L)))
   {
     fprintf(stderr,"Got error: %d from pthread_attr_setstacksize (errno: %d)",
 	    error,errno);


### PR DESCRIPTION
On powerpc64le with 64k pages, attempting to set stack size to 64k fails,
so the thr_lock test fails immediately.

Instead, check the current stack size, and if it's bigger, leave it unchanged.
The test program now succeeds.

Signed-off-by: Daniel Axtens daxtens@au1.ibm.com
