### PR TITLE
Don't dump mysql.gtid_executed

### DIFF
--- a/client/mysqldump.c
+++ b/client/mysqldump.c
@@ -1009,6 +1009,9 @@ static int get_options(int *argc, char ***argv)
                                         "mysql.apply_status", MYF(MY_WME))) ||
       my_hash_insert(&ignore_table,
                      (uchar*) my_strdup(PSI_NOT_INSTRUMENTED,
+                                        "mysql.gtid_executed", MYF(MY_WME))) ||
+      my_hash_insert(&ignore_table,
+                     (uchar*) my_strdup(PSI_NOT_INSTRUMENTED,
                                         "mysql.schema", MYF(MY_WME))) ||
       my_hash_insert(&ignore_table,
                      (uchar*) my_strdup(PSI_NOT_INSTRUMENTED,

--- a/mysql-test/r/bug82848.result
+++ b/mysql-test/r/bug82848.result
@@ -1,0 +1,12 @@
+RESET MASTER;
+USE test;
+CREATE TABLE t1 (id SERIAL);
+FLUSH LOGS;
+PURGE BINARY LOGS BEFORE NOW();
+Warnings:
+Warning	1868	file ./master-bin.000002 was not purged because it is the active log file.
+INSERT INTO t1 VALUES(NULL),(NULL),(NULL);
+RESET MASTER;
+# restart
+1
+DROP TABLE t1;

--- a/mysql-test/t/bug82848.test
+++ b/mysql-test/t/bug82848.test
@@ -1,0 +1,22 @@
+--source include/have_gtid.inc
+--source include/force_restart.inc
+
+RESET MASTER;
+USE test;
+CREATE TABLE t1 (id SERIAL);
+FLUSH LOGS;
+PURGE BINARY LOGS BEFORE NOW();
+INSERT INTO t1 VALUES(NULL),(NULL),(NULL);
+--exec $MYSQL_DUMP --all-databases --triggers --routines --events --master-data=2 > $MYSQLTEST_VARDIR/tmp/bug82848.sql 2> /dev/null
+
+RESET MASTER;
+--exec $MYSQL --force < $MYSQLTEST_VARDIR/tmp/bug82848.sql
+--let $gtid_executed_before= `SELECT @@GLOBAL.GTID_EXECUTED`
+
+--source include/restart_mysqld.inc
+--let $gtid_executed_after= `SELECT @@GLOBAL.GTID_EXECUTED`
+
+--let $gtid_diff= `SELECT '$gtid_executed_before' = '$gtid_executed_after'`
+--echo $gtid_diff
+
+DROP TABLE t1;


### PR DESCRIPTION
https://bugs.mysql.com/bug.php?id=82848

Otherwise this will overwrite the value which is set with
SET @@GLOBAL.GTID_PURGED=...
And this could cause a server to lose the GTID position after a restart
