### PR TITLE
Fix startup error on innodb_dedicated_server=ON.

### DIFF
--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -4013,7 +4013,7 @@ static int innodb_log_file_size_init() {
             var_name_log_files,
             static_cast<unsigned int>(strlen(var_name_log_files)), &source)) {
       if (source == COMPILED) {
-        if (auto_buf_pool_size_in_gb < 1.0) {
+        if (auto_buf_pool_size_in_gb < 1.5) {
           ;
         } else if (auto_buf_pool_size_in_gb < 8.0) {
           srv_n_log_files = static_cast<ulong>(round(auto_buf_pool_size_in_gb));


### PR DESCRIPTION
When innodb_dedicated_server is ON and 2GiB <= server's physical memory < 3GiB,
mysql-server will be shutdown like following:
```
[ERROR] [MY-012961] [InnoDB] Only one log file found
[ERROR] [MY-012930] [InnoDB] Plugin initialization aborted with error not found.
[ERROR] [MY-010334] [Server] Failed to initialize DD Storage Engine
[ERROR] [MY-010020] [Server] Data Dictionary initialization failed.
[ERROR] [MY-010119] [Server] Aborting
```
Because innodb_log_files_in_group becomes 1 in this case.