### PR TITLE
include my_dir.h

### DIFF
--- a/mysys/my_symlink.c
+++ b/mysys/my_symlink.c
@@ -23,6 +23,7 @@
 #include <sys/param.h>
 #include <sys/stat.h>
 #endif
+#include <my_dir.h>
 
 /*
   Reads the content of a symbolic link


### PR DESCRIPTION
Building client libraries only (-DWITHOUT_SERVER=ON) failed with:

error: unknown type name ‘MY_STAT’

and

implicit declaration of function ‘my_fstat’

Include my_dir.h to fix compilation.