### PR TITLE
bug #82039: Add valgrind tool to MTR

### DIFF
--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -4374,6 +4374,7 @@ sub run_testcase ($) {
   my $print_freq=20;
 
   mtr_verbose("Running test:", $tinfo->{name});
+  $ENV{'MTR_TEST_NAME'} = $tinfo->{name};
   resfile_report_test($tinfo) if $opt_resfile;
 
   # Allow only alpanumerics pluss _ - + . in combination names,


### PR DESCRIPTION
Using other valgrind tools in MTR is a little difficult as the MTR ties the tool to memcheck or calllgrind.

This provides a valgrind-tool option for easy selection.

MTR_TEST_NAME is also exported for recording results per test run (using a custom --valgrind-path= wrapper script).
