### PR TITLE
Bug #83457: Incorrect ISA detection code in OEL RPM spec

### DIFF
--- a/packaging/rpm-fedora/mysql_config.sh
+++ b/packaging/rpm-fedora/mysql_config.sh
@@ -2,22 +2,30 @@
 #
 # Wrapper script for mysql_config to support multilib
 #
-# Only works on OEL6/RHEL6 and similar
 #
-# This command respects setarch
 
+# This command respects setarch, works on OL6/RHEL6 and later
 bits=$(rpm --eval %__isa_bits)
 
 case $bits in
-    32|64) status=known ;;
-        *) status=unknown ;;
+    32|64) ;;
+        *) bits=unknown ;;
 esac
 
-if [ "$status" = "unknown" ] ; then
-    echo "$0: error: command 'rpm --eval %__isa_bits' returned unknown value: $bits"
-    exit 1
+# Try mapping by uname if rpm command failed
+if [ "$bits" = "unknown" ] ; then
+    arch=$(uname -m)
+    case $arch in
+	x86_64|ppc64|ppc64le|aarch64) bits=64 ;;
+	i386|i486|i586|i686|pentium3|pentium4|athlon|ppc) bits=32 ;;
+	*) bits=unknown ;;
+    esac
 fi
 
+if [ "$bits" == "unknown" ] ; then
+    echo "$0: error: failed to determine isa bits on your arch."
+    exit 1
+fi
 
 if [ -x /usr/bin/mysql_config-$bits ] ; then
     /usr/bin/mysql_config-$bits "$@"
@@ -25,4 +33,3 @@ else
     echo "$0: error: needed binary: /usr/bin/mysql_config-$bits is missing. Please check your MySQL installation."
     exit 1
 fi
-

--- a/packaging/rpm-oel/mysql_config.sh
+++ b/packaging/rpm-oel/mysql_config.sh
@@ -5,10 +5,10 @@
 #
 
 # This command respects setarch, works on OL6/RHEL6 and later
-isa_bits=$(rpm --eval %__isa_bits)
+bits=$(rpm --eval %__isa_bits)
 
 case $bits in
-    32|64) bits=$isa_bits ;;
+    32|64) ;;
         *) bits=unknown ;;
 esac
 
@@ -16,7 +16,7 @@ esac
 if [ "$bits" = "unknown" ] ; then
     arch=$(uname -m)
     case $arch in
-	x86_64|ppc64) bits=64 ;;
+	x86_64|ppc64|ppc64le|aarch64) bits=64 ;;
 	i386|i486|i586|i686|pentium3|pentium4|athlon|ppc) bits=32 ;;
 	*) bits=unknown ;;
     esac
@@ -33,4 +33,3 @@ else
     echo "$0: error: needed binary: /usr/bin/mysql_config-$bits is missing. Please check your MySQL installation."
     exit 1
 fi
-


### PR DESCRIPTION
packaging/rpm-oel/mysql_config.sh:
- fix code around "rpm --eval %__isa_bits" to work as intended
- add "aarch64" to the list of 64-bit architectures in the fallback code

packaging/rpm-fedora/mysql_config.sh:
- make it identical to the same script in packaging/rpm-oel/
