### PR TITLE
Bug #81814: InnoDB adaptive hash index uses a bad partitioning algorithm for the real world

### DIFF
--- a/storage/innobase/btr/btr0sea.cc
+++ b/storage/innobase/btr/btr0sea.cc
@@ -1193,9 +1193,7 @@ retry:
 	const index_id_t	index_id
 		= btr_page_get_index_id(block->frame);
 	const ulint		ahi_slot
-		= ut_fold_ulint_pair(static_cast<ulint>(index_id),
-				     static_cast<ulint>(block->page.id.space()))
-		% btr_ahi_parts;
+		= static_cast<ulint>(index_id) % btr_ahi_parts;
 	latch = btr_search_latches[ahi_slot];
 
 	ut_ad(!btr_search_own_any(RW_LOCK_S));

--- a/storage/innobase/include/btr0sea.ic
+++ b/storage/innobase/include/btr0sea.ic
@@ -200,10 +200,8 @@ btr_get_search_latch(const dict_index_t* index)
 {
 	ut_ad(index != NULL);
 
-	ulint	ifold = ut_fold_ulint_pair(static_cast<ulint>(index->id),
-					   static_cast<ulint>(index->space));
-
-	return(btr_search_latches[ifold % btr_ahi_parts]);
+	return(btr_search_latches[static_cast<ulint>(index->id) %
+				  btr_ahi_parts]);
 }
 
 /** Get the hash-table based on index attributes.
@@ -216,8 +214,6 @@ btr_get_search_table(const dict_index_t* index)
 {
 	ut_ad(index != NULL);
 
-	ulint	ifold = ut_fold_ulint_pair(static_cast<ulint>(index->id),
-					   static_cast<ulint>(index->space));
-
-	return(btr_search_sys->hash_tables[ifold % btr_ahi_parts]);
+	return(btr_search_sys->hash_tables[static_cast<ulint>(index->id) %
+					   btr_ahi_parts]);
 }


### PR DESCRIPTION
This patch replaces hash-based AHI partitioning with index ID based
one.

Index ID based partitioning is better than the current bad hash
function. It is also not any worse than any 'good' hash function for
real world workloads.

Adding space IDs would only make sense if index IDs were not guaranteed
to be unique. They are unique in 5.7 and the current public release of
8.0.