### PR TITLE
Bug #82889: DebugPrintDeathTest.PrintEval test failure.

### DIFF
--- a/unittest/gunit/dbug-t.cc
+++ b/unittest/gunit/dbug-t.cc
@@ -80,23 +80,19 @@ TEST(DebugPrintTest, PrintEval)
   int y= 0;
 
   // This DBUG_PRINT args should never be evaluated.
-  DBUG_PRINT("never",("%d",1/y));
+  DBUG_PRINT("never",("%d",y+=1));
+  EXPECT_TRUE((y == 0)) << "DBUG_PRINT arg is evaluated.";
 }
 
 
-TEST(DebugPrintDeathTest, PrintEval)
+TEST(DebugPrintEvalTest, PrintEval)
 {
   int y= 0;
 
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-
   DBUG_SET("+d,never");
-  /*
-    The DBUG_PRINT would be evaluated resulting in floating point exception
-    killing the server.
-  */
-  EXPECT_DEATH_IF_SUPPORTED(DBUG_PRINT("never",("%d",1/y)), "");
+  DBUG_PRINT("never",("%d",y+=1));
   DBUG_SET("");
+  EXPECT_TRUE((y >= 1)) << "DBUG_PRINT arg is not evaluated.";
 }
 
 


### PR DESCRIPTION
Commit 5c2b61d has brought two unit tests (DebugPrintTest and
DebugPrintDeathTest) that use "division by zero" exception to check
the evaluation of args of DBUG_PRINT macro.

C99 says in 6.5.5p5: "... if the value of the second operand is zero,
the behavior is undefined".

Also, according to the ARMv8 Architecture Reference Manual if the divisor
is zero, the result of operation is zero and no exception is generated.
Consequently, the DebugPrintDeathTest.PrintEval unit test fails.

This patch avoids using "division by zero" exception.
