### PR TITLE
Bug #71879 - Wrong binlog size reported after moving binlogs

### DIFF
--- a/sql/rpl_master.cc
+++ b/sql/rpl_master.cc
@@ -2247,6 +2247,19 @@ bool show_binlogs(THD* thd)
       file_length= cur.pos;  /* The active log, use the active position */
     else
     {
+     
+      // bug fix for http://bugs.mysql.com/bug.php?id=71879
+      // if bin file path starts with ./ then we will prepend to it full path of binlog directory
+      if(fname[0] == '.' && fname[1] == '/') 
+      {
+        std::string ofname(fname);
+        std::string bin_log_value(mysql_bin_log.get_name());
+        std::size_t lpos = bin_log_value.find_last_of("/");
+        std::string dir_path = bin_log_value.substr(0, lpos);
+        std::string full_path = dir_path + ofname.substr(1, ofname.length());
+        strcpy(fname, full_path.c_str());
+      }
+	    
       /* this is an old log, open it and find the size */
       if ((file= mysql_file_open(key_file_binlog,
                                  fname, O_RDONLY | O_SHARE | O_BINARY,

--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -3394,6 +3394,14 @@ fil_create_new_single_table_tablespace(
 		remote directory, let's create the subdirectories
 		in the path, if they are not there already. */
 		success = os_file_create_subdirs_if_needed(path);
+		
+		// bug fix for http://bugs.mysql.com/bug.php?id=79151
+                if(!success && errno) {
+                        my_error(ER_GET_ERRNO, MYF(0), errno);
+                        mem_free(path);
+                        return(DB_ERROR);
+                }
+		
 		if (!success) {
 			err = DB_ERROR;
 			goto error_exit_3;


### PR DESCRIPTION
Problem was that after moving the bin log files to a new folder, real path of these files was wrong, for this reason program couldn't open and calculate its' size. I corrected files with wrong path, prepended full path of new binlog directory to these files.

I confirm the code being submitted is offered under the terms of the OCA, and that I am authorized to contribute it.