### PR TITLE
Include port number in client error message

### DIFF
--- a/libmysql/errmsg.cc
+++ b/libmysql/errmsg.cc
@@ -36,7 +36,7 @@ const char *client_errors[] = {
     "Unknown MySQL error",
     "Can't create UNIX socket (%d)",
     "Can't connect to local MySQL server through socket '%-.100s' (%d)",
-    "Can't connect to MySQL server on '%-.100s' (%d)",
+    "Can't connect to MySQL server on '%-.100s:%d' (%d)",
     "Can't create TCP/IP socket (%d)",
     "Unknown MySQL server host '%-.100s' (%d)",
     "MySQL server has gone away",

--- a/sql-common/client.cc
+++ b/sql-common/client.cc
@@ -6113,7 +6113,7 @@ static mysql_state_machine_status csm_begin_connect(mysql_async_connect *ctx) {
       DBUG_PRINT("error",
                  ("Got error %d on connect to '%s'", saved_error, host));
       set_mysql_extended_error(mysql, CR_CONN_HOST_ERROR, unknown_sqlstate,
-                               ER_CLIENT(CR_CONN_HOST_ERROR), host,
+                               ER_CLIENT(CR_CONN_HOST_ERROR), host, port,
                                saved_error);
       return STATE_MACHINE_FAILED;
     }


### PR DESCRIPTION
With an `~/.my.cnf` like this:
```
[client]
port=1234
```

Before:
```
$ mysql -h 127.0.0.1
ERROR 2003 (HY000): Can't connect to MySQL server on '127.0.0.1' (111)
```

After:
```
mysql -h 127.0.0.1
ERROR 2003 (HY000): Can't connect to MySQL server on '127.0.0.1:1234' (111)
```

This also works if `-P` is used to supply a port number.

This makes troubleshooting connection issues a tiny bit easier.