### PR TITLE
Fix compile w/ G++ 6.1.1 on Fedora 24

### DIFF
--- a/cmake/maintainer.cmake
+++ b/cmake/maintainer.cmake
@@ -22,7 +22,7 @@ SET(MY_C_WARNING_FLAGS
 
 # Common warning flags for G++ and Clang++
 SET(MY_CXX_WARNING_FLAGS
-    "${MY_WARNING_FLAGS} -Woverloaded-virtual -Wno-unused-parameter")
+    "${MY_WARNING_FLAGS} -Woverloaded-virtual -Wno-unused-parameter -Wno-nonnull-compare")
 
 # Extra warning flags for Clang++
 IF(CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/rapid/plugin/x/mysqlxtest_src/mysqlx.cc
+++ b/rapid/plugin/x/mysqlxtest_src/mysqlx.cc
@@ -1526,12 +1526,12 @@ boost::shared_ptr<Row> Result::next()
   if (m_state == ReadStmtOk)
     read_stmt_ok();
 
-    if (m_state != ReadDone)
-    {
-      ret_val = read_row();
+  if (m_state != ReadDone)
+  {
+    ret_val = read_row();
 
-  if (m_state == ReadStmtOk)
-    read_stmt_ok();
+    if (m_state == ReadStmtOk)
+      read_stmt_ok();
     }
   }
 

--- a/sql/sql_update.cc
+++ b/sql/sql_update.cc
@@ -815,7 +815,7 @@ bool mysql_update(THD *thd,
                                                TRG_EVENT_UPDATE, 0))
         break; /* purecov: inspected */
 
-        found++;
+      found++;
 
         if (!records_are_comparable(table) || compare_records(table))
         {

--- a/storage/innobase/fts/fts0fts.cc
+++ b/storage/innobase/fts/fts0fts.cc
@@ -6819,7 +6819,7 @@ fts_fake_hex_to_dec(
 #ifdef _WIN32
 	sscanf(tmp_id, "%016llu", &dec_id);
 #else
-	sscanf(tmp_id, "%016"PRIu64, &dec_id);
+	sscanf(tmp_id, "%016" PRIu64, &dec_id);
 #endif /* _WIN32 */
 	ut_ad(ret == 1);
 

--- a/storage/innobase/include/fts0priv.ic
+++ b/storage/innobase/include/fts0priv.ic
@@ -53,7 +53,7 @@ fts_write_object_id(
 	/* Use this to construct old(5.6.14 and 5.7.3) windows
 	ambiguous aux table names */
 	DBUG_EXECUTE_IF("innodb_test_wrong_windows_fts_aux_table_name",
-			return(sprintf(str, "%016"PRIu64, id)););
+			return(sprintf(str, "%016" PRIu64, id)););
 
 	DBUG_EXECUTE_IF("innodb_test_wrong_fts_aux_table_name",
 			return(sprintf(str, UINT64PFx, id)););
@@ -66,7 +66,7 @@ fts_write_object_id(
 		// FIXME: Use ut_snprintf(), so does following one.
 		return(sprintf(str, "%016llu", id));
 #else /* _WIN32 */
-		return(sprintf(str, "%016"PRIu64, id));
+		return(sprintf(str, "%016" PRIu64, id));
 #endif /* _WIN32 */
 	}
 


### PR DESCRIPTION
storage/innobase/include/ut0dbg.h:52:20: error: nonnull argument ‘offsets’ compared to NULL [-Werror=nonnull-compare]

storage/innobase/fts/fts0fts.cc:6822:17: error: C++11 requires a space between string literal and macro [-Werror=c++11-compat]

sql/sql_update.cc:813:7: error: this ‘if’ clause does not guard... [-Werror=misleading-indentation]

A similar issue exists in boost:
boost_1_59_0/boost/numeric/ublas/matrix_expression.hpp:2224:17: error: this ‘if’ clause does not guard... [-Werror=misleading-indentation]
