### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/Docs/README.build
+++ b/Docs/README.build
@@ -95,3 +95,16 @@ You should *not* 'make install' googletest/googlemock on your system,
 the libraries must be built from source, with the unit tests.
 
 Note: You need to tell cmake where to find boost, see ../cmake/boost.cmake
+
+Installing and building via vcpkg
+=================================
+
+You can download and install libmysql using the vcpkg(https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    vcpkg install libmysql
+
+The libmysql port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please create an issue or pull request(https://github.com/Microsoft/vcpkg) on the vcpkg repository.


### PR DESCRIPTION
`Libmysql `is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `libmysql `and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `libmysql `, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows:  x64, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/libmysql/portfile.cmake). We try to keep the library maintained as close as possible to the original library.