### PR TITLE
Include <stdexcept> in base64.h

### DIFF
--- a/router/src/http/src/base64.h
+++ b/router/src/http/src/base64.h
@@ -29,6 +29,7 @@
 
 #include <algorithm>  // min
 #include <array>
+#include <stdexcept>
 #include <string>
 #include <utility>  // index_sequence
 #include <vector>


### PR DESCRIPTION
for std::runtime_error.

This change fixes a build error with a future release of MSVC.