### PR TITLE
C++ conformance fixes (MSVC /permissive-)

### DIFF
--- a/client/mysql_secure_installation.cc
+++ b/client/mysql_secure_installation.cc
@@ -35,7 +35,7 @@ static my_bool g_expire_password_on_exit= FALSE;
 static my_bool opt_use_default= FALSE;
 
 #if defined (_WIN32) && !defined (EMBEDDED_LIBRARY)
-static char *shared_memory_base_name= default_shared_memory_base_name;
+static char *shared_memory_base_name= (char*)default_shared_memory_base_name;
 #endif
 
 #include "sslopt-vars.h"

--- a/libmysql/authentication_win/handshake.h
+++ b/libmysql/authentication_win/handshake.h
@@ -100,7 +100,7 @@ public:
   Handshake(const char *ssp, side_t side);
   virtual ~Handshake();
 
-  int Handshake::packet_processing_loop();
+  int packet_processing_loop();
 
   bool virtual is_complete() const
   {

--- a/rapid/plugin/group_replication/libmysqlgcs/include/mysql/gcs/xplatform/my_xp_cond.h
+++ b/rapid/plugin/group_replication/libmysqlgcs/include/mysql/gcs/xplatform/my_xp_cond.h
@@ -123,7 +123,7 @@ public:
 class My_xp_cond_win : public My_xp_cond
 {
 private:
-  static DWORD My_xp_cond_win::get_milliseconds(const struct timespec *abstime);
+  static DWORD get_milliseconds(const struct timespec *abstime);
   /*
     Disabling the copy constructor and assignment operator.
   */

--- a/sql/conn_handler/shared_memory_connection.cc
+++ b/sql/conn_handler/shared_memory_connection.cc
@@ -306,32 +306,34 @@ Channel_info* Shared_mem_listener::listen_for_connection_event()
   if (abort_loop)
     goto errorconn;
 
-  Channel_info* channel_info= new (std::nothrow)
-    Channel_info_shared_mem(m_handle_client_file_map,
-                            m_handle_client_map,
-                            m_event_server_wrote,
-                            m_event_server_read,
-                            m_event_client_wrote,
-                            m_event_client_read,
-                            m_event_conn_closed);
-  if (channel_info != NULL)
   {
-    int4store(m_connect_map,  m_connect_number);
-    if (!SetEvent(m_event_connect_answer))
+    Channel_info* channel_info= new (std::nothrow)
+      Channel_info_shared_mem(m_handle_client_file_map,
+                              m_handle_client_map,
+                              m_event_server_wrote,
+                              m_event_server_read,
+                              m_event_client_wrote,
+                              m_event_client_read,
+                              m_event_conn_closed);
+    if (channel_info != NULL)
     {
-      errmsg= "Could not send answer event";
-      delete channel_info;
-      goto errorconn;
-    }
+      int4store(m_connect_map,  m_connect_number);
+      if (!SetEvent(m_event_connect_answer))
+      {
+        errmsg= "Could not send answer event";
+        delete channel_info;
+        goto errorconn;
+      }
 
-    if (!SetEvent(m_event_client_read))
-    {
-      errmsg= "Could not set client to read mode";
-      delete channel_info;
-      goto errorconn;
+      if (!SetEvent(m_event_client_read))
+      {
+        errmsg= "Could not set client to read mode";
+        delete channel_info;
+        goto errorconn;
+      }
+      m_connect_number++;
+      return channel_info;
     }
-    m_connect_number++;
-    return channel_info;
   }
 errorconn:
   /* Could not form connection;  Free used handlers/memort and retry */

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -822,7 +822,7 @@ static char **opt_argv;
 static mysql_mutex_t LOCK_handler_count;
 static mysql_cond_t COND_handler_count;
 static HANDLE hEventShutdown;
-char *shared_memory_base_name= default_shared_memory_base_name;
+char *shared_memory_base_name= (char*)default_shared_memory_base_name;
 my_bool opt_enable_shared_memory;
 static char shutdown_event_name[40];
 #include "nt_servc.h"
@@ -7107,7 +7107,7 @@ static int mysql_init_variables(void)
 #endif /* ! EMBEDDED_LIBRARY */
 #endif /* HAVE_OPENSSL */
 #if defined (_WIN32) && !defined (EMBEDDED_LIBRARY)
-  shared_memory_base_name= default_shared_memory_base_name;
+  shared_memory_base_name= (char*)default_shared_memory_base_name;
 #endif
 
 #if defined(_WIN32)

--- a/sql/nt_servc.cc
+++ b/sql/nt_servc.cc
@@ -508,7 +508,7 @@ BOOL NTService::IsService(LPCSTR ServiceName)
 }
 /* ------------------------------------------------------------------------
  -------------------------------------------------------------------------- */
-BOOL NTService::got_service_option(char **argv, char *service_option)
+BOOL NTService::got_service_option(char **argv, const char *service_option)
 {
   char *option;
   for (option= argv[1]; *option; option++)

--- a/sql/nt_servc.h
+++ b/sql/nt_servc.h
@@ -61,7 +61,7 @@ class NTService
     BOOL SeekStatus(LPCSTR szInternName, int OperationType);
     BOOL Remove(LPCSTR szInternName);
     BOOL IsService(LPCSTR ServiceName);
-    BOOL got_service_option(char **argv, char *service_option);
+    BOOL got_service_option(char **argv, const char *service_option);
     BOOL is_super_user();
 
     /* 


### PR DESCRIPTION
We (the Microsoft C++ team) use the MySQL project as part of our "Real world code" tests.
I noticed a few issues in windows specific code when building MySQL with the MSVC compiler
in its conformance mode (/permissive-).  For more information on /permissive- see our blog
https://blogs.msdn.microsoft.com/vcblog/2016/11/16/permissive-switch/.

These changes are to address 3 different types of issues:

1) Use of qualified names in member declarations

    struct A {
        void A::f() { } // error C4596: illegal qualified name in member declaration
                        // remove redundant 'A::' to fix
    };

2) String literal type conversion

    char * str = "string"; // String literal loses 'const'
	                       // either change to 'const char*' or cast literal to 'char*'

I cast the value for shared_memory_base_name because adding 'const' to something like that
can have a big domino effect and I'm not sure I have the resourses to verify a change like that on
other systems.  You may want to make it a low priority 'todo' item for the future.  For now
it makes the current compiler behavior explicit.

3) Do not allow skipping an initializer with a goto

    void func(bool b)
    {
        if(b) goto END;
  
        int value = 0; //error C2362: initialization of 'value' is skipped by 'goto END'
              int array[10]; //Okay, not initialized.
  
        //... value used here
  
    END:
        return;
    }

One potential fix is to limit the scope of the initialized variable so it ends before the label.
See our blog for more potential fixes.