### PR TITLE
mysqldumpslow: fix detection of slow log path

### DIFF
--- a/scripts/mysqldumpslow.sh
+++ b/scripts/mysqldumpslow.sh
@@ -63,7 +63,7 @@ unless (@ARGV) {
     warn "basedir=$basedir\n" if $opt{v};
 
     my $datadir = ($defaults =~ m/--datadir=(.*)/)[0];
-    my $slowlog = ($defaults =~ m/--slow-query-log-file=(.*)/)[0];
+    my $slowlog = ($defaults =~ m/--slow_query_log_file=(.*)/)[0];
     if (!$datadir or $opt{i}) {
 	# determine the datadir from the instances section of /etc/my.cnf, if any
 	my $instances  = `my_print_defaults instances`;


### PR DESCRIPTION
Without an argument mysqldumpslow tries to derive the path of the
slow log from my_print_defaults, but that lists slow log like

  $ my_print_defaults mysqld
  ...
  --slow_query_log_file=/var/log/mysql/mysql-slow.log

Fix the script to search with underscores instead of a hyphen.
That way mysqldumpslow is most configurations will work without extra
arguments.

Fixes: https://bugs.launchpad.net/ubuntu/+source/mysql-5.7/+bug/819535

Signed-off-by: Christian Ehrhardt <christian.ehrhardt@canonical.com>