### PR TITLE
Bug #80879: Allow '.' and '+' in compiler flags when generating mysql_config

### DIFF
--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -217,9 +217,9 @@ SET(REPLACE_REGEX_OPTIONS
   "-W[-A-Za-z]*"
   "--param=[-=a-z0-9]*"
   "-O[0-9]"
-  "-march=[-A-Za-z0-9]*"
-  "-mcpu=[-A-Za-z0-9]*"
-  "-mtune=[-A-Za-z0-9]*"
+  "-march=[-A-Za-z0-9.]*"
+  "-mcpu=[+-A-Za-z0-9.]*"
+  "-mtune=[-A-Za-z0-9.]*"
   "-specs=[-A-Za-z0-9/]*"
   "-xO[0-9]"
 )


### PR DESCRIPTION
Change REPLACE_REGEX_OPTIONS in scripts/CMakeLists.txt to allow dots in
-mcpu, -mtune, and -march, and the plus sign in -mcpu.
