### PR TITLE
Fix: non-compiling client/client_utils.cc

### DIFF
--- a/client/auth_utils.cc
+++ b/client/auth_utils.cc
@@ -61,7 +61,7 @@ int parse_cnf_file(istream &sin, map<string, string > *options,
     getline(sin, option_value);
     trim(&option_value);
     if (option_name.length() > 0)
-      options->insert(make_pair<string, string >(option_name, option_value));
+      options->insert(pair<string, string >(option_name, option_value));
   }
   return ALL_OK;
   } catch(...)


### PR DESCRIPTION
Replaced make_pair<string, string > with pair<string, string > to be able to compile using gcc version 6.1.1 20160510 (Ubuntu 6.1.1-2ubuntu12~16.04)
