### PR TITLE
 Configurable compression level for archive storage engine

### DIFF
--- a/storage/archive/azio.cc
+++ b/storage/archive/azio.cc
@@ -64,7 +64,7 @@ extern "C" PSI_file_key arch_key_file_data;
 */
 int az_open(azio_stream *s, const char *path, int Flags, File fd) {
   int err;
-  int level = Z_DEFAULT_COMPRESSION; /* compression level */
+  int level = srv_compression_level - 1; /* compression level */
   int strategy = Z_DEFAULT_STRATEGY; /* compression strategy */
 
   memset(s, 0, sizeof(azio_stream));

--- a/storage/archive/azlib.h
+++ b/storage/archive/azlib.h
@@ -200,6 +200,9 @@ extern "C" {
 #define AZ_BUFSIZE_READ 32768
 #define AZ_BUFSIZE_WRITE 16384
 
+/* Required system variables */
+extern int srv_compression_level;
+
 typedef struct azio_stream {
   z_stream stream;
   int z_err;                     /* error code for last stream operation */

--- a/storage/archive/ha_archive.cc
+++ b/storage/archive/ha_archive.cc
@@ -211,6 +211,11 @@ static void init_archive_psi_keys(void) {
 static const char *ha_archive_exts[] = {ARZ, NullS};
 
 /*
+  Archive system variable values
+*/
+static int srv_compression_level = -1;
+
+/*
   Initialize the archive handler.
 
   SYNOPSIS
@@ -1589,6 +1594,38 @@ bool ha_archive::check_if_incompatible_data(HA_CREATE_INFO *info,
   return COMPATIBLE_DATA_YES;
 }
 
+/*
+  Update the archive_compression_level system variable
+*/
+static void archive_compression_level_update(
+  THD *thd,
+  SYS_VAR *var,
+  void* var_ptr,
+  const void *save)
+{
+  int in_val = *static_cast<const int *>(save);
+  srv_compression_level = in_val;
+}
+
+/*
+  Compression level used by Zlib
+*/
+static MYSQL_SYSVAR_INT(compression_level, srv_compression_level,
+  PLUGIN_VAR_RQCMDARG,
+  "Compression level used by Zlib for archive files."
+  " -1 is Zlib's defualt. Levels 0-9 go in order of increasing compression"
+  " where 0 is no compression at all.",
+  NULL, archive_compression_level_update, -1, -1,
+  9, 0);
+
+/*
+  System variables list
+*/
+static SYS_VAR *archive_system_variables[] = {
+  MYSQL_SYSVAR(compression_level),
+  NULL
+};
+
 struct st_mysql_storage_engine archive_storage_engine = {
     MYSQL_HANDLERTON_INTERFACE_VERSION};
 
@@ -1604,7 +1641,7 @@ mysql_declare_plugin(archive){
     NULL,            /* Plugin Deinit */
     0x0300 /* 3.0 */,
     NULL, /* status variables                */
-    NULL, /* system variables                */
+    archive_system_variables, /* system variables                */
     NULL, /* config options                  */
     0,    /* flags                           */
 } mysql_declare_plugin_end;

--- a/storage/archive/ha_archive.cc
+++ b/storage/archive/ha_archive.cc
@@ -211,9 +211,9 @@ static void init_archive_psi_keys(void) {
 static const char *ha_archive_exts[] = {ARZ, NullS};
 
 /*
-  Archive system variable values
+  Archive system variables
 */
-static int srv_compression_level = -1;
+int srv_compression_level = 0;  // Zlib compression level
 
 /*
   Initialize the archive handler.
@@ -1608,15 +1608,16 @@ static void archive_compression_level_update(
 }
 
 /*
-  Compression level used by Zlib
+  Compression level used by Zlib. I have shifted Zlib's default levels
+  up by one because the settings table doesn't support signed integers.
 */
 static MYSQL_SYSVAR_INT(compression_level, srv_compression_level,
   PLUGIN_VAR_RQCMDARG,
   "Compression level used by Zlib for archive files."
-  " -1 is Zlib's defualt. Levels 0-9 go in order of increasing compression"
-  " where 0 is no compression at all.",
-  NULL, archive_compression_level_update, -1, -1,
-  9, 0);
+  " 0 is Zlib's defualt. Levels 1-10 go in order of increasing compression,"
+  " where 1 is no compression at all.",
+  NULL, archive_compression_level_update, 0, 0,
+  10, 0);
 
 /*
   System variables list
@@ -1641,7 +1642,7 @@ mysql_declare_plugin(archive){
     NULL,            /* Plugin Deinit */
     0x0300 /* 3.0 */,
     NULL, /* status variables                */
-    archive_system_variables, /* system variables                */
+    archive_system_variables, /* system variables */
     NULL, /* config options                  */
     0,    /* flags                           */
 } mysql_declare_plugin_end;


### PR DESCRIPTION
I have added a system variable that allows the user to configure the compression level used by the archive storage engine. This was listed as one of Brian's TODOs and I think it would make a nice addition to the engine. Find below a comparison of the ARZ file sizes for different values of 'archive_compression_level' generated by the windows 'dir' command:

```
05/08/2018  12:04         4,259,928 10_employees.ARZ     :: Compression level 10 (max)
05/08/2018  12:18         4,816,984 0_employees.ARZ      :: Zlib default compression
05/08/2018  12:12         9,076,827 1_employees.ARZ      :: No compression
```

The prefixed number is the compression level. I have shifted Zlib's default compression levels up by one because the variable list doesn't support signed integers. For example, the default compression level is now 0 instead of -1.

I intend on continuing to work on TODOs around the code if you like what I have done here. Constructive feedback is appreciated.

Thanks,
George