### PR TITLE
Bug #80783: Use default buffer pool size for faster startup with --initialize

### DIFF
--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -3950,10 +3950,11 @@ innobase_change_buffering_inited_ok:
 	mysql_cond_register("innodb", all_innodb_conds, count);
 #endif /* HAVE_PSI_INTERFACE */
 
-	/* Set buffer pool size to default for fast startup when mysqld is
-	run with --help --verbose options. */
+	/* Set buffer pool size to default for fast startup when mysqld is run
+	with --help --verbose options or with --initialize/--initialize-insecure
+	options. */
 	ulint	srv_buf_pool_size_org = 0;
-	if (opt_help && opt_verbose
+	if (((opt_help && opt_verbose) || opt_initialize)
 	    && srv_buf_pool_size > srv_buf_pool_def_size) {
 		ib::warn() << "Setting innodb_buf_pool_size to "
 			<< srv_buf_pool_def_size << " for fast startup, "


### PR DESCRIPTION
For performance reasons, use the default buffer pool size rather than
the one specified in configuration when the server is started with
either --initialize or --initialize-insecure options.
