### PR TITLE
Bug #82890: RDTimeStampCounter.TestCycle test failure.

### DIFF
--- a/unittest/gunit/mysys_my_rdtsc-t.cc
+++ b/unittest/gunit/mysys_my_rdtsc-t.cc
@@ -117,7 +117,7 @@ TEST_F(RDTimeStampCounter, TestCycle)
 #if defined(__aarch64__)
   /* The ARM cycle timer has low resolution */
   EXPECT_EQ(LOOP_COUNT, nonzero);
-  EXPECT_NE(0, backward);
+  EXPECT_EQ(0, backward);
 #else
   /* Expect at most 1 backward, the cycle value can overflow */
   EXPECT_TRUE((backward <= 1)) << "The cycle timer is strictly increasing";


### PR DESCRIPTION
RDTimeStampCounter.TestCycle unit test expects that the cycle timer
counter will overflow. The AArch64 cycle timer implementation uses
a 64-bit register, so it is unreasonable to expect overflow, whereas the
condition in the unittest expects at least 1 overflow for some reasons.

Fixed by changing the unittest to not expect an overflow which was
likely the original intent.
