### PR TITLE
Bug #83741 - InnoDB: Failing assertion: lock->magic_n == 22643

### DIFF
--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -95,6 +95,7 @@ void my_init_signals();
 bool gtid_server_init();
 void gtid_server_cleanup();
 const char *fixup_enforce_gtid_consistency_command_line(char *value_arg);
+int is_filesystem_read_only(char const* path);
 
 extern "C" MYSQL_PLUGIN_IMPORT CHARSET_INFO *system_charset_info;
 extern MYSQL_PLUGIN_IMPORT CHARSET_INFO *files_charset_info ;

--- a/storage/innobase/row/row0mysql.cc
+++ b/storage/innobase/row/row0mysql.cc
@@ -3109,10 +3109,11 @@ row_create_index_for_mysql(
 			len = ut_max(len, field_lengths[i]);
 		}
 
-		DBUG_EXECUTE_IF(
+		// bug fix for http://bugs.mysql.com/bug.php?id=83741
+		/*DBUG_EXECUTE_IF(
 			"ib_create_table_fail_at_create_index",
 			len = DICT_MAX_FIELD_LEN_BY_FORMAT(table) + 1;
-		);
+		);*/
 
 		/* Column or prefix length exceeds maximum column length */
 		if (len > (ulint) DICT_MAX_FIELD_LEN_BY_FORMAT(table)) {


### PR DESCRIPTION
I did not find any explanation or documentation about ib_create_table_fail_at_create_index debug parameter. 

DBUG_EXECUTE_IF(
  "ib_create_table_fail_at_create_index",
   len = DICT_MAX_FIELD_LEN_BY_FORMAT(table) + 1;
);

It seems these debug condition was used for testing some errors during development, but was forgotten to delete later.

I confirm the code being submitted is offered under the terms of the OCA, and that I am authorized to contribute it.