### PR TITLE
bug 82427: Check filesize read in sql authentication plugin (5.7)

### DIFF
--- a/sql/auth/sql_authentication.cc
+++ b/sql/auth/sql_authentication.cc
@@ -212,12 +212,19 @@ Rsa_authentication_keys::read_key_file(RSA **key_ptr,
     /* For public key, read key file content into a char buffer. */
     if (!is_priv_key)
     {
-      int filesize;
+      int filesize, filesize_read;
       fseek(key_file, 0, SEEK_END);
       filesize= ftell(key_file);
       fseek(key_file, 0, SEEK_SET);
       *key_text_buffer= new char[filesize+1];
-      (void) fread(*key_text_buffer, filesize, 1, key_file);
+      filesize_read= fread(*key_text_buffer, 1, filesize, key_file);
+      if (filesize_read != filesize)
+      {
+        sql_print_error("Failure to %d bytes from file, only %d bytes read:",
+                        filesize, filesize_read);
+        fclose(key_file);
+        return true;
+      }
       (*key_text_buffer)[filesize]= '\0';
     }
     fclose(key_file);


### PR DESCRIPTION
Avoids compile error in gcc-5.4.0 (the default in Ubuntu-16.04)

sql/auth/sql_authentication.cc: In member function 'bool Rsa_authentication_keys::read_key_file(RSA**, bool, char**)':
sql/auth/sql_authentication.cc:220:60: error: ignoring return value of 'size_t fread(void_, size_t, size_t, FILE_)', declared with attribute warn_unused_result [-Werror=unused-result](void) fread(*key_text_buffer, filesize, 1, key_file);
