### PR TITLE
fixed broken GCS error message

### DIFF
--- a/plugin/group_replication/libmysqlgcs/src/bindings/xcom/gcs_xcom_utils.cc
+++ b/plugin/group_replication/libmysqlgcs/src/bindings/xcom/gcs_xcom_utils.cc
@@ -335,8 +335,7 @@ bool is_parameters_syntax_correct(
     if (get_ip_and_port(const_cast<char *>(local_node_str->c_str()), host_str,
                         &local_node_port)) {
       MYSQL_GCS_LOG_ERROR("Invalid hostname or IP address ("
-                          << *local_node_str->c_str()
-                          << ") assigned to the parameter "
+                          << *local_node_str << ") assigned to the parameter "
                           << "local_node!");
       error = GCS_NOK;
       goto end;


### PR DESCRIPTION
Fixed broken error message of MySQL Group Replication.

When empty `group_replication_local_address` specified, the error message is truncated like below.
```
[GCS] Invalid hostname or IP address (
```
Or with wrong `group_replication_local_address` like `172.17.220.AAA`, it shows only the first char of specified value.
```
[GCS] Invalid hostname or IP address (1) assigned to the parameter local_node!
```

This is expected message.
```
[GCS] Invalid hostname or IP address (172.17.220.AAA:1111) assigned to the parameter local_node!
```