### PR TITLE
Fix error: enum constant in boolean context

### DIFF
--- a/sql/sp.cc
+++ b/sql/sp.cc
@@ -1149,7 +1149,10 @@ bool sp_update_routine(THD *thd, enum_sp_type type, sp_name *name,
     // validate comment string to invalid utf8 characters.
     if (is_invalid_string(chistics->comment,
                           system_charset_info))
-      DBUG_RETURN(SP_INTERNAL_ERROR);
+    {
+       my_error(SP_INTERNAL_ERROR, MYF(0));
+       DBUG_RETURN(true);
+    }
 
     // Check comment string length.
     if (check_string_char_length({ chistics->comment.str,


### PR DESCRIPTION
When building the 8.0 branch using 6.3.0 on Ubuntu 17.04, the
following error is seen:

[ 42%] Building CXX object sql/CMakeFiles/sql_main.dir/sp.cc.o
In file included from /home/eric/src/mysql-server/include/template_utils.h:21:0,
                 from /home/eric/src/mysql-server/include/my_byteorder.h:53,
                 from /home/eric/src/mysql-server/include/m_ctype.h:29,
                 from /home/eric/src/mysql-server/include/map_helpers.h:26,
                 from /home/eric/src/mysql-server/sql/sp.h:25,
                 from /home/eric/src/mysql-server/sql/sp.cc:18:
/home/eric/src/mysql-server/sql/sp.cc: In function 'bool sp_update_routine(THD*, enum_sp_type, sp_name*, st_sp_chistics*)':
/home/eric/src/mysql-server/include/my_dbug.h:77:50: error: enum constant in boolean context [-Werror=int-in-bool-context]
 #define DBUG_RETURN(a1) do {DBUG_LEAVE; return(a1);} while(0)
                                                  ^
/home/eric/src/mysql-server/sql/sp.cc:1152:7: note: in expansion of macro 'DBUG_RETURN'
       DBUG_RETURN(SP_INTERNAL_ERROR);
       ^
cc1plus: all warnings being treated as errors
sql/CMakeFiles/sql_main.dir/build.make:3013: recipe for target 'sql/CMakeFiles/sql_main.dir/sp.cc.o' failed
make[2]: *** [sql/CMakeFiles/sql_main.dir/sp.cc.o] Error 1
CMakeFiles/Makefile2:10336: recipe for target 'sql/CMakeFiles/sql_main.dir/all' failed
make[1]: *** [sql/CMakeFiles/sql_main.dir/all] Error 2
Makefile:160: recipe for target 'all' failed
make: *** [all] Error 2

This patch addresses the error.