### PR TITLE
Bug #81814: InnoDB adaptive hash index uses a bad partitioning algorithm

### DIFF
--- a/storage/innobase/btr/btr0sea.cc
+++ b/storage/innobase/btr/btr0sea.cc
@@ -1092,10 +1092,7 @@ retry:
   Determine the ahi_slot based on the block contents. */
 
   const space_index_t index_id = btr_page_get_index_id(block->frame);
-  const ulint ahi_slot =
-      ut_fold_ulint_pair(static_cast<ulint>(index_id),
-                         static_cast<ulint>(block->page.id.space())) %
-      btr_ahi_parts;
+  const ulint ahi_slot = static_cast<ulint>(index_id) % btr_ahi_parts;
   latch = btr_search_latches[ahi_slot];
 
   ut_ad(!btr_search_own_any(RW_LOCK_S));

--- a/storage/innobase/include/btr0sea.ic
+++ b/storage/innobase/include/btr0sea.ic
@@ -182,10 +182,7 @@ UNIV_INLINE
 rw_lock_t *btr_get_search_latch(const dict_index_t *index) {
   ut_ad(index != NULL);
 
-  ulint ifold = ut_fold_ulint_pair(static_cast<ulint>(index->id),
-                                   static_cast<ulint>(index->space));
-
-  return (btr_search_latches[ifold % btr_ahi_parts]);
+  return (btr_search_latches[static_cast<ulint>(index->id) % btr_ahi_parts]);
 }
 
 /** Get the hash-table based on index attributes.
@@ -196,8 +193,6 @@ UNIV_INLINE
 hash_table_t *btr_get_search_table(const dict_index_t *index) {
   ut_ad(index != NULL);
 
-  ulint ifold = ut_fold_ulint_pair(static_cast<ulint>(index->id),
-                                   static_cast<ulint>(index->space));
-
-  return (btr_search_sys->hash_tables[ifold % btr_ahi_parts]);
+  return (btr_search_sys->hash_tables[static_cast<ulint>(index->id) %
+                                      btr_ahi_parts]);
 }


### PR DESCRIPTION
This is a 8.0.11-based version of a previously contributed patch.