### PR TITLE
Bug #76852 - Segmentation fault while starting MySQL with binary log in disk full Linux

### DIFF
--- a/mysys/my_error.c
+++ b/mysys/my_error.c
@@ -257,7 +257,14 @@ void my_printf_warning(const char *format, ...)
   va_start(args,format);
   (void) my_vsnprintf (wbuff, sizeof(wbuff), format, args);
   va_end(args);
-  (*sql_print_warning_hook)(wbuff);
+  if(sql_print_warning_hook)
+  {
+    (*sql_print_warning_hook)(wbuff);
+  }
+  else
+  {
+    fprintf(stderr, "%s\n", wbuff);
+  }
   DBUG_VOID_RETURN;
 }
 
@@ -379,7 +386,7 @@ const char **my_error_unregister(int first, int last)
   /* Save the return value and free the header. */
   errmsgs= meh_p->get_errmsgs();
   my_free(meh_p);
-  
+
   return errmsgs;
 }
 

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -894,7 +894,7 @@ void set_remaining_args(int argc, char **argv)
   remaining_argc= argc;
   remaining_argv= argv;
 }
-/* 
+/*
   Multiple threads of execution use the random state maintained in global
   sql_rand to generate random numbers. sql_rnd_with_mutex use mutex
   LOCK_sql_rand to protect sql_rand across multiple instantiations that use
@@ -1168,7 +1168,7 @@ static void charset_error_reporter(enum loglevel level,
   va_list args;
   va_start(args, format);
   vprint_msg_to_log(level, format, args);
-  va_end(args);                      
+  va_end(args);
 }
 C_MODE_END
 
@@ -3703,10 +3703,10 @@ rpl_make_log_name(const char *opt,
     MY_REPLACE_EXT | MY_UNPACK_FILENAME | MY_SAFE_PATH;
 
   /* mysql_real_data_home_ptr  may be null if no value of datadir has been
-     specified through command-line or througha cnf file. If that is the 
+     specified through command-line or througha cnf file. If that is the
      case we make mysql_real_data_home_ptr point to mysql_real_data_home
      which, in that case holds the default path for data-dir.
-  */ 
+  */
   if(mysql_real_data_home_ptr == NULL)
     mysql_real_data_home_ptr= mysql_real_data_home;
 
@@ -4663,6 +4663,8 @@ static int init_server_components()
     We need to call each of these following functions to ensure that
     all things are initialized so that unireg_abort() doesn't fail
   */
+  sql_print_warning_hook = sql_print_warning;
+
   mdl_init();
   if (table_def_init() | hostname_cache_init(host_cache_size))
     unireg_abort(1);
@@ -5486,7 +5488,7 @@ int mysqld_main(int argc, char **argv)
 #endif
   }
 
-  /* 
+  /*
    The subsequent calls may take a long time : e.g. innodb log read.
    Thus set the long running service control manager timeout
   */
@@ -5596,7 +5598,7 @@ int mysqld_main(int argc, char **argv)
   */
   error_handler_hook= my_message_sql;
   start_signal_handler();       // Creates pidfile
-  sql_print_warning_hook = sql_print_warning;
+
 
   if (mysql_rm_tmp_tables() || acl_init(opt_noacl) ||
       my_tz_init((THD *)0, default_tz_name, opt_bootstrap))
@@ -7131,7 +7133,7 @@ struct my_option my_long_options[]=
   {"default-storage-engine", 0, "The default storage engine for new tables",
    &default_storage_engine, 0, 0, GET_STR, REQUIRED_ARG,
    0, 0, 0, 0, 0, 0 },
-  {"default-tmp-storage-engine", 0, 
+  {"default-tmp-storage-engine", 0,
     "The default storage engine for new explict temporary tables",
    &default_tmp_storage_engine, 0, 0, GET_STR, REQUIRED_ARG,
    0, 0, 0, 0, 0, 0 },
@@ -7172,7 +7174,7 @@ struct my_option my_long_options[]=
   {"ignore-db-dir", OPT_IGNORE_DB_DIRECTORY,
    "Specifies a directory to add to the ignore list when collecting "
    "database names from the datadir. Put a blank argument to reset "
-   "the list accumulated so far.", 0, 0, 0, GET_STR, REQUIRED_ARG, 
+   "the list accumulated so far.", 0, 0, 0, GET_STR, REQUIRED_ARG,
    0, 0, 0, 0, 0, 0},
   {"language", 'L',
    "Client error messages in given language. May be given as a full path. "
@@ -7503,7 +7505,7 @@ static int show_slave_last_heartbeat(THD *thd, SHOW_VAR *var, char *buff)
       buff[0]='\0';
     else
     {
-      thd->variables.time_zone->gmt_sec_to_TIME(&received_heartbeat_time, 
+      thd->variables.time_zone->gmt_sec_to_TIME(&received_heartbeat_time,
         active_mi->last_heartbeat);
       my_datetime_to_str(&received_heartbeat_time, buff, 0);
     }
@@ -7532,7 +7534,7 @@ static int show_slave_rows_last_search_algorithm_used(THD *thd, SHOW_VAR *var, c
 {
   uint res= slave_rows_last_search_algorithm_used;
   const char* s= ((res == Rows_log_event::ROW_LOOKUP_TABLE_SCAN) ? "TABLE_SCAN" :
-                  ((res == Rows_log_event::ROW_LOOKUP_HASH_SCAN) ? "HASH_SCAN" : 
+                  ((res == Rows_log_event::ROW_LOOKUP_HASH_SCAN) ? "HASH_SCAN" :
                    "INDEX_SCAN"));
 
   var->type= SHOW_CHAR;
@@ -8669,7 +8671,7 @@ mysqld_get_one_option(int optid,
       if (push_ignored_db_dir(argument))
       {
         sql_print_error("Can't start server: "
-                        "cannot process --ignore-db-dir=%.*s", 
+                        "cannot process --ignore-db-dir=%.*s",
                         FN_REFLEN, argument);
         return 1;
       }
@@ -8943,7 +8945,7 @@ static int get_options(int *argc_ptr, char ***argv_ptr)
 
   /*
     TIMESTAMP columns get implicit DEFAULT values when
-    --explicit_defaults_for_timestamp is not set. 
+    --explicit_defaults_for_timestamp is not set.
     This behavior is deprecated now.
   */
   if (!opt_help && !global_system_variables.explicit_defaults_for_timestamp)
@@ -9417,7 +9419,7 @@ static int fix_paths(void)
   (void) my_load_path(mysql_real_data_home,mysql_real_data_home,mysql_home);
   (void) my_load_path(pidfile_name, pidfile_name_ptr, mysql_real_data_home);
 
-  convert_dirname(opt_plugin_dir, opt_plugin_dir_ptr ? opt_plugin_dir_ptr : 
+  convert_dirname(opt_plugin_dir, opt_plugin_dir_ptr ? opt_plugin_dir_ptr :
                                   get_relative_path(PLUGINDIR), NullS);
   (void) my_load_path(opt_plugin_dir, opt_plugin_dir, mysql_home);
   opt_plugin_dir_ptr= opt_plugin_dir;
@@ -9583,7 +9585,7 @@ static void create_pid_file()
 
 /**
   Remove the process' pid file.
-  
+
   @param  flags  file operation flags
 */
 
@@ -9597,11 +9599,11 @@ static void delete_pid_file(myf flags)
                               O_RDONLY, flags)))
     return;
 
-  /* Make sure that the pid file was created by the same process. */    
+  /* Make sure that the pid file was created by the same process. */
   uchar buff[MAX_BIGINT_WIDTH + 1];
   size_t error= mysql_file_read(file, buff, sizeof(buff), flags);
   mysql_file_close(file, flags);
-  buff[sizeof(buff) - 1]= '\0'; 
+  buff[sizeof(buff) - 1]= '\0';
   if (error != MY_FILE_ERROR &&
       atol((char *) buff) == (long) getpid())
   {
@@ -10260,4 +10262,3 @@ void init_server_psi_keys(void)
 }
 
 #endif /* HAVE_PSI_INTERFACE */
-


### PR DESCRIPTION
According to BUG report, `my_printf_warning` function is calling `*sql_print_warning_hook` which is NULL/uninitialized at that point of crash.
The 2 possible solution is initialize `sql_print_warning_hook= sql_print_warning` at the top of `init_server_components()` or to add a check for `sql_print_warning_hook` inside `my_error.c/my_printf_warning()`. The best to have both of them.
