### PR TITLE
Bug #79454: Inefficient InnoDB row stats implementation

### DIFF
--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -117,7 +117,7 @@ enum_tx_isolation thd_get_trx_isolation(const THD* thd);
 
 /* for ha_innopart, Native InnoDB Partitioning. */
 #include "ha_innopart.h"
-
+extern thread_local_key_t ut_rnd_ulint_counter_key;
 /** to protect innobase_open_files */
 static mysql_mutex_t innobase_share_mutex;
 /** to force correct commit order in binlog */
@@ -3486,6 +3486,11 @@ innobase_init(
 	ulong		num_pll_degree;
 
 	DBUG_ENTER("innobase_init");
+
+	/* Create key for setting ut_rnd_ulint_counter for spin lock
+	delay as thread local. */
+	my_create_thread_local_key(&ut_rnd_ulint_counter_key,NULL);
+
 	handlerton* innobase_hton= (handlerton*) p;
 	innodb_hton_ptr = innobase_hton;
 
@@ -4108,6 +4113,7 @@ innobase_end(
 		mysql_cond_destroy(&commit_cond);
 	}
 
+	my_delete_thread_local_key(ut_rnd_ulint_counter_key);
 	DBUG_RETURN(err);
 }
 

--- a/storage/innobase/include/ut0rnd.ic
+++ b/storage/innobase/include/ut0rnd.ic
@@ -39,6 +39,7 @@ Created 5/30/1994 Heikki Tuuri
 #define UT_XOR_RND2		143537923
 
 #include <my_thread_local.h>
+#include <my_thread_os_id.h>
 
 extern thread_local_key_t ut_rnd_ulint_counter_key;
 /********************************************************//**
@@ -95,10 +96,15 @@ ut_rnd_gen_ulint(void)
 
 	rnd_count_value = my_get_thread_local(ut_rnd_ulint_counter_key);
 
-	if(!rnd_count_value) {
+	if(UNIV_UNLIKELY(!rnd_count_value)) {
 		/* Reset the value if we recieve NULL rnd value i.e.
 		coming from new thread */
-		rnd = 65654363;
+		rnd = static_cast<ulint>(my_thread_os_id());
+
+		if (UNIV_UNLIKELY(!rnd)) {
+
+			rnd = 65654363;
+		}
 	} else {
 		/* Set otherwise rnd to non null recieved from the
 		existing thread */

--- a/storage/innobase/include/ut0rnd.ic
+++ b/storage/innobase/include/ut0rnd.ic
@@ -38,9 +38,9 @@ Created 5/30/1994 Heikki Tuuri
 #define UT_XOR_RND1		187678878
 #define UT_XOR_RND2		143537923
 
-/** Seed value of ut_rnd_gen_ulint() */
-extern	ulint	 ut_rnd_ulint_counter;
+#include <my_thread_local.h>
 
+extern thread_local_key_t ut_rnd_ulint_counter_key;
 /********************************************************//**
 This is used to set the random number seed. */
 UNIV_INLINE
@@ -49,11 +49,13 @@ ut_rnd_set_seed(
 /*============*/
 	ulint	 seed)		 /*!< in: seed */
 {
-	ut_rnd_ulint_counter = seed;
+	/* Setting the seed value as thread local */
+	my_set_thread_local(ut_rnd_ulint_counter_key,(void *)seed);
 }
 
 /********************************************************//**
 The following function generates a series of 'random' ulint integers.
+This function is now based on thread local variables.
 @return the next 'random' number */
 UNIV_INLINE
 ulint
@@ -81,6 +83,7 @@ The following function generates 'random' ulint integers which
 enumerate the value space of ulint integers in a pseudo random
 fashion. Note that the same integer is repeated always after
 2 to power 32 calls to the generator (if ulint is 32-bit).
+This function is now based on thread local variables.
 @return the 'random' number */
 UNIV_INLINE
 ulint
@@ -88,16 +91,31 @@ ut_rnd_gen_ulint(void)
 /*==================*/
 {
 	ulint	rnd;
+	void*	rnd_count_value;
 
-	ut_rnd_ulint_counter = UT_RND1 * ut_rnd_ulint_counter + UT_RND2;
+	rnd_count_value = my_get_thread_local(ut_rnd_ulint_counter_key);
 
-	rnd = ut_rnd_gen_next_ulint(ut_rnd_ulint_counter);
+	if(!rnd_count_value) {
+		/* Reset the value if we recieve NULL rnd value i.e.
+		coming from new thread */
+		rnd = 65654363;
+	} else {
+		/* Set otherwise rnd to non null recieved from the
+		existing thread */
+		rnd = (ulint) rnd_count_value;
+        }
+
+	rnd = UT_RND1 * rnd + UT_RND2;
+	/* Setting the rnd value as thread local */
+	my_set_thread_local(ut_rnd_ulint_counter_key,(void *)rnd);
+	rnd = ut_rnd_gen_next_ulint(rnd);
 
 	return(rnd);
 }
 
 /********************************************************//**
 Generates a random integer from a given interval.
+This function is now based on thread local variables.
 @return the 'random' number */
 UNIV_INLINE
 ulint

--- a/storage/innobase/ut/ut0rnd.cc
+++ b/storage/innobase/ut/ut0rnd.cc
@@ -24,6 +24,7 @@ Created 5/11/1994 Heikki Tuuri
 ********************************************************************/
 
 #include "ut0rnd.h"
+#include <my_thread_local.h>
 
 #ifdef UNIV_NONINL
 #include "ut0rnd.ic"
@@ -36,9 +37,8 @@ Created 5/11/1994 Heikki Tuuri
 #define UT_RANDOM_3	1.0132677
 /*@}*/
 
-/** Seed value of ut_rnd_gen_ulint(). */
-ulint	ut_rnd_ulint_counter = 65654363;
-
+/** Key for thread local variable ut_rnd_ulint_counter */
+thread_local_key_t   ut_rnd_ulint_counter_key;
 /***********************************************************//**
 Looks for a prime number slightly greater than the given argument.
 The prime is chosen so that it is not near any power of 2.


### PR DESCRIPTION
This is a backport of commit 32b184c from 8.0 (which has been reverted from lower versions for unknown reasons) + a change to seed thread-local PRNG with OS thread ID. This is required to optimize InnoDB statistic counters on many-core ARM64 machines.