### PR TITLE
Bug #85588: When using rlike operator to detect characters with hex v…

### DIFF
--- a/client/mysqltest.cc
+++ b/client/mysqltest.cc
@@ -8325,7 +8325,7 @@ int match_re(my_regex_t *re, char *str)
     str= comm_end + 2;
   }
   
-  int err= my_regexec(re, str, (size_t)0, NULL, 0);
+  int err= my_regexec(re, str, strlen(str), (size_t)0, NULL, 0);
 
   if (err == 0)
     return 1;
@@ -9827,8 +9827,8 @@ int reg_replace(char** buf_p, int* buf_len_p, char *pattern,
   while (!err_code)
   {
     /* find the match */
-    err_code= my_regexec(&r,str_p, r.re_nsub+1, subs,
-                         (str_p == string) ? MY_REG_NOTBOL : 0);
+    err_code= my_regexec(&r,str_p, strlen(str_p), r.re_nsub+1, subs,
+                         (str_p != string) ? MY_REG_NOTBOL : 0);
 
     /* if regular expression error (eg. bad syntax, or out of memory) */
     if (err_code && err_code != MY_REG_NOMATCH)

--- a/mysql-test/r/func_regexp.result
+++ b/mysql-test/r/func_regexp.result
@@ -157,3 +157,6 @@ SELECT ' '  REGEXP '[[:space:]]';
 SELECT '\t' REGEXP '[[:space:]]';
 '\t' REGEXP '[[:space:]]'
 1
+SELECT (CONVERT(UNHEX('00149D5554') USING BINARY) RLIKE CONCAT('[', UNHEX('80'), '-', UNHEX('FF'), ']'));
+(CONVERT(UNHEX('00149D5554') USING BINARY) RLIKE CONCAT('[', UNHEX('80'), '-', UNHEX('FF'), ']'))
+1

--- a/mysql-test/t/func_regexp.test
+++ b/mysql-test/t/func_regexp.test
@@ -106,3 +106,13 @@ SELECT '\t' REGEXP '[[:blank:]]';
 
 SELECT ' '  REGEXP '[[:space:]]';
 SELECT '\t' REGEXP '[[:space:]]';
+
+#
+# Bug #85588: When using rlike operator to detect characters with hex values 
+# between 80 and FF, it does not work when converting a binary string that 
+# starts with hexadecimal '00' using unhex function.
+# This test verifies that binary string having hexadecimal 00 byte is
+# processed correctly.
+
+SELECT (CONVERT(UNHEX('00149D5554') USING BINARY) RLIKE CONCAT('[', UNHEX('80'), '-', UNHEX('FF'), ']'));
+

--- a/regex/engine.c
+++ b/regex/engine.c
@@ -63,10 +63,11 @@ struct match {
  ==	size_t nmatch, regmatch_t pmatch[], int eflags);
  */
 static int			/* 0 success, MY_REG_NOMATCH failure */
-matcher(charset,g, str, nmatch, pmatch, eflags)
+matcher(charset,g, str, strlength, nmatch, pmatch, eflags)
 const CHARSET_INFO *charset;
 register struct re_guts *g;
 char *str;
+size_t strlength;
 size_t nmatch;
 my_regmatch_t pmatch[];
 int eflags;
@@ -89,7 +90,7 @@ int eflags;
 		stop = str + pmatch[0].rm_eo;
 	} else {
 		start = str;
-		stop = start + strlen(start);
+                stop = start + strlength;
 	}
 	if (stop < start)
 		return(MY_REG_INVARG);

--- a/regex/engine.ih
+++ b/regex/engine.ih
@@ -4,8 +4,8 @@ extern "C" {
 #endif
 
 /* === engine.c === */
-static int matcher(const CHARSET_INFO *charset,register struct re_guts *g,
-                   char *string, size_t nmatch, my_regmatch_t pmatch[],
+static int matcher(const CHARSET_INFO *charset,struct re_guts *g,
+                   char *string, size_t strlength, size_t nmatch, my_regmatch_t pmatch[],
                    int eflags);
 static char *dissect(const CHARSET_INFO *charset, register struct match *m,
                      char *start, char *stop, sopno startst, sopno stopst);

--- a/regex/main.c
+++ b/regex/main.c
@@ -149,7 +149,7 @@ char *argv[];
 		subs[0].rm_so = startoff;
 		subs[0].rm_eo = strlen(argv[optind]) - endoff;
 	}
-	err = my_regexec(&re, argv[optind], (size_t)NS, subs, eopts);
+    err = my_regexec(&re, argv[optind], strlen(argv[optind]), (size_t)NS, subs, eopts);
 	if (err) {
 		len = my_regerror(err, &re, erbuf, sizeof(erbuf));
 		fprintf(stderr, "error %s, %d/%d `%s'\n",
@@ -329,7 +329,7 @@ int opts;			/* may not match f1 */
 		subs[0].rm_so = strchr(f2, '(') - f2 + 1;
 		subs[0].rm_eo = strchr(f2, ')') - f2;
 	}
-	err = my_regexec(&re, f2copy, NSUBS, subs, options('e', f1));
+    err = my_regexec(&re, f2copy, strlen(f2copy), NSUBS, subs, options('e', f1));
 
 	if (err != 0 && (f3 != NULL || err != MY_REG_NOMATCH)) {
 		/* unexpected error or wrong error */

--- a/regex/my_regex.h
+++ b/regex/my_regex.h
@@ -66,7 +66,7 @@ extern size_t my_regerror(int, const my_regex_t *, char *, size_t);
 
 
 /* === regexec.c === */
-extern int my_regexec(const my_regex_t *, const char *, size_t, my_regmatch_t [], int);
+extern int my_regexec(const my_regex_t *, const char *, size_t, size_t, my_regmatch_t [], int);
 #define	MY_REG_NOTBOL	00001
 #define	MY_REG_NOTEOL	00002
 #define	MY_REG_STARTEND	00004

--- a/regex/regexec.c
+++ b/regex/regexec.c
@@ -110,9 +110,10 @@
  * have been prototyped.
  */
 int				/* 0 success, MY_REG_NOMATCH failure */
-my_regexec(preg, str, nmatch, pmatch, eflags)
+my_regexec(preg, str, strlength, nmatch, pmatch, eflags)
 const my_regex_t *preg;
 const char *str;
+size_t strlength;
 size_t nmatch;
 my_regmatch_t pmatch[];
 int eflags;
@@ -134,7 +135,7 @@ int eflags;
 
 	if ((size_t) g->nstates <= CHAR_BIT*sizeof(states1) &&
 	    !(eflags&MY_REG_LARGE))
-		return(smatcher(preg->charset, g, pstr, nmatch, pmatch, eflags));
+        return(smatcher(preg->charset, g, pstr, strlength, nmatch, pmatch, eflags));
 	else
-		return(lmatcher(preg->charset, g, pstr, nmatch, pmatch, eflags));
+        return(lmatcher(preg->charset, g, pstr, strlength, nmatch, pmatch, eflags));
 }

--- a/sql/item_cmpfunc.cc
+++ b/sql/item_cmpfunc.cc
@@ -5577,7 +5577,7 @@ longlong Item_func_regex::val_int()
     }
     res= &conv;
   }
-  return my_regexec(&preg,res->c_ptr_safe(),0,(my_regmatch_t*) 0,0) ? 0 : 1;
+  return my_regexec(&preg, res->c_ptr_safe(), res->length(), 0, (my_regmatch_t*) 0, 0) ? 0 : 1;
 }
 
 


### PR DESCRIPTION
…alues between 80 and FF, it does not work when converting a binary string that starts with hexadecimal '00' using unhex function.