### PR TITLE
Shorten LOG table MDL duration

### DIFF
--- a/mysql-test/r/feature_shorten_log_table_mdl_scope.result
+++ b/mysql-test/r/feature_shorten_log_table_mdl_scope.result
@@ -1,0 +1,8 @@
+create user 'u0'@'%';
+grant all privileges on *.* to 'u0'@'%';
+begin;
+select * from mysql.slow_log;
+start_time	user_host	query_time	lock_time	rows_sent	rows_examined	db	last_insert_id	insert_id	server_id	sql_text	thread_id
+truncate table mysql.slow_log;
+commit;
+drop user 'u0'@'%';

--- a/mysql-test/t/feature_shorten_log_table_mdl_scope.test
+++ b/mysql-test/t/feature_shorten_log_table_mdl_scope.test
@@ -1,0 +1,28 @@
+--source include/count_sessions.inc
+
+connection default;
+
+create user 'u0'@'%';
+grant all privileges on *.* to 'u0'@'%';
+
+connect(con_u0, localhost, u0,,);
+connect(con_root,localhost, root,,);
+
+connection con_root;
+begin;
+select * from mysql.slow_log;
+
+
+connection con_u0;
+truncate table mysql.slow_log;
+
+
+connection con_root;
+commit;
+
+
+connection default;
+drop user 'u0'@'%';
+
+disconnect con_u0;
+disconnect con_root;

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -5816,8 +5816,15 @@ TABLE_LIST *SELECT_LEX::add_table_to_list(
 
   // Pure table aliases do not need to be locked:
   if (!(table_options & TL_OPTION_ALIAS)) {
+    enum_mdl_duration mdl_duration;
+    /* Shorten SLOW_LOG/GENERAL_LOG table MDL to STATEMENT */
+    if (query_logger.check_if_log_table(ptr, false) == QUERY_LOG_NONE)
+      mdl_duration = MDL_TRANSACTION;
+    else
+      mdl_duration = MDL_STATEMENT;
+
     MDL_REQUEST_INIT(&ptr->mdl_request, MDL_key::TABLE, ptr->db,
-                     ptr->table_name, mdl_type, MDL_TRANSACTION);
+                     ptr->table_name, mdl_type, mdl_duration);
   }
   if (table_name->is_derived_table()) {
     ptr->derived_key_list.empty();


### PR DESCRIPTION
Log table like slow_log/general_log didn't generate binary log, the MDL scope hold by statement on Log table can be shorten to  MDL_STATEMENT from MDL_TRANSACTION, it can decrease the possibility of MDL blocking when truncate these tables.