### PR TITLE
Aarch64 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -866,6 +866,15 @@ ELSE()
   OPTION(USE_LD_GOLD "Use GNU gold linker" OFF)
 ENDIF()
 
+#for aarch64 - allow dynamic use of LSE atomics
+IF(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+  MY_CHECK_CXX_COMPILER_FLAG( "-moutline-atomics" HAVE_OUTLINE_ATOMICS)
+  IF(HAVE_OUTLINE_ATOMICS)
+     STRING_APPEND(CMAKE_C_FLAGS   " -moutline-atomics")
+     STRING_APPEND(CMAKE_CXX_FLAGS " -moutline-atomics")
+  ENDIF()
+ENDIF()
+
 IF(LINUX)
   OPTION(LINK_RANDOMIZE "Randomize the order of all symbols in the binary" OFF)
   SET(LINK_RANDOMIZE_SEED "mysql"

--- a/storage/innobase/include/ut0ut.h
+++ b/storage/innobase/include/ut0ut.h
@@ -115,6 +115,8 @@ to memory). */
 the YieldProcessor macro defined in WinNT.h. It is a CPU architecture-
 independent way by using YieldProcessor. */
 #define UT_RELAX_CPU() YieldProcessor()
+#elif defined(__aarch64__)
+#define UT_RELAX_CPU() __asm__ __volatile__("isb" ::: "memory")
 #else
 #define UT_RELAX_CPU() __asm__ __volatile__("" ::: "memory")
 #endif


### PR DESCRIPTION
After signing the OCA was sorted out, this branch fixes two items missing in aarch64:
* an implementation of UT_RELAX_CPU macro
* enabling runtime conditional LSE atomics support, using the -moutline-atomics gcc compiler flag