### PR TITLE
Bug#23014086: DEFAULT LOG-TC-SIZE TOO SMALL ON POWER/ARM - 3 * ( 64K …

### DIFF
--- a/mysql-test/include/mysqld--help.inc
+++ b/mysql-test/include/mysqld--help.inc
@@ -58,6 +58,8 @@ perl;
     s/\b393216\b/262144/;
     # Replacing port number with string
     s/^port \d+/port ####/;
+    # log-tc-size varies by platform
+    s/^log-tc-size \d+/log-tc-size #####/;
     foreach $var (@env) { s/$ENV{$var}/$var/ }
     next if /use --skip-(use-)?symbolic-links to disable/; # for valgrind, again
     next if $skip;

--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -1353,7 +1353,7 @@ log-syslog-facility daemon
 log-syslog-include-pid TRUE
 log-syslog-tag 
 log-tc tc.log
-log-tc-size 24576
+log-tc-size #####
 log-throttle-queries-not-using-indexes 0
 log-timestamps UTC
 log-warnings 0

--- a/mysql-test/r/mysqld--help-win.result
+++ b/mysql-test/r/mysqld--help-win.result
@@ -1348,7 +1348,7 @@ log-statements-unsafe-for-binlog TRUE
 log-syslog FALSE
 log-syslog-tag 
 log-tc tc.log
-log-tc-size 24576
+log-tc-size #####
 log-throttle-queries-not-using-indexes 0
 log-timestamps UTC
 log-warnings 0

--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -9470,15 +9470,16 @@ int MYSQL_BIN_LOG::recover(IO_CACHE *log, Format_description_log_event *fdle,
     is partially written to the binlog.
   */
   bool in_transaction= FALSE;
+  int memory_page_size= my_getpagesize();
 
   if (! fdle->is_valid() ||
-      my_hash_init(&xids, &my_charset_bin, TC_LOG_PAGE_SIZE/3, 0,
+      my_hash_init(&xids, &my_charset_bin, memory_page_size/3, 0,
                    sizeof(my_xid), 0, 0, MYF(0),
                    key_memory_binlog_recover_exec))
     goto err1;
 
   init_alloc_root(key_memory_binlog_recover_exec,
-                  &mem_root, TC_LOG_PAGE_SIZE, TC_LOG_PAGE_SIZE);
+                  &mem_root, memory_page_size, memory_page_size);
 
   while ((ev= Log_event::read_log_event(log, 0, fdle, TRUE))
          && ev->is_valid())

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -313,6 +313,7 @@ bool server_id_supplied = false;
 bool opt_endinfo, using_udf_functions;
 my_bool locked_in_memory;
 bool opt_using_transactions;
+ulong opt_tc_log_size;
 bool volatile abort_loop;
 static enum_server_operational_state server_operational_state= SERVER_BOOTING;
 ulong log_warnings;
@@ -5736,8 +5737,9 @@ struct my_option my_long_options[]=
    REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {"log-tc-size", 0, "Size of transaction coordinator log.",
    &opt_tc_log_size, &opt_tc_log_size, 0, GET_ULONG,
-   REQUIRED_ARG, TC_LOG_MIN_SIZE, TC_LOG_MIN_SIZE, ULONG_MAX, 0,
-   TC_LOG_PAGE_SIZE, 0},
+   REQUIRED_ARG, TC_LOG_MIN_PAGES * my_getpagesize(),
+   TC_LOG_MIN_PAGES * my_getpagesize(), ULONG_MAX, 0,
+   my_getpagesize(), 0},
   {"master-info-file", 0,
    "The location and name of the file that remembers the master and where "
    "the I/O replication thread is in the master's binlogs.",

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -222,8 +222,7 @@ public:
 };
 
 
-#define TC_LOG_PAGE_SIZE   8192
-#define TC_LOG_MIN_SIZE    (3*TC_LOG_PAGE_SIZE)
+#define TC_LOG_MIN_PAGES   6
 
 typedef struct st_user_var_events
 {

--- a/sql/tc_log.cc
+++ b/sql/tc_log.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+/* Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -85,7 +85,6 @@ ulong tc_log_page_waits= 0;
 
 static const char tc_log_magic[]={(char) 254, 0x23, 0x05, 0x74};
 
-ulong opt_tc_log_size= TC_LOG_MIN_SIZE;
 ulong tc_log_max_pages_used=0, tc_log_page_size=0, tc_log_cur_pages_used=0;
 
 int TC_LOG_MMAP::open(const char *opt_name)
@@ -98,10 +97,6 @@ int TC_LOG_MMAP::open(const char *opt_name)
   DBUG_ASSERT(opt_name && opt_name[0]);
 
   tc_log_page_size= my_getpagesize();
-  if (TC_LOG_PAGE_SIZE > tc_log_page_size)
-  {
-    DBUG_ASSERT(TC_LOG_PAGE_SIZE % tc_log_page_size == 0);
-  }
 
   fn_format(logname,opt_name,mysql_data_home,"",MY_UNPACK_FILENAME);
   if ((fd= mysql_file_open(key_file_tclog, logname, O_RDWR, MYF(0))) < 0)


### PR DESCRIPTION
…PAGE SIZE) MINIMIUM NEEDED

Backport from 8.0 commit 62b80f7d9db06d0edecf5a277e6a7fc489d806d5 - from Jon Olav Hauglid

This does a runtime lookup of the pagesize.