### PR TITLE
Add buildrequires openldap-devel

### DIFF
--- a/packaging/rpm-docker/mysql.spec.in
+++ b/packaging/rpm-docker/mysql.spec.in
@@ -62,6 +62,7 @@ BuildRequires:  ncurses-devel
 BuildRequires:  numactl-devel
 BuildRequires:  openssl-devel
 BuildRequires:  zlib-devel
+BuildRequires:  openldap-devel
 BuildRoot:      %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 
 # For rpm => 4.9 only: https://fedoraproject.org/wiki/Packaging:AutoProvidesAndRequiresFiltering


### PR DESCRIPTION
rpmbuild for mysql-community-minimal failed, since missing openldap-devel
this issue has been resolved for `packaging/rpm-oel/mysql.spec.in` at https://bugs.mysql.com/bug.php?id=88789