### PR TITLE
innodb buf_resize_thread - release mutexes when no change

### DIFF
--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -3022,6 +3022,7 @@ DECLARE_THREAD(buf_resize_thread)(
 			buf_resize_status(sout.str().c_str());
 
 			/* nothing to do */
+			buf_pool_mutex_exit_all();
 			continue;
 		}
 		buf_pool_mutex_exit_all();


### PR DESCRIPTION
The Innodb buf_resize_thread fails to release the mutexes when the old and new innodb buffer pool sizes are the same.

While the innodb_buffer_pool_size_validate does actually do the same check, its theoretically possible to resize the pool twice and trigger this condition if both changes occur before innodb_buffer_pool_size_update is called the first time.
