### PR TITLE
Add missing newline to 'Row event for unknown table' message

### DIFF
--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -2475,7 +2475,7 @@ void Rows_log_event::print_verbose(IO_CACHE *file,
       !(td= map->create_table_def()))
   {
     char llbuff[22];
-    my_b_printf(file, "### Row event for unknown table #%s",
+    my_b_printf(file, "### Row event for unknown table #%s\n",
                 llstr(m_table_id, llbuff));
     return;
   }


### PR DESCRIPTION
Add missing newline to 'Row event for unknown table' message
    
This is what currently happens:
```
$ ./my sqlbinlog data/binlog.000004 --base64-output=decode-rows --verbose --start-position=832 --stop-position=880
/*!50530 SET @@SESSION.PSEUDO_SLAVE_MODE=1*/;
/*!50003 SET @OLD_COMPLETION_TYPE=@@COMPLETION_TYPE,COMPLETION_TYPE=0*/;
DELIMITER /*!*/;
# at 832
#170713 17:09:31 server id 5718  end_log_pos 880 CRC32 0xa79de20f      Write_rows: table id 257 flags: STMT_END_F
### Row event for unknown table #257SET @@SESSION.GTID_NEXT= 'AUTOMATIC' /* added by mysqlbinlog */ /*!*/;
DELIMITER ;
# End of log file
/*!50003 SET COMPLETION_TYPE=@OLD_COMPLETION_TYPE*/;
/*!50530 SET @@SESSION.PSEUDO_SLAVE_MODE=0*/;
 ```
   
This is how it should look:
```
$ ./my sqlbinlog data/binlog.000004 --base64-output=decode-rows --verbose --start-position=832 --stop-position=880
/*!50530 SET @@SESSION.PSEUDO_SLAVE_MODE=1*/;
/*!50003 SET @OLD_COMPLETION_TYPE=@@COMPLETION_TYPE,COMPLETION_TYPE=0*/;
DELIMITER /*!*/;
# at 832
#170713 17:09:31 server id 5718  end_log_pos 880 CRC32 0xa79de20f      Write_rows: table id 257 flags: STMT_END_F
### Row event for unknown table #257
SET @@SESSION.GTID_NEXT= 'AUTOMATIC' /* added by mysqlbinlog */ /*!*/;
DELIMITER ;
# End of log file
/*!50003 SET COMPLETION_TYPE=@OLD_COMPLETION_TYPE*/;
/*!50530 SET @@SESSION.PSEUDO_SLAVE_MODE=0*/;
 ```
    
The "SET @@SESSION.GTID_NEXT…" message should be on a new line.
