### PR TITLE
Add optional release_extra rpm tag to distinguish rebuilt rpms

### DIFF
--- a/packaging/rpm-docker/mysql.spec.in
+++ b/packaging/rpm-docker/mysql.spec.in
@@ -52,7 +52,7 @@ Name:           mysql%{?cluster:-cluster}-%{product_suffix}-minimal
 Summary:        A very fast and reliable SQL database server
 Group:          Applications/Databases
 Version:        @MYSQL_NO_DASH_VERSION@
-Release:        0.1%{?milestone:.%{milestone}}%{?commercial:.1}%{?dist}
+Release:        0.1%{?milestone:.%{milestone}}%{?commercial:.1}%{?release_extra}%{?dist}
 License:        Copyright (c) 2000, @MYSQL_COPYRIGHT_YEAR@, %{mysql_vendor}. All rights reserved. Under %{?license_type} license as shown in the Description field.
 URL:            http://www.mysql.com/
 Packager:       MySQL Release Engineering <mysql-build@oss.oracle.com>

--- a/packaging/rpm-fedora/mysql.spec.in
+++ b/packaging/rpm-fedora/mysql.spec.in
@@ -70,7 +70,7 @@ Name:           mysql-%{product_suffix}
 Summary:        A very fast and reliable SQL database server
 Group:          Applications/Databases
 Version:        @MYSQL_NO_DASH_VERSION@
-Release:        0.1%{?milestone:.%{milestone}}%{?dist}
+Release:        0.1%{?milestone:.%{milestone}}%{?release_extra}%{?dist}
 License:        Copyright (c) 2000, @MYSQL_COPYRIGHT_YEAR@, %{mysql_vendor}. All rights reserved. Under %{?license_type} license as shown in the Description field.
 Source0:        https://cdn.mysql.com/Downloads/MySQL-@MYSQL_BASE_VERSION@/%{src_dir}.tar.gz
 Source1:        http://downloads.sourceforge.net/boost/@BOOST_PACKAGE_NAME@.tar.bz2

--- a/packaging/rpm-oel/mysql.spec.in
+++ b/packaging/rpm-oel/mysql.spec.in
@@ -95,7 +95,7 @@ Name:           mysql%{?cluster:-cluster}-%{product_suffix}
 Summary:        A very fast and reliable SQL database server
 Group:          Applications/Databases
 Version:        @MYSQL_NO_DASH_VERSION@
-Release:        0.1%{?milestone:.%{milestone}}%{?commercial:.1}%{?dist}
+Release:        0.1%{?milestone:.%{milestone}}%{?commercial:.1}%{?release_extra}%{?dist}
 License:        Copyright (c) 2000, @MYSQL_COPYRIGHT_YEAR@, %{mysql_vendor}. All rights reserved. Under %{?license_type} license as shown in the Description field.
 Source0:        https://cdn.mysql.com/Downloads/MySQL-@MYSQL_BASE_VERSION@/%{src_dir}.tar.gz
 URL:            http://www.mysql.com/

--- a/packaging/rpm-sles/mysql.spec.in
+++ b/packaging/rpm-sles/mysql.spec.in
@@ -93,7 +93,7 @@ Name:           mysql%{?cluster:-cluster}-%{product_suffix}
 Summary:        A very fast and reliable SQL database server
 Group:          Applications/Databases
 Version:        @MYSQL_NO_DASH_VERSION@
-Release:        0.1%{?milestone:.%{milestone}}%{?commercial:.1}%{?dist}
+Release:        0.1%{?milestone:.%{milestone}}%{?commercial:.1}%{?release_extra}%{?dist}
 License:        Copyright (c) 2000, @MYSQL_COPYRIGHT_YEAR@, %{mysql_vendor}. All rights reserved. Under %{?license_type} license as shown in the Description field.
 Source0:        https://cdn.mysql.com/Downloads/MySQL-@MYSQL_BASE_VERSION@/%{src_dir}.tar.gz
 URL:            http://www.mysql.com/


### PR DESCRIPTION
If I download a src rpm built by Oracle and want to rebuild it with different options then I can do something like:

`$ rpmbuild --rebuild --define 'with_ssl system' mysql-community-5.7.21-1.el7.src.rpm`

However, doing this means the rebuilt rpms will have exactly the same name as the original one. It's not clear from the rpm name alone[1] that I have built this new rpm so there's a clear chance of confusion.

This patch provides for an optional `--define` argument, `release_extra`, that can be used when rebuilding rpms from the src rpm so that the new rpm will be named slightly differently.

e.g.

`$ rpmbuild --rebuild --define 'release_extra .sjm' --define 'with_ssl system' mysql-community-5.7.21-1.el7.src.rpm`

would create a binary filename of the form `mysql-community-server-5.7.20-1.sjm.el7.x86_64.rpm` which is easily distinguishable from the original rpms built by Oracle. The release version change is minimal so any existing software that sees this will only need minimal adjustments should it see these newly named rpms.

This argument would NOT be used by Oracle but only by any users who want to simplify the way rebuilt packages can be distinguished from the upstream originals.

[1] `rpm -qi mysql-community-server` would show you the build host etc.