### PR TITLE
innodb_numa_interleave=1, use numa numa_get_mems_allowed

### DIFF
--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -87,9 +87,10 @@ struct set_numa_interleave_t
 
 			ib::info() << "Setting NUMA memory policy to"
 				" MPOL_INTERLEAVE";
+			struct bitmask *numa_mems_allowed = numa_get_mems_allowed();
 			if (set_mempolicy(MPOL_INTERLEAVE,
-					  numa_all_nodes_ptr->maskp,
-					  numa_all_nodes_ptr->size) != 0) {
+					  numa_mems_allowed->maskp,
+					  numa_mems_allowed->size) != 0) {
 
 				ib::warn() << "Failed to set NUMA memory"
 					" policy to MPOL_INTERLEAVE: "
@@ -895,10 +896,11 @@ buf_chunk_init(
 
 #ifdef HAVE_LIBNUMA
 	if (srv_numa_interleave) {
+		struct bitmask *numa_mems_allowed = numa_get_mems_allowed();
 		int	st = mbind(chunk->mem, chunk->mem_size(),
 				   MPOL_INTERLEAVE,
-				   numa_all_nodes_ptr->maskp,
-				   numa_all_nodes_ptr->size,
+				   numa_mems_allowed->maskp,
+				   numa_mems_allowed->size,
 				   MPOL_MF_MOVE);
 		if (st != 0) {
 			ib::warn() << "Failed to set NUMA memory policy of"


### PR DESCRIPTION
Using numa_all_nodes_ptr was excessively optimistic. Due to
constraints in systemd, containers or otherwise mysqld could of been
limited to a smaller set of cpus. Use the numa_get_mems_allowed
library function to see what we can interleave between before doing
so. This prevents repetitive errors "mbind: Invalid argument".