### PR TITLE
Code changes for zSystems (s390x)

### DIFF
--- a/storage/innobase/include/os0atomic.h
+++ b/storage/innobase/include/os0atomic.h
@@ -50,7 +50,7 @@ typedef ulint	lock_word_t;
 #endif /* _WIN32 */
 
 #if defined __i386__ || defined __x86_64__ || defined _M_IX86 \
-    || defined _M_X64 || defined __WIN__
+    || defined _M_X64 || defined __WIN__ || defined __s390__
 
 #define IB_STRONG_MEMORY_MODEL
 

--- a/storage/innobase/include/os0atomic.h
+++ b/storage/innobase/include/os0atomic.h
@@ -54,7 +54,7 @@ typedef ulint	lock_word_t;
 
 #define IB_STRONG_MEMORY_MODEL
 
-#endif /* __i386__ || __x86_64__ || _M_IX86 || _M_X64 || __WIN__ */
+#endif /* __i386__ || __x86_64__ || _M_IX86 || _M_X64 || __WIN__ || __s390__ */
 
 /**********************************************************//**
 Atomic compare-and-swap and increment for InnoDB. */


### PR DESCRIPTION
Defined `__s390__` flag to support Z architecture.
