### PR TITLE
Bug#93240 wait_timeout error not clear and not sent to client.

### DIFF
--- a/include/mysql_com.h
+++ b/include/mysql_com.h
@@ -359,6 +359,13 @@ typedef struct st_net {
   */
   unsigned char *unused;
   unsigned int last_errno;
+  /**
+    1 - Error, but socket still usable
+    2 - Error, do not use the socket
+    3 - Not used, but will result in a recoverable error.
+    4 - Read error, OK to try write the error and then close the socket.
+    5 - Write error, OK to try read the error and then close the socket.
+  */
   unsigned char error; 
   my_bool unused4; /* Please remove with the next incompatible ABI change. */
   my_bool unused5; /* Please remove with the next incompatible ABI change. */

--- a/mysql-test/r/ssl.result
+++ b/mysql-test/r/ssl.result
@@ -2241,6 +2241,6 @@ Ssl_cipher	SSL_CIPHER
 SET @@SESSION.wait_timeout = 2;
 # Wait for ssl_con to be disconnected.
 # Check that ssl_con has been disconnected.
-# CR_SERVER_LOST, CR_SERVER_GONE_ERROR
+# CR_SERVER_LOST, CR_SERVER_GONE_ERROR, ER_NET_WAIT_ERROR
 SELECT 1;
 Got one of the listed errors

--- a/mysql-test/r/wait_timeout.result
+++ b/mysql-test/r/wait_timeout.result
@@ -9,7 +9,7 @@ SELECT 1;
 connection wait_con;
 connection default;
 SELECT 2;
-Got one of the listed errors
+ERROR 08S01: wait_timeout exceeded, too long idle time since last command
 --enable_reconnect;
 SELECT 3;
 3
@@ -24,7 +24,7 @@ SELECT 1;
 connection wait_con;
 connection con1;
 SELECT 2;
-Got one of the listed errors
+ERROR 08S01: wait_timeout exceeded, too long idle time since last command
 --enable_reconnect;
 SELECT 3;
 3
@@ -41,9 +41,25 @@ disconnection con1;
 SET @@SESSION.wait_timeout = 2;
 # Wait for con1 to be disconnected.
 # Check that con1 has been disconnected.
-# CR_SERVER_LOST, CR_SERVER_GONE_ERROR
 SELECT 1;
-Got one of the listed errors
+ERROR 08S01: wait_timeout exceeded, too long idle time since last command
+#
+# Test UNIX domain sockets timeout with reconnect.
+#
+# Open con1 and set a timeout.
+--enable_reconnect;
+SET @is_old_connection = 1;
+SELECT @is_old_connection;
+@is_old_connection
+1
+SET @@SESSION.wait_timeout = 2;
+# Wait for con1 to be disconnected.
+# Check that con1 has been reconnected.
+SELECT "Unix domain socket will hit wait_timeout with reconnect";
+ERROR 08S01: wait_timeout exceeded, too long idle time since last command
+SELECT @is_old_connection;
+@is_old_connection
+NULL
 #
 # Test TCP/IP sockets timeout.
 #
@@ -51,6 +67,24 @@ Got one of the listed errors
 SET @@SESSION.wait_timeout = 2;
 # Wait for con1 to be disconnected.
 # Check that con1 has been disconnected.
-# CR_SERVER_LOST, CR_SERVER_GONE_ERROR
 SELECT 1;
+ERROR 08S01: wait_timeout exceeded, too long idle time since last command
+SELECT "TCP/IP reconnect check";
 Got one of the listed errors
+#
+# Test TCP/IP sockets timeout with reconnect.
+#
+# Open con1 and set a timeout.
+--enable_reconnect;
+SET @@SESSION.wait_timeout = 2;
+SET @is_old_connection = 1;
+SELECT @is_old_connection;
+@is_old_connection
+1
+# Wait for con1 to be disconnected.
+# Check that con1 has been disconnected.
+SELECT "TCP/IP will hit wait_timeout with reconnect";
+ERROR 08S01: wait_timeout exceeded, too long idle time since last command
+SELECT @is_old_connection;
+@is_old_connection
+NULL

--- a/mysql-test/t/ssl.test
+++ b/mysql-test/t/ssl.test
@@ -52,8 +52,8 @@ let $wait_condition=
 
 --echo # Check that ssl_con has been disconnected.
 connection ssl_con;
---echo # CR_SERVER_LOST, CR_SERVER_GONE_ERROR
---error 2006,2013
+--echo # CR_SERVER_LOST, CR_SERVER_GONE_ERROR, ER_NET_WAIT_ERROR
+--error 2006,2013,ER_NET_WAIT_ERROR
 SELECT 1;
 
 connection default;

--- a/mysql-test/t/wait_timeout.test
+++ b/mysql-test/t/wait_timeout.test
@@ -66,8 +66,7 @@ let $wait_condition= SELECT COUNT(*)=1 FROM information_schema.processlist;
 connection default;
 # When the connection is closed in this way, the error code should
 # be consistent see Bug#2845 for an explanation
-# depending on platform/client, either errno 2006 or 2013 can occur below
---error 2006,2013
+--error ER_NET_WAIT_ERROR
 SELECT 2;
 --echo --enable_reconnect;
 --enable_reconnect
@@ -123,8 +122,7 @@ disconnect wait_con;
 connection con1;
 # When the connection is closed in this way, the error code should
 # be consistent see Bug#2845 for an explanation
-# depending on platform/client, either errno 2006 or 2013 can occur below
---error 2006,2013
+--error ER_NET_WAIT_ERROR
 SELECT 2;
 --echo --enable_reconnect;
 --enable_reconnect
@@ -161,12 +159,44 @@ let $wait_condition=
 
 --echo # Check that con1 has been disconnected.
 connection con1;
---echo # CR_SERVER_LOST, CR_SERVER_GONE_ERROR
---error 2006,2013
+--error ER_NET_WAIT_ERROR
 SELECT 1;
 
 disconnect con1;
 connection default;
+
+--echo #
+--echo # Test UNIX domain sockets timeout with reconnect.
+--echo #
+
+--echo # Open con1 and set a timeout.
+connect(con1,localhost,root,,);
+
+--echo --enable_reconnect;
+--enable_reconnect
+SET @is_old_connection = 1;
+SELECT @is_old_connection;
+
+LET $ID= `SELECT connection_id()`;
+SET @@SESSION.wait_timeout = 2;
+
+--echo # Wait for con1 to be disconnected.
+connection default;
+let $wait_condition=
+  SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.PROCESSLIST
+  WHERE ID = $ID;
+--source include/wait_condition.inc
+
+--echo # Check that con1 has been reconnected.
+connection con1;
+--error ER_NET_WAIT_ERROR
+SELECT "Unix domain socket will hit wait_timeout with reconnect";
+
+SELECT @is_old_connection;
+
+disconnect con1;
+connection default;
+
 
 --echo #
 --echo # Test TCP/IP sockets timeout.
@@ -187,9 +217,47 @@ let $wait_condition=
 
 --echo # Check that con1 has been disconnected.
 connection con1;
---echo # CR_SERVER_LOST, CR_SERVER_GONE_ERROR
---error 2006,2013
+--error ER_NET_WAIT_ERROR
 SELECT 1;
+
+# depending on platform/client, either errno 2006 or 2013 can occur below
+--error 2006,2013
+SELECT "TCP/IP reconnect check";
+
+disconnect con1;
+connection default;
+
+
+
+--echo #
+--echo # Test TCP/IP sockets timeout with reconnect.
+--echo #
+
+--echo # Open con1 and set a timeout.
+connect(con1,127.0.0.1,root,,);
+
+--echo --enable_reconnect;
+--enable_reconnect
+LET $ID= `SELECT connection_id()`;
+SET @@SESSION.wait_timeout = 2;
+SET @is_old_connection = 1;
+SELECT @is_old_connection;
+
+--echo # Wait for con1 to be disconnected.
+connection default;
+let $wait_condition=
+  SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.PROCESSLIST
+  WHERE ID = $ID;
+--source include/wait_condition.inc
+
+--echo # Check that con1 has been disconnected.
+connection con1;
+# TODO: Investigate why no error with updated client and old server?
+# Expected: https://dev.mysql.com/doc/refman/5.7/en/c-api-auto-reconnect.html
+--error ER_NET_WAIT_ERROR
+SELECT "TCP/IP will hit wait_timeout with reconnect";
+
+SELECT @is_old_connection;
 
 disconnect con1;
 connection default;

--- a/sql/share/errmsg-utf8.txt
+++ b/sql/share/errmsg-utf8.txt
@@ -7774,6 +7774,9 @@ ER_XA_REPLICATION_FILTERS
 ER_CANT_OPEN_ERROR_LOG
   eng "Could not open file '%s' for error logging%s%s"
 
+ER_NET_WAIT_ERROR 08S01
+  eng "wait_timeout exceeded, too long idle time since last command"
+
 #
 #  End of 5.7 error messages.
 #


### PR DESCRIPTION
The log entry for a client aborted due to wait_timeout exceeded
is not clearly stated. So this creates a specific error for it.

Also from the client perspective it only sees that the server closed
the connection, not why, so the error will be sent back to
the client before closing the connection.

Notes:
This patch does not work with YaSSL, since it does not clear its
errors in report_errors() in debug build, and ERR_clear_error is
not supported in release build. This results in write will fail
on the previous non-cleared read error (from wait_timeout).

Also debug build non-patched clients will fail an assertion,
due to it only expects async returned result/error in case of COM_QUIT.

And adding protection in net_read_packet like:
  /* Socket can't be used for reading */
  if (net->error == 2 || net->error == 4)
    return packet_error;
will make some rpl tests fail.