### PR TITLE
Define constant following its comment

### DIFF
--- a/include/mysql_com.h
+++ b/include/mysql_com.h
@@ -615,6 +615,8 @@
   @sa cli_safe_read_with_ok(), read_ok_ex(), net_send_ok(), net_send_eof()
 */
 #define CLIENT_DEPRECATE_EOF (1UL << 24)
+
+
 /**
   Verify server certificate.
 
@@ -622,6 +624,7 @@
 
   @deprecated in favor of --ssl-mode.
 */
+#define CLIENT_SSL_VERIFY_SERVER_CERT (1UL << 30)
 
 
 /**
@@ -630,7 +633,6 @@
 #define CLIENT_OPTIONAL_RESULTSET_METADATA (1UL << 25)
 
 
-#define CLIENT_SSL_VERIFY_SERVER_CERT (1UL << 30)
 /**
   Don't reset the options after an unsuccessful connect
 


### PR DESCRIPTION
Moves the definition of `CLIENT_SSL_VERIFY_SERVER_CERT ` to immediately follow the comment describing it. This fixes the documentation at https://dev.mysql.com/doc/dev/mysql-server/latest/group__group__cs__capabilities__flags.html#ga4e7c0220984fdf1e231344f450cfd51e and addresses [bug 88208](https://bugs.mysql.com/bug.php?id=88208).