### PR TITLE
Set non-zero error code for compression failures

### DIFF
--- a/client/dump/compression_lz4_writer.cc
+++ b/client/dump/compression_lz4_writer.cc
@@ -38,7 +38,7 @@ void Compression_lz4_writer::prepare_buffer(size_t src_size) {
 void Compression_lz4_writer::process_buffer(size_t lz4_result) {
   if (LZ4F_isError(lz4_result)) {
     this->pass_message(Mysql::Tools::Base::Message_data(
-        0, "LZ4 compression failed", Mysql::Tools::Base::Message_type_error));
+        1, "LZ4 compression failed", Mysql::Tools::Base::Message_type_error));
   } else if (lz4_result > 0) {
     this->append_output(std::string(&m_buffer[0], lz4_result));
   }

--- a/client/dump/compression_zlib_writer.cc
+++ b/client/dump/compression_zlib_writer.cc
@@ -39,7 +39,7 @@ void Compression_zlib_writer::process_buffer(bool flush_stream) {
 
     if (res == Z_STREAM_ERROR) {
       this->pass_message(Mysql::Tools::Base::Message_data(
-          0, "zlib compression failed",
+          1, "zlib compression failed",
           Mysql::Tools::Base::Message_type_error));
     }
 
@@ -76,7 +76,7 @@ bool Compression_zlib_writer::init() {
   int ret = deflateInit(&m_compression_context, m_compression_level);
   if (ret != Z_OK) {
     this->pass_message(Mysql::Tools::Base::Message_data(
-        0, "zlib compression initialization failed",
+        1, "zlib compression initialization failed",
         Mysql::Tools::Base::Message_type_error));
     return true;
   }

--- a/client/dump/mysqldump_tool_chain_maker.cc
+++ b/client/dump/mysqldump_tool_chain_maker.cc
@@ -126,7 +126,7 @@ I_object_reader *Mysqldump_tool_chain_maker::create_chain(
         compression_writer_as_writer = compression_writer;
       } else {
         this->pass_message(Mysql::Tools::Base::Message_data(
-            0, "Unknown compression method: " + algorithm_name,
+            1, "Unknown compression method: " + algorithm_name,
             Mysql::Tools::Base::Message_type_error));
         return NULL;
       }

--- a/client/dump/program.cc
+++ b/client/dump/program.cc
@@ -72,6 +72,7 @@ void Program::error(const Mysql::Tools::Base::Message_data &message) {
   if (message.get_message_type() == Mysql::Tools::Base::Message_type_error) {
     std::cerr << "Dump process encountered error and will not continue."
               << std::endl;
+    assert((int)message.get_code() != 0);
     m_error_code.store((int)message.get_code());
   }
 }


### PR DESCRIPTION
When running `mysqlpump --output-compression foobar` it tries to use foobar as the compression method which will obviously not work.

```
mysqlpump: [ERROR] (0) Unknown compression method: foobar
Dump process encountered error and will not continue.
```
While it says it won't continue it actually does continue.

When the process ends the returncode is taken from the error. However as the error code is 0 the return code is also 0. The result is that the return code doesn't indicate failure.