### PR TITLE
bug 80808: CHECKSUM TABLE to calculate in multiple column chunks

### DIFF
--- a/mysql-test/r/myisam.result
+++ b/mysql-test/r/myisam.result
@@ -617,6 +617,10 @@ test.t2	2948697075
 test.t3	NULL
 Warnings:
 Error	1146	Table 'test.t3' doesn't exist
+alter table t1 add d int default 30, add e bigint default 300000, add f decimal(30) default 442;
+checksum table t2;
+Table	Checksum
+test.t2	2948697075
 drop table t1,t2;
 create table t1 (a int, key (a));
 show keys from t1;

--- a/mysql-test/t/myisam.test
+++ b/mysql-test/t/myisam.test
@@ -556,6 +556,8 @@ insert t2 select * from t1;
 checksum table t1, t2, t3 quick;
 checksum table t1, t2, t3;
 checksum table t1, t2, t3 extended;
+alter table t1 add d int default 30, add e bigint default 300000, add f decimal(30) default 442;
+checksum table t2;
 #show table status;
 drop table t1,t2;
 

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -10366,6 +10366,8 @@ bool mysql_checksum_table(THD *thd, TABLE_LIST *tables,
 	      row_crc= checksum_crc32(row_crc, t->record[0], t->s->null_bytes);
             }
 
+	    uchar *checksum_start= NULL;
+	    size_t checksum_length= 0;
 	    for (uint i= 0; i < t->s->fields; i++ )
 	    {
 	      Field *f= t->field[i];
@@ -10381,6 +10383,12 @@ bool mysql_checksum_table(THD *thd, TABLE_LIST *tables,
                 case MYSQL_TYPE_GEOMETRY:
                 case MYSQL_TYPE_BIT:
                 {
+                  if (checksum_start)
+                  {
+                    row_crc= my_checksum(row_crc, checksum_start, checksum_length);
+                    checksum_start= NULL;
+                    checksum_length= 0;
+                  }
                   String tmp;
                   f->val_str(&tmp);
                   row_crc= checksum_crc32(row_crc, (uchar*) tmp.ptr(),
@@ -10388,10 +10396,29 @@ bool mysql_checksum_table(THD *thd, TABLE_LIST *tables,
                   break;
                 }
                 default:
-                  row_crc= checksum_crc32(row_crc, f->ptr, f->pack_length());
+                  if (checksum_start)
+                  {
+                    if (checksum_start + checksum_length == f->ptr)
+                    {
+                      checksum_length+= f->pack_length();
+                    }
+                    else
+                    {
+                      row_crc= my_checksum(row_crc, checksum_start, checksum_length);
+                      checksum_start= f->ptr;
+                      checksum_length= f->pack_length();
+                    }
+                  }
+                  else
+                  {
+                    checksum_start= f->ptr;
+                    checksum_length= f->pack_length();
+                  }
                   break;
 	      }
 	    }
+	    if (checksum_start)
+	      row_crc= my_checksum(row_crc, checksum_start, checksum_length);
 
 	    crc+= row_crc;
 	  }


### PR DESCRIPTION
Checksum implementations contain optimizations for calculating
checksums of larger blocks of memory.

This optimization calls my_checksum on a larger block of memory
rather than calling on multiple adjacent memory as its going though
the table columns for each table row.

Note: even though current crc32 is not optimized I'm preparing patches to change this.
