### PR TITLE
Fixed a mrec_buf_t[] index bug in row_merge_blocks().

### DIFF
--- a/storage/innobase/row/row0merge.cc
+++ b/storage/innobase/row/row0merge.cc
@@ -2089,7 +2089,7 @@ corrupt:
 		file->fd, foffs0, &mrec0, offsets0);
 	b1 = row_merge_read_rec(
 		&block[srv_sort_buf_size],
-		&buf[srv_sort_buf_size], b1, dup->index,
+		&buf[1], b1, dup->index,
 		file->fd, foffs1, &mrec1, offsets1);
 	if (UNIV_UNLIKELY(!b0 && mrec0)
 	    || UNIV_UNLIKELY(!b1 && mrec1)) {

--- a/vio/viossl.c
+++ b/vio/viossl.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+/* Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -397,9 +397,6 @@ static int ssl_do(struct st_VioSSLFd *ptr, Vio *vio,
   DBUG_PRINT("info", ("ssl: 0x%lx timeout: %ld", (long) ssl, timeout));
   SSL_clear(ssl);
   SSL_set_fd(ssl, sd);
-#if !defined(HAVE_YASSL) && OPENSSL_VERSION_NUMBER > 0x00908000L
-  SSL_clear_options(ssl, SSL_OP_LEGACY_SERVER_CONNECT);
-#endif
 #if !defined(HAVE_YASSL) && defined(SSL_OP_NO_COMPRESSION)
   SSL_set_options(ssl, SSL_OP_NO_COMPRESSION); /* OpenSSL >= 1.0 only */
 #elif OPENSSL_VERSION_NUMBER >= 0x00908000L /* workaround for OpenSSL 0.9.8 */


### PR DESCRIPTION
typedef byte        mrec_buf_t[UNIV_PAGE_SIZE_MAX];
sizeof(mrec_buf_t) = sizeof_of(byte)* UNIV_PAGE_SIZE_MAX

buf is a mrec_buf_t[3] type, not a byte[] type.
The index of buf should be 1, not srv_sort_buf_size.