### PR TITLE
5.7 bug 82039 mtr valgrind to specify any tool

### DIFF
--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -4378,6 +4378,7 @@ sub run_testcase ($) {
   my $print_freq=20;
 
   mtr_verbose("Running test:", $tinfo->{name});
+  $ENV{'MTR_TEST_NAME'} = $tinfo->{name};
   resfile_report_test($tinfo) if $opt_resfile;
 
   # Allow only alpanumerics pluss _ - + . in combination names,

--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -1734,6 +1734,16 @@ sub command_line_setup {
     if ($opt_suite_timeout <= 0);
 
   # --------------------------------------------------------------------------
+  # Check trace protocol option
+  # --------------------------------------------------------------------------
+  if ( $opt_trace_protocol )
+  {
+    push(@opt_extra_mysqld_opt, "--optimizer_trace=enabled=on,one_line=off");
+    # some queries yield big traces:
+    push(@opt_extra_mysqld_opt, "--optimizer-trace-max-mem-size=1000000");
+  }
+
+  # --------------------------------------------------------------------------
   # Check valgrind arguments
   # --------------------------------------------------------------------------
   if ( $opt_valgrind or $opt_valgrind_path or @valgrind_args)
@@ -1777,13 +1787,6 @@ sub command_line_setup {
     push(@valgrind_args, "--trace-children=yes")
       unless @valgrind_args;
     unshift(@valgrind_args, "--tool=callgrind");
-  }
-
-  if ( $opt_trace_protocol )
-  {
-    push(@opt_extra_mysqld_opt, "--optimizer_trace=enabled=on,one_line=off");
-    # some queries yield big traces:
-    push(@opt_extra_mysqld_opt, "--optimizer-trace-max-mem-size=1000000");
   }
 
   # default to --tool=memcheck


### PR DESCRIPTION
A rework of previous submission. Avoid duplicate ways to specify a tool.

corrects removed callgrind option.

Adds suppressions globally to all valgrind tools - the suppression file specifies the tool anyway.
