### PR TITLE
Bug #88197 Accelerated SHA1/SHA256 with ARMv8 Crypto Extensions

### DIFF
--- a/extra/yassl/taocrypt/include/sha.hpp
+++ b/extra/yassl/taocrypt/include/sha.hpp
@@ -24,6 +24,18 @@
 
 #include "hash.hpp"
 
+#if defined ARMV8_CE_SHA
+    #include <arm_neon.h>
+    #if defined(__BYTE_ORDER__)
+        #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+            #define LITTLE_ENDIAN_ORDER
+        #else
+            #define BIG_ENDIAN_ORDER
+        #endif
+    #else
+        #error macro __BYTE_ORDER__ is not defined in host compiler
+    #endif
+#endif
 
 #if defined(TAOCRYPT_X86ASM_AVAILABLE) && defined(TAO_ASM)
     #define DO_SHA_ASM


### PR DESCRIPTION
Support for 64-bit ARMv8 SHA1/SHA256 cryptography extensions in yaSSL taoCrypt.
The SHA1/SHA256 with ARMv8 NEON intrinsics will optimized the performance rather than uses table-based lookup.

Change-Id: I66378124fe09fcf98f40f83ffe6b662e231f9741
Signed-off-by: Yuqi Gu <yuqi.gu@arm.com>