### PR TITLE
fix for innodb_numa_interleave missing

### DIFF
--- a/config.h.cmake
+++ b/config.h.cmake
@@ -663,5 +663,6 @@
 
 #cmakedefine CPU_LEVEL1_DCACHE_LINESIZE @CPU_LEVEL1_DCACHE_LINESIZE@
 #cmakedefine HAVE_LIBNUMA 1
+#cmakedefine WITH_NUMA 1
 
 #endif

--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -53,10 +53,10 @@ Created 11/5/1995 Heikki Tuuri
 #include "page0zip.h"
 #include "srv0mon.h"
 #include "buf0checksum.h"
-#ifdef HAVE_LIBNUMA
+#ifdef HAVE_LIBNUMA && defined(WITH_NUMA) && !defined(UNIV_INNOCHECKSUM)
 #include <numa.h>
 #include <numaif.h>
-#endif // HAVE_LIBNUMA
+#endif // HAVE_LIBNUMA && WITH_NUMA
 
 /*
 		IMPLEMENTATION OF THE BUFFER POOL


### PR DESCRIPTION
Latest MySQL 5.6 misses the innodb_numa_interleave server variable.
https://bugs.mysql.com/bug.php?id=78953
