### PR TITLE
Fixed a mrec_buf_t[] index bug in row_merge_blocks().

### DIFF
--- a/storage/innobase/row/row0merge.cc
+++ b/storage/innobase/row/row0merge.cc
@@ -2480,7 +2480,7 @@ static MY_ATTRIBUTE((warn_unused_result)) dberr_t
 
   b0 = row_merge_read_rec(&block[0], &buf[0], b0, dup->index, file->fd, foffs0,
                           &mrec0, offsets0);
-  b1 = row_merge_read_rec(&block[srv_sort_buf_size], &buf[srv_sort_buf_size],
+  b1 = row_merge_read_rec(&block[srv_sort_buf_size], &buf[1],
                           b1, dup->index, file->fd, foffs1, &mrec1, offsets1);
   if (UNIV_UNLIKELY(!b0 && mrec0) || UNIV_UNLIKELY(!b1 && mrec1)) {
     goto corrupt;


### PR DESCRIPTION
typedef byte        mrec_buf_t[UNIV_PAGE_SIZE_MAX];
sizeof(mrec_buf_t) = sizeof_of(byte)* UNIV_PAGE_SIZE_MAX

buf is a mrec_buf_t[3] type, not a byte[] type.
The index of buf should be 1, not srv_sort_buf_size.