### PR TITLE
correct make_pair for c++11

### DIFF
--- a/client/auth_utils.cc
+++ b/client/auth_utils.cc
@@ -61,7 +61,7 @@ int parse_cnf_file(istream &sin, map<string, string > *options,
     getline(sin, option_value);
     trim(&option_value);
     if (option_name.length() > 0)
-      options->insert(make_pair<string, string >(option_name, option_value));
+      options->insert(make_pair<string &, string &>(option_name, option_value));
   }
   return ALL_OK;
   } catch(...)


### PR DESCRIPTION
Adding -std=c++11 to the CXX flags as follows causes one compile fault fixed as follow.

There are lots of auto_ptr deprecation warnings too that need handling at some point. Seems a straight replacement to unique_ptr doesn't solve all cases.

cmake ../mysql-5.7 -DCMAKE_C_COMPILER=${CC:-gcc} -DCMAKE_CXX_COMPILER=${CXX:-g++} -DCMAKE_C_FLAGS_RELWITHDEBINFO="-O3 -mcpu=power8 -g"  -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O3 -mcpu=power8 -g -std=c++11" -DWITH_SSL=system -DCMAKE_INSTALL_PREFIX=/usr/local/mysql-5.7 -DDOWNLOAD_BOOST=1 -DWITH_BOOST=/home/danielgb/build_boost  -DCMAKE_C_FLAGS="-O3 -mcpu=power8 -g" -DCMAKE_CXX_FLAGS="-O3 -mcpu=power8 -g -std=c++11"
