### PR TITLE
mysys: Remove alloca() from lock-free allocator

### DIFF
--- a/include/lf.h
+++ b/include/lf.h
@@ -111,13 +111,12 @@ typedef struct {
 typedef struct {
   void * volatile pin[LF_PINBOX_PINS];
   LF_PINBOX *pinbox;
-  void  **stack_ends_here;
   void  *purgatory;
   uint32 purgatory_count;
   uint32 volatile link;
 /* we want sizeof(LF_PINS) to be 64 to avoid false sharing */
-#if SIZEOF_INT*2+SIZEOF_CHARP*(LF_PINBOX_PINS+3) != 64
-  char pad[64-sizeof(uint32)*2-sizeof(void*)*(LF_PINBOX_PINS+3)];
+#if SIZEOF_INT*2+SIZEOF_CHARP*(LF_PINBOX_PINS+2) != 64
+  char pad[64-sizeof(uint32)*2-sizeof(void*)*(LF_PINBOX_PINS+2)];
 #endif
 } LF_PINS;
 

--- a/include/my_pthread.h
+++ b/include/my_pthread.h
@@ -853,7 +853,6 @@ struct st_my_thread_var
   my_bool init;
   struct st_my_thread_var *next,**prev;
   void *opt_info;
-  void  *stack_ends_here;
 #ifndef DBUG_OFF
   void *dbug;
   char name[THREAD_NAME_SIZE+1];

--- a/mysys/lf_alloc-pin.c
+++ b/mysys/lf_alloc-pin.c
@@ -96,8 +96,7 @@
   upper 16 bits are used for a version.
 
   It is assumed that pins belong to a THD and are not transferable
-  between THD's (LF_PINS::stack_ends_here being a primary reason
-  for this limitation).
+  between THD's
 */
 #include <my_global.h>
 #include <my_sys.h>
@@ -146,7 +145,6 @@ void lf_pinbox_destroy(LF_PINBOX *pinbox)
 */
 LF_PINS *_lf_pinbox_get_pins(LF_PINBOX *pinbox)
 {
-  struct st_my_thread_var *var;
   uint32 pins, next, top_ver;
   LF_PINS *el;
   /*
@@ -189,12 +187,6 @@ LF_PINS *_lf_pinbox_get_pins(LF_PINBOX *pinbox)
   el->link= pins;
   el->purgatory_count= 0;
   el->pinbox= pinbox;
-  var= my_thread_var;
-  /*
-    Threads that do not call my_thread_init() should still be
-    able to use the LF_HASH.
-  */
-  el->stack_ends_here= (var ? & var->stack_ends_here : NULL);
   return el;
 }
 
@@ -321,12 +313,6 @@ static int match_pins(LF_PINS *el, void *addr)
         return 1;
   return 0;
 }
-
-#if STACK_DIRECTION < 0
-#define available_stack_size(CUR,END) (long) ((char*)(CUR) - (char*)(END))
-#else
-#define available_stack_size(CUR,END) (long) ((char*)(END) - (char*)(CUR))
-#endif
 
 #define next_node(P, X) (*((uchar * volatile *)(((uchar *)(X)) + (P)->free_ptr_offset)))
 #define anext_node(X) next_node(&allocator->pinbox, (X))

--- a/mysys/my_thr_init.c
+++ b/mysys/my_thr_init.c
@@ -297,9 +297,6 @@ my_bool my_thread_init(void)
   mysql_mutex_init(key_my_thread_var_mutex, &tmp->mutex, MY_MUTEX_INIT_FAST);
   mysql_cond_init(key_my_thread_var_suspend, &tmp->suspend, NULL);
 
-  tmp->stack_ends_here= (char*)&tmp +
-                         STACK_DIRECTION * (long)my_thread_stack_size;
-
   mysql_mutex_lock(&THR_LOCK_threads);
   tmp->id= ++thread_id;
   ++THR_thread_count;


### PR DESCRIPTION
A crash on powerpc64le was traced to the use of alloca() in
_lf_pinbox_real_free, where the code was attempting to allocate
252kB on the stack.

_lf_pinbox_real_free is not a hotpath, and the lock-free allocator is
used only in the performance schema and mysys/waiting_threads.c (which
appears to be dead code). So simply replace alloca() with the much
safer my_malloc(): allocate on the heap.

The first patch removes alloca(), and the second patch does cleanups: 
The calculation of stack_ends_here was only used by the lock-free
allocator, and only to do aggressive sizing of an alloca() call.
The calculation is unclear and the use in alloca() caused a crash:
remove it all.
