### PR TITLE
Bug #79151 - error -1 from storage engine while creating table with non-existing datadir

### DIFF
--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -3394,6 +3394,14 @@ fil_create_new_single_table_tablespace(
 		remote directory, let's create the subdirectories
 		in the path, if they are not there already. */
 		success = os_file_create_subdirs_if_needed(path);
+		
+		// bug fix for http://bugs.mysql.com/bug.php?id=79151
+                if(!success && errno) {
+                        my_error(ER_GET_ERRNO, MYF(0), errno);
+                        mem_free(path);
+                        return(DB_ERROR);
+                }
+		
 		if (!success) {
 			err = DB_ERROR;
 			goto error_exit_3;


### PR DESCRIPTION
According to this bug report http://bugs.mysql.com/bug.php?id=79151
I added three lines of codes to send a client an occured system error code, but not unclear -1 error.

I confirm the code being submitted is offered under the terms of the OCA, and that I am authorized to contribute it.