### PR TITLE
Call processor in visit_item for FUNC_ITEM

### DIFF
--- a/include/mysql/service_parser.h
+++ b/include/mysql/service_parser.h
@@ -174,6 +174,17 @@ extern struct mysql_parser_service_st {
 
 
   /**
+    Returns the MYSQL_ITEM type as integer
+
+    @param item The item to get the type of.
+
+    @return The type as integer
+
+  */
+  int (*mysql_item_type)(MYSQL_ITEM item);
+
+
+  /**
     Frees a string buffer allocated by the server.
 
     @param The string whose buffer will be freed.
@@ -244,6 +255,9 @@ extern struct mysql_parser_service_st {
 #define mysql_parser_item_string(item) \
   mysql_parser_service->mysql_item_string(item)
 
+#define mysql_parser_item_type(item) \
+  mysql_parser_service->mysql_item_type(item)
+
 #define mysql_parser_free_string(string) \
   mysql_parser_service->mysql_free_string(string)
 
@@ -273,6 +287,7 @@ int mysql_parser_extract_prepared_params(MYSQL_THD thd, int *positions);
 int mysql_parser_visit_tree(MYSQL_THD thd, parse_node_visit_function processor,
                             unsigned char* arg);
 MYSQL_LEX_STRING mysql_parser_item_string(MYSQL_ITEM item);
+int mysql_parser_item_type(MYSQL_ITEM item);
 void mysql_parser_free_string(MYSQL_LEX_STRING string);
 MYSQL_LEX_STRING mysql_parser_get_query(MYSQL_THD thd);
 MYSQL_LEX_STRING mysql_parser_get_normalized_query(MYSQL_THD thd);

--- a/include/mysql/services.h.pp
+++ b/include/mysql/services.h.pp
@@ -393,6 +393,7 @@ extern struct mysql_parser_service_st {
   int (*mysql_visit_tree)(void* thd, parse_node_visit_function processor,
                           unsigned char* arg);
   MYSQL_LEX_STRING (*mysql_item_string)(MYSQL_ITEM item);
+  int (*mysql_item_type)(MYSQL_ITEM item);
   void (*mysql_free_string)(MYSQL_LEX_STRING string);
   MYSQL_LEX_STRING (*mysql_get_query)(void* thd);
   MYSQL_LEX_STRING (*mysql_get_normalized_query)(void* thd);
@@ -416,6 +417,7 @@ int mysql_parser_extract_prepared_params(void* thd, int *positions);
 int mysql_parser_visit_tree(void* thd, parse_node_visit_function processor,
                             unsigned char* arg);
 MYSQL_LEX_STRING mysql_parser_item_string(MYSQL_ITEM item);
+int mysql_parser_item_type(MYSQL_ITEM item);
 void mysql_parser_free_string(MYSQL_LEX_STRING string);
 MYSQL_LEX_STRING mysql_parser_get_query(void* thd);
 MYSQL_LEX_STRING mysql_parser_get_normalized_query(void* thd);
@@ -494,13 +496,13 @@ extern struct mysql_keyring_service_st
   int (*my_key_store_func)(const char *, const char *, const char *,
                            const void *, size_t);
   int (*my_key_fetch_func)(const char *, char **, const char *, void **,
-                               size_t *);
+                           size_t *);
   int (*my_key_remove_func)(const char *, const char *);
   int (*my_key_generate_func)(const char *, const char *, const char *,
-                                  size_t);
+                              size_t);
 } *mysql_keyring_service;
 int my_key_store(const char *, const char *, const char *, const void *, size_t);
 int my_key_fetch(const char *, char **, const char *, void **,
-                     size_t *);
+                 size_t *);
 int my_key_remove(const char *, const char *);
 int my_key_generate(const char *, const char *, const char *, size_t);

--- a/sql/parser_service.cc
+++ b/sql/parser_service.cc
@@ -363,6 +363,11 @@ MYSQL_LEX_STRING mysql_parser_item_string(MYSQL_ITEM item)
   return res;
 }
 
+extern "C"
+int mysql_parser_item_type(MYSQL_ITEM item)
+{
+  return item->type();
+}
 
 extern "C"
 void mysql_parser_free_string(MYSQL_LEX_STRING string)

--- a/sql/parser_service.cc
+++ b/sql/parser_service.cc
@@ -70,6 +70,7 @@ protected:
     case Item::NULL_ITEM:
     case Item::VARBIN_ITEM:
     case Item::CACHE_ITEM:
+    case Item::FUNC_ITEM:
       return m_processor(item, m_arg);
     default:
       break;

--- a/sql/sql_plugin_services.h
+++ b/sql/sql_plugin_services.h
@@ -121,6 +121,7 @@ static struct mysql_parser_service_st parser_handler=
   mysql_parser_extract_prepared_params,
   mysql_parser_visit_tree,
   mysql_parser_item_string,
+  mysql_parser_item_type,
   mysql_parser_free_string,
   mysql_parser_get_query,
   mysql_parser_get_normalized_query


### PR DESCRIPTION
The use case:
Be able to use a post-parse plugin that acts on specific functions being called.

This is done by just adding `FUNC_ITEM` to the list.
However multiple comments seem to indicate that visit function is only called for literals.

The solutions I see are:

1. Splitting this into two processor functions, one for literals and one for functions. However `parse_node_visit_function` etc. have generic names, so to make this clean these then have to be renamed to something like `pare_node_visit_literal_function` etc.
2. Keep this in one processor, but allow one to get the type of the item, this allows one to filter out `FUNC_ITEM` and any other item when needed. That's what is in this pull request.

Please let me know if you think this is a good solution or if there is a better or cleaner solution. 