### PR TITLE
THR_LOCK_open reduce usage

### DIFF
--- a/include/my_sys.h
+++ b/include/my_sys.h
@@ -671,12 +671,6 @@ extern char *my_filename(File fd);
 extern MY_MODE get_file_perm(ulong perm_flags);
 extern bool my_chmod(const char *filename, ulong perm_flags, myf my_flags);
 
-#ifdef EXTRA_DEBUG
-void my_print_open_files(void);
-#else
-#define my_print_open_files()
-#endif
-
 extern bool init_tmpdir(MY_TMPDIR *tmpdir, const char *pathlist);
 extern char *my_tmpdir(MY_TMPDIR *tmpdir);
 extern void free_tmpdir(MY_TMPDIR *tmpdir);

--- a/mysys/mf_tempfile.cc
+++ b/mysys/mf_tempfile.cc
@@ -147,9 +147,7 @@ File create_temp_file(char *to, const char *dir, const char *prefix,
   }
 #endif
   if (file >= 0) {
-    mysql_mutex_lock(&THR_LOCK_open);
     my_tmp_file_created++;
-    mysql_mutex_unlock(&THR_LOCK_open);
   }
   DBUG_RETURN(file);
 }

--- a/mysys/my_file.cc
+++ b/mysys/my_file.cc
@@ -147,7 +147,7 @@ uint my_set_max_open_files(uint files) {
 void my_free_open_file_info() {
   DBUG_ENTER("my_free_file_info");
   if (my_file_info != my_file_info_default) {
-    /* Copy data back for my_print_open_files */
+    /* Copy data back for my_end */
     memcpy((char *)my_file_info_default, my_file_info,
            sizeof(*my_file_info_default) * MY_NFILE);
     my_free(my_file_info);

--- a/mysys/my_open.cc
+++ b/mysys/my_open.cc
@@ -182,19 +182,3 @@ File my_register_filename(File fd, const char *FileName,
   }
   DBUG_RETURN(-1);
 }
-
-#ifdef EXTRA_DEBUG
-
-void my_print_open_files(void) {
-  if (my_file_opened | my_stream_opened) {
-    uint i;
-    for (i = 0; i < my_file_limit; i++) {
-      if (my_file_info[i].type != UNOPEN) {
-        my_message_local(INFORMATION_LEVEL, EE_FILE_NOT_CLOSED,
-                         my_file_info[i].name, i);
-      }
-    }
-  }
-}
-
-#endif


### PR DESCRIPTION
By considering `my_*_opened` as statistical counters and file descriptors as unique with a little restructuring we can eliminate lots of THR_LOCK_open usage.