### PR TITLE
Bug #79378: buf_block_align() makes incorrect assumptions about chunk size

### DIFF
--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -3855,14 +3855,18 @@ buf_block_from_ahi(const byte* ptr)
 	ut_ad(buf_chunk_map_ref == buf_chunk_map_reg);
 	ut_ad(!buf_pool_resizing);
 
-	const byte* bound = reinterpret_cast<uintptr_t>(ptr)
-			    > srv_buf_pool_chunk_unit
-			    ? ptr - srv_buf_pool_chunk_unit : 0;
-	it = chunk_map->upper_bound(bound);
+	buf_chunk_t*		chunk;
 
-	ut_a(it != chunk_map->end());
+	it = chunk_map->upper_bound(ptr);
 
-	buf_chunk_t*	chunk = it->second;
+	ut_a(it != chunk_map->begin());
+
+	if (it == chunk_map->end()) {
+		chunk = chunk_map->rbegin()->second;
+	} else {
+		chunk = (--it)->second;
+	}
+
 	ulint		offs = ptr - chunk->blocks->frame;
 
 	offs >>= UNIV_PAGE_SIZE_SHIFT;


### PR DESCRIPTION
5.7.12 introduced some cleanups in the code changed by this patch. So I'm resubmitting it after rebasing on 5.7.12.
