### PR TITLE
MTR: binlog test suite failed to cleanup

### DIFF
--- a/mysql-test/suite/binlog/t/binlog_bug36391.test
+++ b/mysql-test/suite/binlog/t/binlog_bug36391.test
@@ -34,3 +34,4 @@ SHOW TABLES;
 
 # Clean up
 DROP TABLE t1;
+--remove_file $datadir/master-bin.saved

--- a/mysql-test/suite/binlog/t/binlog_checksum.test
+++ b/mysql-test/suite/binlog/t/binlog_checksum.test
@@ -37,5 +37,5 @@ show tables;
 drop table t1;
 set @@global.binlog_checksum = @save_binlog_checksum;
 set @@global.master_verify_checksum = @save_master_verify_checksum;
-
+--remove_file $MYSQLD_DATADIR/master-bin.saved
 --echo End of the tests

--- a/mysql-test/suite/binlog/t/binlog_mysqlbinlog-cp932.test
+++ b/mysql-test/suite/binlog/t/binlog_mysqlbinlog-cp932.test
@@ -32,3 +32,4 @@ select HEX(f) from t4;
 
 drop table t3, t4, t03, t04;
 --echo End of 5.0 tests
+--remove_file $datadir/master-bin.saved

--- a/mysql-test/suite/binlog/t/binlog_tmp_table.test
+++ b/mysql-test/suite/binlog/t/binlog_tmp_table.test
@@ -95,6 +95,7 @@ select * from foo;
 
 # clean up
 drop table foo;
+-- remove_file $MYSQLD_DATADIR/master-bin.saved35583
 
 #################################################################
 # BUG#51226
@@ -163,3 +164,4 @@ RESET MASTER;
 # assertion: assert that when replaying the binary log will succeed,
 #            instead of failing with "Table 'XXX.YYY' doesn't exist"
 -- exec $MYSQL_BINLOG $MYSQLD_DATADIR/master-bin.saved51226 | $MYSQL
+-- remove_file $MYSQLD_DATADIR/master-bin.saved51226


### PR DESCRIPTION
Patch removes copy(ied)_files

To reproduce:
$ env | grep MTR
MTR_PARALLEL=50
MTR_MEM=1
MTR_PARALLEL_MAX=160
$ (cd mysql-test; ./mtr --force --max-test-fail=40 --repeat=10 --suite=binlog)

...
binlog.log_builtin_as_identified_by_password 'mix' w42 [ pass ]    934
binlog.binlog_database 'row'             w37 [ pass ]    612
binlog.log_builtin_as_identified_by_password 'row' w9 [ pass ]    671
binlog.binlog_max_extension 'stmt'       w5 [ pass ]   4158
binlog.binlog_user_if_exists 'row'       w17 [ pass ]    858
binlog.binlog_gtid_next_xa 'stmt'        w46 [ pass ]   2075
binlog.binlog_grant_alter_user 'stmt'    w4 [ pass ]   1249
binlog.binlog_grant_alter_user 'mix'     w2 [ pass ]   1120
binlog.binlog_database 'stmt'            w41 [ pass ]   1108
binlog.binlog_mysqlbinlog_start_stop 'stmt' w48 [ pass ]   3682
binlog.binlog_bug36391 'mix'             w20 [ retry-fail ]
        Test ended at 2016-03-24 14:54:38

CURRENT_TEST: binlog.binlog_bug36391
mysqltest: At line 26: command "copy_file" failed with error 1. my_errno=17

$ extra/perror 17
OS error code  17:  File exists
