### PR TITLE
innodb pagesize tests fix (innodb_zip.16k and innodb.innodb_buffer_pool_resize)  

### DIFF
--- a/mysql-test/suite/innodb_zip/t/16k.test
+++ b/mysql-test/suite/innodb_zip/t/16k.test
@@ -20,7 +20,7 @@ SELECT variable_value FROM information_schema.global_status
 
 --echo # Test 2) The number of buffer pool pages is dependent upon the page size.
 --disable_warnings
---replace_result 1535 {checked_valid} 1536 {checked_valid}
+--replace_result 1535 {checked_valid} 1536 {checked_valid} 1539 {checked_valid}
 SELECT variable_value FROM information_schema.global_status
        WHERE LOWER(variable_name) = 'innodb_buffer_pool_pages_total';
 --enable_warnings

--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -2895,7 +2895,7 @@ calc_buf_pool_size:
 			buf_pool->old_size = buf_pool->curr_size;
 		}
 		srv_buf_pool_curr_size = curr_size;
-		innodb_set_buf_pool_size(buf_pool_size_align(curr_size));
+		innodb_set_buf_pool_size(srv_buf_pool_size);
 	}
 
 	const bool	new_size_too_diff


### PR DESCRIPTION
Architectures with 64k page sizes fail on these two tests, innodb_zip.16k and innodb.innodb_buffer_pool_resize.
