### PR TITLE
Bug#20671150 BROKEN BUILD DUE MISSING CHECK OF RETURN VALUE OF FREAD()

### DIFF
--- a/sql/sql_acl.cc
+++ b/sql/sql_acl.cc
@@ -11678,17 +11678,26 @@ private:
       }
 
       /* For public key, read key file content into a char buffer. */
+      bool read_error= false;
       if (!is_priv_key)
       {
-        int filesize;
+        int filesize, items_read;
         fseek(key_file, 0, SEEK_END);
         filesize= ftell(key_file);
         fseek(key_file, 0, SEEK_SET);
         *key_text_buffer= new char[filesize+1];
-        (void) fread(*key_text_buffer, filesize, 1, key_file);
+        items_read= fread(*key_text_buffer, filesize, 1, key_file);
+        read_error= items_read != 1;
+        if (read_error)
+        {
+          char errbuf[MYSQL_ERRMSG_SIZE];
+          sql_print_error("Failure to read key file: %s",
+                          my_strerror(errbuf, MYSQL_ERRMSG_SIZE, my_errno()));
+        }
         (*key_text_buffer)[filesize]= '\0';
       }
       fclose(key_file);
+      return read_error;
     }
     return false;
   }


### PR DESCRIPTION
Check return value from fread(), return error if it fails.

Ported to 5.6 by Daniel Black

Signed-off-by: Daniel Black daniel.black@au.ibm.com
