### PR TITLE
bug 80809: innodb.innodb fails on PPC64

### DIFF
--- a/mysql-test/suite/innodb/t/innodb.test
+++ b/mysql-test/suite/innodb/t/innodb.test
@@ -1394,7 +1394,7 @@ drop table t1;
 # Test for testable InnoDB status variables. This test
 # uses previous ones(pages_created, rows_deleted, ...).
 --disable_warnings
---replace_result 1535 {checked_valid} 1536 {checked_valid} 3071 {checked_valid} 3072 {checked_valid} 6144 {checked_valid}
+--replace_result 1535 {checked_valid} 1536 {checked_valid} 3071 {checked_valid} 3072 {checked_valid} 6144 {checked_valid} 1539 {checked_valid}
 SELECT variable_value FROM information_schema.global_status WHERE LOWER(variable_name) = 'innodb_buffer_pool_pages_total';
 --replace_result 4096 {checked_valid} 8192 {checked_valid} 16384 {checked_valid}
 SELECT variable_value FROM information_schema.global_status WHERE LOWER(variable_name) = 'innodb_page_size';


### PR DESCRIPTION
Because page size differences on PPC64, the innodb_buffer_pool_pages_total
value may also be 1539.

Like MariaDB bug MDEV-6872 (fix http://bazaar.launchpad.net/~maria-captains/maria/5.5/revision/4325)
