### PR TITLE
do not pass type to std::make_pair()

### DIFF
--- a/client/auth_utils.cc
+++ b/client/auth_utils.cc
@@ -61,7 +61,7 @@ int parse_cnf_file(istream &sin, map<string, string > *options,
     getline(sin, option_value);
     trim(&option_value);
     if (option_name.length() > 0)
-      options->insert(make_pair<string, string >(option_name, option_value));
+      options->insert(make_pair(option_name, option_value));
   }
   return ALL_OK;
   } catch(...)


### PR DESCRIPTION
We not pass type template arguments to std::make_pair()
explicitly, and let the compiler deduce them on its own.
This fixes compiler error on GCC 6.1.1.
