### PR TITLE
Bug #87293: Fix TTASFutex Lock release barrier

### DIFF
--- a/storage/innobase/include/ib0mutex.h
+++ b/storage/innobase/include/ib0mutex.h
@@ -265,7 +265,7 @@ struct TTASFutexMutex {
 		them up. Reset the lock state to unlocked so that waiting
 		threads can test for success. */
 
-		os_rmb;
+		os_wmb;
 
 		if (state() == MUTEX_STATE_WAITERS) {
 


### PR DESCRIPTION
Pertaining to the issue reported for [Bug #87293](https://bugs.mysql.com/bug.php?id=87293) ,
It think that the os_rmb() in TTASFutexMutex mutex release is inadequate for aarch64 platforms and should be replaced with a os_wmb(). 
It also seems to fix the intermittent crash seen for Futex locks .
