### PR TITLE
Update xcom_base.c

### DIFF
--- a/rapid/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/xcom_base.c
+++ b/rapid/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/xcom_base.c
@@ -3133,10 +3133,11 @@ static void	handle_ack_prepare(site_def const * site, pax_machine *p, pax_msg *m
 	    SYCEXP(m->synode))		;
 	if (m->from != VOID_NODE_NO && eq_ballot(p->proposer.bal, m->reply_to)) { /* answer to my prepare */
 		handle_simple_ack_prepare(site, p, m);
-		if (gt_ballot(m->proposal, p->proposer.msg->proposal)) { /* greater */
+		/* if (gt_ballot(m->proposal, p->proposer.msg->proposal)) {  greater */
+			assert(m);
 			replace_pax_msg(&p->proposer.msg, m);
 			assert(p->proposer.msg);
-		}
+		/* } */
 		if (gt_ballot(m->reply_to, p->proposer.sent_prop))
 			check_propose(site, p);
 	}


### PR DESCRIPTION
https://bugs.mysql.com/bug.php?id=92690

code : 

                if (gt_ballot(m->proposal, p->proposer.msg->proposal)) { /* greater */
			replace_pax_msg(&p->proposer.msg, m);
			assert(p->proposer.msg);
		}

When encountering such a scene:

Three nodes: n0, n1, n2, one transaction only node 0 and node 1 accpeted, node 2 initiated prepare_op to 0, 1.

 at this time, node1's handle_prepare_op copies the accpetor of the state machine  into the message reply to node 2 with ack_prepare_op, when node 2 accepts node 1 After the paxos msg, I think that a reasonable algorithm should look like this:
    gt_ballot(m->proposal, p->proposer.msg->proposal) == true
    Then :replace_pax_msg(&p->proposer.msg, m);

In fact not the case, due to m->proposal == p->proposer.msg->proposa;
so It will ignore the already accepted messages sent by node 1.

Eventually, node 0 has completed learn, and node 1 is not completed. In addition, node 2 also causes node1 to be replaced by empty message of node2 because of check_propose, and finally the node1 and node2 transactions are lost.