### PR TITLE
NDB: Disallow connect string to start with '/'

### DIFF
--- a/storage/ndb/src/mgmsrv/main.cpp
+++ b/storage/ndb/src/mgmsrv/main.cpp
@@ -227,6 +227,15 @@ static int mgmd_main(int argc, char** argv)
     mgmd_exit(1);
   }
 
+  if (opt_ndb_connectstring)
+  {
+    if (strncmp(opt_ndb_connectstring, "/", 1) == 0)
+    {
+      fprintf(stderr, "ERROR: ndb-connect-string starts with '/', use -f to specify config file instead of -c\n");
+      mgmd_exit(1);
+    }
+  }
+
   if (opt_nowait_nodes)
   {
     int res = parse_mask(opt_nowait_nodes, opts.nowait_nodes);


### PR DESCRIPTION
One can easily use -c to specify the config file by mistake.
-c is connect-string. -f is config file.

Confusing these is bad enough, but ndb_mgmd often accepts a
bogus value for the -c option (e.g -c /etc/ndb/config.ini)

This commit only works if the -c option gets a full path, it won't work for relative paths. Feel free to throw my commit away and implement a different fix for this issue.