### PR TITLE
Bug #80818: default log-tc-size too small on POWER - 3 * ( 64K page size) minimium needed

### DIFF
--- a/mysql-test/include/mysqld--help.inc
+++ b/mysql-test/include/mysqld--help.inc
@@ -56,6 +56,8 @@ perl;
     s/\b196608\b/262144/;
     # Replacing port number with string
     s/^port \d+/port ####/;
+    # log-tc-size varies to 64K*3 on some platforms
+    s/^log-tc-size 262144/log-tc-size 24576/;
     foreach $var (@env) { s/$ENV{$var}/$var/ }
     next if /use --skip-(use-)?symbolic-links to disable/; # for valgrind, again
     next if $skip;

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -212,7 +212,11 @@ public:
 };
 
 
+#if defined(__powerpc__) || defined(__aarch64__)
+#define TC_LOG_PAGE_SIZE   65535
+#else
 #define TC_LOG_PAGE_SIZE   8192
+#endif
 #define TC_LOG_MIN_SIZE    (3*TC_LOG_PAGE_SIZE)
 
 typedef struct st_user_var_events


### PR DESCRIPTION
This is a slightly modified version of the patch contributed by Daniel
Black, adding support for AArch64 in addition to POWER when choosing the
page size for TC log.
