### PR TITLE
Bug #87543: dd_sdi-t.cc assumes 'char' to be signed

### DIFF
--- a/unittest/gunit/dd_sdi-t.cc
+++ b/unittest/gunit/dd_sdi-t.cc
@@ -515,7 +515,7 @@ TEST(SdiTest, Serialization_perf)
 
 TEST(SdiTest, CharPromotion)
 {
-  char x= 127;
+  signed char x= 127;
   unsigned char ux= x;
   EXPECT_EQ(127u, ux);
 
@@ -526,7 +526,7 @@ TEST(SdiTest, CharPromotion)
   EXPECT_EQ(127u, usx);
 
   unsigned char tmp= 0xe0;
-  x= static_cast<char>(tmp);
+  x= static_cast<signed char>(tmp);
   EXPECT_EQ(-32,x);
 
   ux= x;


### PR DESCRIPTION
Declare 'x' as a signed char explicitly in the CharPromotion test.