### PR TITLE
Export zlib version in a variable

### DIFF
--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -123,6 +123,7 @@
 #include "sql/xa.h"
 #include "template_utils.h"              // pointer_cast
 #include "thr_lock.h"
+#include "zlib.h"
 
 #ifdef WITH_PERFSCHEMA_STORAGE_ENGINE
 #include "../storage/perfschema/pfs_server.h"
@@ -4829,6 +4830,12 @@ static Sys_var_charptr Sys_version_compile_os(
        "version_compile_os", "version_compile_os",
        READ_ONLY NON_PERSIST GLOBAL_VAR(server_version_compile_os_ptr), NO_CMD_LINE,
        IN_SYSTEM_CHARSET, DEFAULT(SYSTEM_TYPE));
+
+static char *server_version_compile_zlib_ptr;
+static Sys_var_charptr Sys_version_compile_zlib(
+       "version_compile_zlib", "version_compile_zlib",
+       READ_ONLY NON_PERSIST GLOBAL_VAR(server_version_compile_zlib_ptr), NO_CMD_LINE,
+       IN_SYSTEM_CHARSET, DEFAULT(ZLIB_VERSION));
 
 static Sys_var_ulong Sys_net_wait_timeout(
        "wait_timeout",


### PR DESCRIPTION
If [innodb_log_compressed_pages](https://dev.mysql.com/doc/refman/8.0/en/innodb-parameters.html#sysvar_innodb_log_compressed_pages) is used one needs to be careful which zlib version in used when using InnoDB recovery. Among others this could impact backup/restore with a hot backup tool or a storage snapshot.

This patch exposes the zlib version.
Currently this is only exposed via:
```
storage/innobase/srv/srv0start.cc:      ib::info() << "Compressed tables use zlib " ZLIB_VERSION
```

Related: https://bugs.launchpad.net/percona-xtrabackup/+bug/1736139