### PR TITLE
Adjust spec file to show a proper rpmbuild command

### DIFF
--- a/packaging/rpm-oel/mysql.spec.in
+++ b/packaging/rpm-oel/mysql.spec.in
@@ -14,8 +14,14 @@
 # Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston
 # MA  02110-1301  USA.
 
-# Rebuild on OL5/RHEL5 needs following rpmbuild options:
-#  rpmbuild --define 'dist .el5' --define 'rhel 5' --define 'el5 1' mysql.spec
+# To build on OL5..OL7/RHEL5..RHEL7 you need one of the following
+# rpmbuild options:
+#   --define 'dist .el5' --define 'rhel 5' --define 'el5 1'  # OL5/RHEL5
+#   --define 'dist .el6' --define 'rhel 6' --define 'el6 1'  # OL6/RHEL6
+#   --define 'dist .el7' --define 'rhel 7' --define 'el7 1'  # OL7/RHEL7
+#
+# So to build for EL7/RHEL7 you would run the following:
+# $ rpmbuild -ba --define 'dist .el7' --define 'rhel 7' --define 'el7 1' mysql.spec
 
 # Install cmake28 from EPEL when building on OL5/RHEL5 and OL6/RHEL6.
 


### PR DESCRIPTION
Also give an example for RHEL 7.

I've not played with rpmbuild for some time and sat there copying the "sample" rpmbuild command to build the package only to realise later that I was missing the -ba.

I think it probably makes sense to update this to reference the latest RHEL7 version. The patch is tiny and only a documentation change but might be handy and save someone a few minutes scratching their head like I did.