### PR TITLE
Add TLS SNI support to the client.

### DIFF
--- a/include/violite.h
+++ b/include/violite.h
@@ -208,7 +208,7 @@ struct st_VioSSLFd
 };
 
 int sslaccept(struct st_VioSSLFd*, Vio *, long timeout, unsigned long *errptr);
-int sslconnect(struct st_VioSSLFd*, Vio *, long timeout, unsigned long *errptr);
+int sslconnect(struct st_VioSSLFd*, Vio *, long timeout, unsigned long *errptr, const char *host);
 
 struct st_VioSSLFd
 *new_VioSSLConnectorFd(const char *key_file, const char *cert_file,

--- a/sql-common/client.c
+++ b/sql-common/client.c
@@ -3411,7 +3411,7 @@ Establishes SSL if requested and supported.
 @retval 1       failure
 */
 static int
-cli_establish_ssl(MYSQL *mysql)
+cli_establish_ssl(MYSQL *mysql, const char *host)
 {
 #ifdef HAVE_OPENSSL
   NET *net= &mysql->net;
@@ -3501,7 +3501,7 @@ cli_establish_ssl(MYSQL *mysql)
     DBUG_PRINT("info", ("IO layer change in progress..."));
     MYSQL_TRACE(SSL_CONNECT, mysql, ());
     if (sslconnect(ssl_fd, net->vio,
-      (long) (mysql->options.connect_timeout), &ssl_error))
+      (long) (mysql->options.connect_timeout), &ssl_error, (const char *)host))
     {
       char buf[512];
       ERR_error_string_n(ssl_error, buf, 512);
@@ -4679,7 +4679,7 @@ CLI_MYSQL_REAL_CONNECT(MYSQL *mysql,const char *host, const char *user,
     scramble_buffer= scramble_data;
   }
 
-  if (cli_establish_ssl(mysql))
+  if (cli_establish_ssl(mysql, host))
     goto error;
 
   /*

--- a/vio/test-ssl.c
+++ b/vio/test-ssl.c
@@ -99,7 +99,7 @@ main(int argc, char**	argv)
   client_vio = (struct st_vio*)my_malloc(sizeof(struct st_vio),MYF(0));
   client_vio->sd = sv[0];
   client_vio->vioblocking(client_vio, 0, &unused);
-  sslconnect(ssl_connector,client_vio,60L,&ssl_error);
+  sslconnect(ssl_connector,client_vio,60L,&ssl_error, "the_hostname");
   server_vio = (struct st_vio*)my_malloc(sizeof(struct st_vio),MYF(0));
   server_vio->sd = sv[1];
   server_vio->vioblocking(client_vio, 0, &unused);

--- a/vio/test-sslclient.c
+++ b/vio/test-sslclient.c
@@ -85,7 +85,7 @@ main(	int	argc __attribute__((unused)),
 	/* ----------------------------------------------- */
 	/* Now we have TCP conncetion. Start SSL negotiation. */
 	read(client_vio->sd,xbuf, sizeof(xbuf));
-        sslconnect(ssl_connector,client_vio,60L,&ssl_error);
+        sslconnect(ssl_connector,client_vio,60L,&ssl_error, "the_hostname");
 	err = vio_read(client_vio,xbuf, sizeof(xbuf));
 	if (err<=0) {
 		my_free(ssl_connector);

--- a/vio/viotest-ssl.c
+++ b/vio/viotest-ssl.c
@@ -99,7 +99,7 @@ int main(int argc, char **argv)
 
   client_vio = (Vio*)my_malloc(sizeof(struct st_vio),MYF(0));
   client_vio->sd = sv[0];
-  sslconnect(ssl_connector,client_vio,&ssl_error);
+  sslconnect(ssl_connector,client_vio,&ssl_error, "the_hostname");
   server_vio = (Vio*)my_malloc(sizeof(struct st_vio),MYF(0));
   server_vio->sd = sv[1];
   sslaccept(ssl_acceptor,server_vio,&ssl_error);


### PR DESCRIPTION
The shipped yassl library doesn’t seem to include SNI, but OpenSSL makes it easy to have this now.

I don’t know of any MySQL-compatible servers that implement SNI, but having it on the client now will make it that much more useful when a server implements it. It’s basically “free” for now, so there’s little reason not to have it.

I have a Perl test server script that demonstrates that this works, if that’s of use.
