### PR TITLE
Mirror acl_users Array with Map -- rebased on mysql-8.0.11

### DIFF
--- a/sql/auth/sql_auth_cache.h
+++ b/sql/auth/sql_auth_cache.h
@@ -281,6 +281,36 @@ class GRANT_TABLE : public GRANT_NAME {
   bool ok() { return privs != 0 || cols != 0; }
 };
 
+/*
+ * A default/no-arg constructor is useful with containers-of-containers
+ * situations in which a two-allocator scoped_allocator_adapter is not enough.
+ * This custom allocator provides a Malloc_allocator with a no-arg constructor
+ * by hard-coding the key_memory_acl_cache constructor argument.
+ * This "solution" lacks beauty, yet is pragmatic.
+ */
+template <class T>
+class Acl_cache_allocator : public Malloc_allocator<T> {
+ public:
+  Acl_cache_allocator() : Malloc_allocator<T>(key_memory_acl_cache) {}
+  template <class U>
+  struct rebind {
+    typedef Acl_cache_allocator<U> other;
+  };
+
+  template <class U>
+  Acl_cache_allocator(const Acl_cache_allocator<U> &other
+                      __attribute__((unused)))
+      : Malloc_allocator<T>(key_memory_acl_cache) {}
+
+  template <class U>
+  Acl_cache_allocator &operator=(const Acl_cache_allocator<U> &other
+                                 __attribute__((unused))) {}
+};
+typedef Acl_cache_allocator<ACL_USER *> Acl_user_ptr_allocator;
+typedef std::list<ACL_USER *, Acl_user_ptr_allocator> Acl_user_ptr_list;
+Acl_user_ptr_list *cached_acl_users_for_name(const char *name);
+void rebuild_cached_acl_users_for_name(void);
+
 /* Data Structures */
 
 extern MEM_ROOT global_acl_memory;

--- a/sql/auth/sql_authentication.cc
+++ b/sql/auth/sql_authentication.cc
@@ -1685,17 +1685,21 @@ static bool find_mpvio_user(THD *thd, MPVIO_EXT *mpvio) {
   DBUG_PRINT("info", ("entry: %s", mpvio->auth_info.user_name));
   DBUG_ASSERT(mpvio->acl_user == 0);
 
-  if (likely(acl_users)) {
-    Acl_cache_lock_guard acl_cache_lock(thd, Acl_cache_lock_mode::READ_MODE);
-    if (!acl_cache_lock.lock(false)) DBUG_RETURN(true);
+  Acl_cache_lock_guard acl_cache_lock(thd, Acl_cache_lock_mode::READ_MODE);
+  if (!acl_cache_lock.lock(false)) DBUG_RETURN(true);
 
-    for (ACL_USER *acl_user_tmp = acl_users->begin();
-         acl_user_tmp != acl_users->end(); ++acl_user_tmp) {
+  Acl_user_ptr_list *list = nullptr;
+  if (likely(acl_users)) {
+    list = cached_acl_users_for_name(mpvio->auth_info.user_name);
+  }
+  if (list) {
+    for (auto it = list->begin(); it != list->end(); ++it) {
+      ACL_USER *acl_user_tmp = (*it);
+
       if ((!acl_user_tmp->user ||
            !strcmp(mpvio->auth_info.user_name, acl_user_tmp->user)) &&
           acl_user_tmp->host.compare_hostname(mpvio->host, mpvio->ip)) {
         mpvio->acl_user = acl_user_tmp->copy(mpvio->mem_root);
-
         /*
           When setting mpvio->acl_user_plugin we can save memory allocation if
           this is a built in plugin.
@@ -1709,8 +1713,8 @@ static bool find_mpvio_user(THD *thd, MPVIO_EXT *mpvio) {
         break;
       }
     }
-    acl_cache_lock.unlock();
   }
+  acl_cache_lock.unlock();
 
   if (!mpvio->acl_user) {
     /*

--- a/sql/auth/sql_user.cc
+++ b/sql/auth/sql_user.cc
@@ -1329,6 +1329,7 @@ static int handle_grant_struct(enum enum_acl_lists struct_no, bool drop,
 
         if (drop) {
           acl_users->erase(idx);
+          rebuild_cached_acl_users_for_name();
           /*
              - If we are iterating through an array then we just have moved all
              elements after the current element one position closer to its head.
@@ -1341,6 +1342,7 @@ static int handle_grant_struct(enum enum_acl_lists struct_no, bool drop,
           acl_user->user = strdup_root(&global_acl_memory, user_to->user.str);
           acl_user->host.update_hostname(
               strdup_root(&global_acl_memory, user_to->host.str));
+          rebuild_cached_acl_users_for_name();
         } else {
           /* If search is requested, we do not need to search further. */
           break;
@@ -1931,6 +1933,7 @@ bool mysql_drop_user(THD *thd, List<LEX_USER> &list, bool if_exists) {
 
   /* Rebuild 'acl_check_hosts' since 'acl_users' has been modified */
   rebuild_check_host();
+  rebuild_cached_acl_users_for_name();
 
   if (result && !thd->is_error()) {
     String operation_str;
@@ -2077,6 +2080,7 @@ bool mysql_rename_user(THD *thd, List<LEX_USER> &list) {
 
   /* Rebuild 'acl_check_hosts' since 'acl_users' has been modified */
   rebuild_check_host();
+  rebuild_cached_acl_users_for_name();
 
   if (result && !thd->is_error())
     my_error(ER_CANNOT_USER, MYF(0), "RENAME USER", wrong_users.c_ptr_safe());


### PR DESCRIPTION
The acl_users Prealloced_array is used widely, this commit does not
replace it, rather this commit creates a table of usernames to lists
of matching ACL_USER objects so that the find_mpvio_user and
find_acl_user functions can return more quickly when there are many
tens of thousands of users.

To test the setup, a script was created which creates many users:

https://github.com/ericherman/code-snips/blob/master/shell/create-many-mysql-users

For this testing, 32768 user names were created, each user has six
hosts.

While there is a small amount of jitter, the following was typical
for the "before" case:

$ time { for i in {0..10000}; do \
  /home/eric/builds/mysql-8.0/bin/mysql --port=13306 \
  --ssl-mode=DISABLED --host=127.0.0.1 --user=user0032768 -pnone \
  -e "SELECT 1;" >/dev/null 2>&1 || echo "DARN $?"; done; }

real	0m40.236s
user	0m25.599s
sys	0m6.986s

With the patch, the following was typical of the "after" case:
$ time { for i in {0..10000}; do \
  /home/eric/builds/mysql-8.0/bin/mysql --port=23306 \
  --ssl-mode=DISABLED --host=127.0.0.1 --user=user0032768 -pnone \
  -e "SELECT 1;" >/dev/null 2>&1 || echo "DARN $?"; done; }

real	0m33.984s
user	0m22.060s
sys	0m9.205s

Examining with "perf" shows us where time is spent originally:

perf record -F 20000 -a \
 -p $(cat /data/mysql-8.0-data/mysqld.pid) & sleep 0.3; \
  /home/eric/builds/mysql-8.0/bin/mysql --user=root \
 --host=127.0.0.1 --port=13306 --ssl-mode=DISABLED <<<"SELECT 1"; \
 killall perf; perf report -i ./perf.data

 # Overhead  Command  Shared Object       Symbol
    44.63%  mysqld   libc-2.26.so        [.] __strcmp_sse2_unaligned
     3.48%  mysqld   mysqld              [.] setup_fields
     2.05%  mysqld   mysqld              [.] vio_io_wait
     1.90%  mysqld   [vdso]              [.] 0x0000000000000c1e
     1.88%  mysqld   mysqld              [.] find_mpvio_user
     1.87%  mysqld   libc-2.26.so        [.] __tzstring
     1.85%  mysqld   mysqld              [.] alloc_and_copy_thd_dynamic_variables
     1.82%  mysqld   mysqld              [.] pfs_get_thread_statement_locker_v1
     1.79%  mysqld   mysqld              [.] dd::cache::Object_registry::Object_registry
     1.79%  mysqld   mysqld              [.] Protocol_classic::parse_packet
     1.77%  mysqld   mysqld              [.] thd_increment_bytes_received
     1.77%  mysqld   mysqld              [.] TaoCrypt::SHA256::Transform
     1.72%  mysqld   mysqld              [.] Item_int::init
     1.71%  mysqld   mysqld              [.] dispatch_command

With the change we see different results:

perf record -F 20000 -a \
 -p $(cat /data/mysql-8.0-acl_user-data/mysqld.pid) & sleep 0.3; \
 /home/eric/builds/mysql-8.0/bin/mysql --user=root \
 --host=127.0.0.1 --port=23306 --ssl-mode=DISABLED  <<<"SELECT 1"; \
 killall perf; perf report -i ./perf.data

 # Overhead  Command  Shared Object       Symbol
     9.91%  mysqld   libc-2.26.so        [.] _int_malloc
     7.19%  mysqld   mysqld              [.] thd_increment_bytes_received
     7.13%  mysqld   mysqld              [.] net_write_command
     6.93%  mysqld   mysqld              [.] get_thread_attributes
     6.73%  mysqld   mysqld              [.] Protocol_classic::net_store_data
     6.68%  mysqld   mysqld              [.] Item::charset_for_protocol
     6.57%  mysqld   mysqld              [.] pfs_unlock_rwlock_v1
     6.37%  mysqld   mysqld              [.] plugin_foreach_with_mask
     6.34%  mysqld   mysqld              [.] MYSQLparse
     6.34%  mysqld   mysqld              [.] lex_start
     6.32%  mysqld   mysqld              [.] TaoCrypt::Transform256
     6.10%  mysqld   mysqld              [.] pfs_memory_free_v1
     5.58%  mysqld   mysqld              [.] my_hash_sort_uca_900_tmpl<Mb_wc_utf8mb4, 1>
     4.53%  mysqld   mysqld              [.] THD::THD

From the differences in perf output, we see that the changed code is
no longer spending an over-whelming amount of its time comparing
strings or in find_mpvio_user.

I would like to thank Mattias Jonsson, as he was a great help in
this work: in an earlier version, he figured out my bug where the
map would have no-longer-valid pointers (because of the sorting of
acl_users). Also, he found my NULL vs. empty-string bug.  I would
like to thank Gonzalo Diethelm for being willing and able to act as
a sounding board during my discussions, and helping me write more
idiomatic C++ code and giving me some good debugging ideas.  I would
like to thank Dmitry Lenev for helping me think-through the
ACL_compare logic, Philippe Bruhat for patiently debugging with me,
Kendrick Shaw for helping me with allocators, and Daniël van Eeden
for pointing out the issue in the first place and encouraging me to
hack on it.