### PR TITLE
mtr ctype.gb18030_binlog and main.ctype_ldmland need to be repeatable

### DIFF
--- a/mysql-test/r/ctype_ldml.result
+++ b/mysql-test/r/ctype_ldml.result
@@ -1140,3 +1140,4 @@ DROP TABLE t1;
 #
 # Search for occurrences of [ERROR] Syntax error at '[strength tertiary]'
 Occurances : 1
+FLUSH ERROR LOGS;

--- a/mysql-test/t/ctype_gb18030_binlog.test
+++ b/mysql-test/t/ctype_gb18030_binlog.test
@@ -40,5 +40,6 @@ SELECT hex(f1), f1 FROM t1;
 DROP PROCEDURE p1;
 DROP TABLE t1;
 DROP TABLE t2;
+--remove_file $MYSQLD_DATADIR/master-bin-gb18030.saved
 
 --source include/restore_default_binlog_format.inc

--- a/mysql-test/t/ctype_ldml.test
+++ b/mysql-test/t/ctype_ldml.test
@@ -389,3 +389,6 @@ perl;
   print "Occurances : $count_error\n";
   close(FILE);
 EOF
+
+--remove_file $MYSQLTEST_VARDIR/tmp/ctype_ldml_log.err
+FLUSH ERROR LOGS;


### PR DESCRIPTION
./mtr --repeat=2 on both of these tests causes failure on the second run
