### PR TITLE
Spelling correction in error message

### DIFF
--- a/sql/conn_handler/socket_connection.cc
+++ b/sql/conn_handler/socket_connection.cc
@@ -924,7 +924,7 @@ Channel_info* Mysqld_socket_listener::listen_for_connection_event()
 #ifdef __APPLE__
   if (mysql_socket_getfd(connect_sock) >= FD_SETSIZE)
   {
-    sql_print_warning("File Descriptor %d exceedeed FD_SETSIZE=%d",
+    sql_print_warning("File Descriptor %d exceeded FD_SETSIZE=%d",
                       mysql_socket_getfd(connect_sock), FD_SETSIZE);
     connection_errors_internal++;
     (void) mysql_socket_close(connect_sock);


### PR DESCRIPTION
This is incredibly minor, but I noticed it and thought I'd correct it.
