### PR TITLE
bug 84299: Symlinks for mtr mem directory not supported

### DIFF
--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -1488,7 +1488,7 @@ sub command_line_setup {
 
     foreach my $fs (@tmpfs_locations)
     {
-      if ( -d $fs )
+      if ( -d $fs && ! -l $fs )
       {
 	my $template= "var_${opt_build_thread}_XXXX";
 	$opt_mem= tempdir( $template, DIR => $fs, CLEANUP => 0);


### PR DESCRIPTION
Thanks @bjornmu for feedback (https://github.com/mysql/mysql-server/pull/116#issuecomment-268479774). Here is the check requested.

As per http://perldoc.perl.org/functions/-X.html -l will return false where not supported by OS so this should still work on Windows.

I note also on my Fedora based distro that /run/user/1000 is a shm too. ~The following may be added as well.~

edit: /run/user/1000 isn't that good of a choice. Other locations are bigger.
<pre>
$ df -h /dev/shm
Filesystem      Size  Used Avail Use% Mounted on
tmpfs           3.8G  154M  3.6G   5% /dev/shm
$ df -h /run/user/1000/
Filesystem      Size  Used Avail Use% Mounted on
tmpfs           766M   28K  766M   1% /run/user/1000
$ df -h /tmp
Filesystem      Size  Used Avail Use% Mounted on
tmpfs           3.8G  3.0G  850M  78% /tmp
</pre>