### PR TITLE
Bug #79454: Inefficient InnoDB row stats implementation

### DIFF
--- a/storage/innobase/include/sync0types.h
+++ b/storage/innobase/include/sync0types.h
@@ -30,7 +30,6 @@ Created 9/5/1995 Heikki Tuuri
 #include <iostream>
 
 #include "ut0new.h"
-#include "ut0counter.h"
 
 #if defined(UNIV_DEBUG) && !defined(UNIV_INNOCHECKSUM)
 /** Set when InnoDB has invoked exit(). */


### PR DESCRIPTION
Use PRNG-based slot indexes for InnoDB row counters on AArch64.

Using RDTSC- (aka counter-based) indexes result in higher contention on
many-core AArch64 machines due to low timer resolution (100 MHz). Using
sched_getcpu()-based indexers leads to lower single-threaded
performance, because sched_getcpu() is expensive on AArch64 (it is not
implemented via VDSO like on x86).

This also requires a better quality PRNG and properly seeding it for
each thread. These will be addressed in separate patches.