### PR TITLE
support runtime LSE atomics detection for aarch64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -840,6 +840,15 @@ ELSE()
   OPTION(USE_LD_GOLD "Use GNU gold linker" OFF)
 ENDIF()
 
+#for aarch64 - allow dynamic use of LSE atomics
+IF(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+  MY_CHECK_CXX_COMPILER_FLAG( "-moutline-atomics" HAVE_OUTLINE_ATOMICS)
+  IF(HAVE_OUTLINE_ATOMICS)
+     STRING_APPEND(CMAKE_C_FLAGS   " -moutline-atomics")
+     STRING_APPEND(CMAKE_CXX_FLAGS " -moutline-atomics")
+  ENDIF()
+ENDIF()
+
 IF(LINUX)
   OPTION(LINK_RANDOMIZE "Randomize the order of all symbols in the binary" OFF)
   SET(LINK_RANDOMIZE_SEED "mysql"


### PR DESCRIPTION
Outline-atomics flag modifies builtin atomics to detect CPU support for
atomic instructions in runtime, thus getting benefits of using LSE
atomics without hurting compatibility.
This flag has no effect if compiling for aarch64 >=v8.1.

Due to the nature of exclusive accesses, which are used when LSE atomics are not available, the effect of LSE atomics is much stronger on large core counts. We've observed as far as 4x transactions per second on sysbench read_only by adding outline-atomics to 64-core aarch64 server (AWS g6.16xlarge).