### PR TITLE
mtr: mem is pure flag / add /run/shm

### DIFF
--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -219,7 +219,7 @@ sub using_extern { return (keys %opts_extern > 0);};
 
 our $opt_fast= 0;
 our $opt_force;
-our $opt_mem= $ENV{'MTR_MEM'};
+our $opt_mem= $ENV{'MTR_MEM'}  ? 1 : 0;
 our $opt_clean_vardir= $ENV{'MTR_CLEAN_VARDIR'};
 
 our $opt_gcov;
@@ -1482,10 +1482,11 @@ sub command_line_setup {
       if $opt_tmpdir;
 
     # Search through list of locations that are known
-    # to be "fast disks" to find a suitable location
-    # Use --mem=<dir> as first location to look.
-    my @tmpfs_locations= ($opt_mem, "/dev/shm", "/tmp");
+    # to be "fast disks" to find a suitable location/
+    my @tmpfs_locations= ($opt_mem, "/run/shm", "/dev/shm", "/tmp");
 
+    # Use $ENV{'MTR_MEM'} as first location to look (if defined)
+    unshift(@tmpfs_locations, $ENV{'MTR_MEM'}) if defined $ENV{'MTR_MEM'};
     foreach my $fs (@tmpfs_locations)
     {
       if ( -d $fs )
@@ -7202,7 +7203,7 @@ Options to control directories to use
   mem                   Run testsuite in "memory" using tmpfs or ramdisk
                         Attempts to find a suitable location
                         using a builtin list of standard locations
-                        for tmpfs (/dev/shm)
+                        for tmpfs (/run/shm, /dev/shm)
                         The option can also be set using environment
                         variable MTR_MEM=[DIR]
   clean-vardir          Clean vardir if tests were successful and if


### PR DESCRIPTION
Since 716621db3f3055781e24f561325cec6eac181717, opt_mem is
a pure flag. However it is assigned to the value of $MTR_MEM.

This leads to conflicts when MTR_MEM=/xxx/yy ./mtr --mem is
invoked. Here the --mem option overrided opt_mem leaving the
default path to be chosen.

This change makes when MTR_MEM set, opt_mem, the flag, is also
set. Both the environment and flag can no be set without conflicting.

/run/shm is added to the beginning of the path as its now used
in a few distros and is conceptually better than /dev for its purpose.