### PR TITLE
bug 82428: Check filesize read in rsa authentication plugin (5.6)

### DIFF
--- a/sql/sql_acl.cc
+++ b/sql/sql_acl.cc
@@ -11659,12 +11659,19 @@ private:
       /* For public key, read key file content into a char buffer. */
       if (!is_priv_key)
       {
-        int filesize;
+        int filesize, filesize_read;
         fseek(key_file, 0, SEEK_END);
         filesize= ftell(key_file);
         fseek(key_file, 0, SEEK_SET);
         *key_text_buffer= new char[filesize+1];
-        (void) fread(*key_text_buffer, filesize, 1, key_file);
+        filesize_read= fread(*key_text_buffer, 1, filesize, key_file);
+        if (filesize_read != filesize)
+        {
+          sql_print_error("Failure to %d bytes from file, only %d bytes read:",
+                          filesize, filesize_read);
+          fclose(key_file);
+          return true;
+        }
         (*key_text_buffer)[filesize]= '\0';
       }
       fclose(key_file);


### PR DESCRIPTION
Avoids compile error in gcc-5.4.0 (default in ubuntu-16.04)

sql_acl.cc: In member function 'bool Rsa_authentication_keys::read_key_file(RSA**, bool, char**)':
sql_acl.cc:11688:62: error: ignoring return value of 'size_t fread(void_, size_t, size_t, FILE_)', declared with attribute warn_unused_result [-Werror=unused-result](void) fread(*key_text_buffer, filesize, 1, key_file);
