### PR TITLE
feature/flashback

### DIFF
--- a/client/client_priv.h
+++ b/client/client_priv.h
@@ -175,7 +175,8 @@ enum options_client {
   OPT_MYSQL_BINARY_AS_HEX,
   OPT_LOAD_DATA_LOCAL_DIR,
   /* Add new option above this */
-  OPT_MAX_CLIENT_OPTION
+  OPT_FLASHBACK_TABLES,
+  OPT_MAX_CLIENT_OPTION,
 };
 
 /**

--- a/libbinlogevents/include/rows_event.h
+++ b/libbinlogevents/include/rows_event.h
@@ -940,6 +940,7 @@ class Rows_event : public Binary_log_event {
   /** Post header content */
   Table_id m_table_id;
   uint16_t m_flags; /** Flags for row-level events */
+  unsigned long long m_flags_pos; /* The position of the m_flags */
 
   /* Body of the event */
   unsigned long m_width; /** The width of the columns bitmap */
@@ -949,6 +950,7 @@ class Rows_event : public Binary_log_event {
   std::vector<uint8_t> columns_before_image;
   std::vector<uint8_t> columns_after_image;
   std::vector<uint8_t> row;
+  unsigned long long m_rows_before_size; /* The length before row */
 
  public:
   class Extra_row_info {

--- a/libbinlogevents/src/rows_event.cpp
+++ b/libbinlogevents/src/rows_event.cpp
@@ -383,6 +383,7 @@ Rows_event::Rows_event(const char *buf, const Format_description_event *fde)
   } else {
     READER_TRY_SET(m_table_id, read_and_letoh<uint64_t>, 6);
   }
+  m_flags_pos = reader().position();
   READER_TRY_SET(m_flags, read_and_letoh<uint16_t>);
 
   if (post_header_len == ROWS_HEADER_LEN_V2) {
@@ -453,6 +454,7 @@ Rows_event::Rows_event(const char *buf, const Format_description_event *fde)
   } else
     columns_after_image = columns_before_image;
 
+  m_rows_before_size = reader().position();  // Get the size that before SET part
   data_size = READER_CALL(available_to_read);
   READER_TRY_CALL(assign, &row, data_size);
   // JAG: TODO: Investigate and comment here about the need of this extra byte

--- a/mysql-test/suite/binlog/r/flashback.result
+++ b/mysql-test/suite/binlog/r/flashback.result
@@ -1,0 +1,860 @@
+SET  binlog_row_image=full;
+# BINLOG_FORMAT = ROW
+# BINLOG_ROW_IMAGE = FULL
+#
+# Preparatory cleanup.
+#
+DROP TABLE IF EXISTS t1;
+#
+# We need a fixed timestamp to avoid varying results.
+#
+SET timestamp=1000000000;
+# < CASE 1 >
+# Delete all existing binary logs.
+#
+RESET MASTER;
+CREATE TABLE t1 (
+c01 tinyint,
+c02 smallint,
+c03 mediumint,
+c04 int,
+c05 bigint,
+c06 char(10),
+c07 varchar(20),
+c08 TEXT
+) ENGINE=InnoDB;
+# < CASE 1 >
+# Insert data to t1
+#
+INSERT INTO t1 VALUES(0,0,0,0,0,'','','');
+INSERT INTO t1 VALUES(1,2,3,4,5, "abc", "abcdefg", "abcedfghijklmnopqrstuvwxyz");
+INSERT INTO t1 VALUES(127, 32767, 8388607, 2147483647, 9223372036854775807, repeat('a', 10), repeat('a', 20), repeat('a', 255));
+# < CASE 1 >
+# Update t1
+#
+UPDATE t1 SET c01=100 WHERE c02=0 OR c03=3;
+# < CASE 1 >
+# Clear t1
+#
+DELETE FROM t1;
+FLUSH LOGS;
+# < CASE 1 >
+# Show mysqlbinlog result without -B
+#
+/*!50530 SET @@SESSION.PSEUDO_SLAVE_MODE=1*/;
+/*!50003 SET @OLD_COMPLETION_TYPE=@@COMPLETION_TYPE,COMPLETION_TYPE=0*/;
+DELIMITER /*!*/;
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Start: binlog v 4, server v #.##.## created 010909  9:46:40 at startup
+ROLLBACK/*!*/;
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Previous-GTIDs
+# [empty]
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Anonymous_GTID	last_committed=0	sequence_number=1	rbr_only=no	original_committed_timestamp=X	immediate_commit_timestamp=X	transaction_length=X
+# original_commit_timestamp=X (X-X-X X:X:X.X GMT)
+# immediate_commit_timestamp=X (X-X-X X:X:X.X GMT)
+/*!80001 SET @@session.original_commit_timestamp=X*//*!*/;
+/*!80014 SET @@session.original_server_version=X*//*!*/;
+/*!80014 SET @@session.immediate_server_version=X*//*!*/;
+SET @@SESSION.GTID_NEXT= 'ANONYMOUS'/*!*/;
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0	Xid = #
+use `test`/*!*/;
+SET TIMESTAMP=1000000000/*!*/;
+SET @@session.pseudo_thread_id=#/*!*/;
+SET @@session.foreign_key_checks=1, @@session.sql_auto_is_null=0, @@session.unique_checks=1, @@session.autocommit=1/*!*/;
+SET @@session.sql_mode=X/*!*/;
+SET @@session.auto_increment_increment=1, @@session.auto_increment_offset=1/*!*/;
+/*!\C utf8mb4 *//*!*/;
+SET @@session.character_set_client=X,@@session.collation_connection=X,@@session.collation_server=X/*!*/;
+SET @@session.lc_time_names=0/*!*/;
+SET @@session.collation_database=DEFAULT/*!*/;
+/*!80011 SET @@session.default_collation_for_utf8mb4=255*//*!*/;
+/*!80013 SET @@session.sql_require_primary_key=0*//*!*/;
+CREATE TABLE t1 (
+c01 tinyint,
+c02 smallint,
+c03 mediumint,
+c04 int,
+c05 bigint,
+c06 char(10),
+c07 varchar(20),
+c08 TEXT
+) ENGINE=InnoDB
+/*!*/;
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Anonymous_GTID	last_committed=1	sequence_number=2	rbr_only=yes	original_committed_timestamp=X	immediate_commit_timestamp=X	transaction_length=X
+/*!50718 SET TRANSACTION ISOLATION LEVEL READ COMMITTED*//*!*/;
+# original_commit_timestamp=X (X-X-X X:X:X.X GMT)
+# immediate_commit_timestamp=X (X-X-X X:X:X.X GMT)
+/*!80001 SET @@session.original_commit_timestamp=X*//*!*/;
+/*!80014 SET @@session.original_server_version=X*//*!*/;
+/*!80014 SET @@session.immediate_server_version=X*//*!*/;
+SET @@SESSION.GTID_NEXT= 'ANONYMOUS'/*!*/;
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
+SET TIMESTAMP=1000000000/*!*/;
+BEGIN
+/*!*/;
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Table_map: `test`.`t1` mapped to number #
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Write_rows: table id # flags: STMT_END_F
+### INSERT INTO `test`.`t1`
+### SET
+###   @1=0 /* TINYINT meta=0 nullable=1 is_null=0 */
+###   @2=0 /* SHORTINT meta=0 nullable=1 is_null=0 */
+###   @3=0 /* MEDIUMINT meta=0 nullable=1 is_null=0 */
+###   @4=0 /* INT meta=0 nullable=1 is_null=0 */
+###   @5=0 /* LONGINT meta=0 nullable=1 is_null=0 */
+###   @6='' /* STRING(40) meta=65064 nullable=1 is_null=0 */
+###   @7='' /* VARSTRING(80) meta=80 nullable=1 is_null=0 */
+###   @8='' /* BLOB/TEXT meta=2 nullable=1 is_null=0 */
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Xid = #
+COMMIT/*!*/;
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Anonymous_GTID	last_committed=2	sequence_number=3	rbr_only=yes	original_committed_timestamp=X	immediate_commit_timestamp=X	transaction_length=X
+/*!50718 SET TRANSACTION ISOLATION LEVEL READ COMMITTED*//*!*/;
+# original_commit_timestamp=X (X-X-X X:X:X.X GMT)
+# immediate_commit_timestamp=X (X-X-X X:X:X.X GMT)
+/*!80001 SET @@session.original_commit_timestamp=X*//*!*/;
+/*!80014 SET @@session.original_server_version=X*//*!*/;
+/*!80014 SET @@session.immediate_server_version=X*//*!*/;
+SET @@SESSION.GTID_NEXT= 'ANONYMOUS'/*!*/;
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
+SET TIMESTAMP=1000000000/*!*/;
+BEGIN
+/*!*/;
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Table_map: `test`.`t1` mapped to number #
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Write_rows: table id # flags: STMT_END_F
+### INSERT INTO `test`.`t1`
+### SET
+###   @1=1 /* TINYINT meta=0 nullable=1 is_null=0 */
+###   @2=2 /* SHORTINT meta=0 nullable=1 is_null=0 */
+###   @3=3 /* MEDIUMINT meta=0 nullable=1 is_null=0 */
+###   @4=4 /* INT meta=0 nullable=1 is_null=0 */
+###   @5=5 /* LONGINT meta=0 nullable=1 is_null=0 */
+###   @6='abc' /* STRING(40) meta=65064 nullable=1 is_null=0 */
+###   @7='abcdefg' /* VARSTRING(80) meta=80 nullable=1 is_null=0 */
+###   @8='abcedfghijklmnopqrstuvwxyz' /* BLOB/TEXT meta=2 nullable=1 is_null=0 */
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Xid = #
+COMMIT/*!*/;
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Anonymous_GTID	last_committed=3	sequence_number=4	rbr_only=yes	original_committed_timestamp=X	immediate_commit_timestamp=X	transaction_length=X
+/*!50718 SET TRANSACTION ISOLATION LEVEL READ COMMITTED*//*!*/;
+# original_commit_timestamp=X (X-X-X X:X:X.X GMT)
+# immediate_commit_timestamp=X (X-X-X X:X:X.X GMT)
+/*!80001 SET @@session.original_commit_timestamp=X*//*!*/;
+/*!80014 SET @@session.original_server_version=X*//*!*/;
+/*!80014 SET @@session.immediate_server_version=X*//*!*/;
+SET @@SESSION.GTID_NEXT= 'ANONYMOUS'/*!*/;
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
+SET TIMESTAMP=1000000000/*!*/;
+BEGIN
+/*!*/;
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Table_map: `test`.`t1` mapped to number #
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Write_rows: table id # flags: STMT_END_F
+### INSERT INTO `test`.`t1`
+### SET
+###   @1=127 /* TINYINT meta=0 nullable=1 is_null=0 */
+###   @2=32767 /* SHORTINT meta=0 nullable=1 is_null=0 */
+###   @3=8388607 /* MEDIUMINT meta=0 nullable=1 is_null=0 */
+###   @4=2147483647 /* INT meta=0 nullable=1 is_null=0 */
+###   @5=9223372036854775807 /* LONGINT meta=0 nullable=1 is_null=0 */
+###   @6='aaaaaaaaaa' /* STRING(40) meta=65064 nullable=1 is_null=0 */
+###   @7='aaaaaaaaaaaaaaaaaaaa' /* VARSTRING(80) meta=80 nullable=1 is_null=0 */
+###   @8='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' /* BLOB/TEXT meta=2 nullable=1 is_null=0 */
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Xid = #
+COMMIT/*!*/;
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Anonymous_GTID	last_committed=4	sequence_number=5	rbr_only=yes	original_committed_timestamp=X	immediate_commit_timestamp=X	transaction_length=X
+/*!50718 SET TRANSACTION ISOLATION LEVEL READ COMMITTED*//*!*/;
+# original_commit_timestamp=X (X-X-X X:X:X.X GMT)
+# immediate_commit_timestamp=X (X-X-X X:X:X.X GMT)
+/*!80001 SET @@session.original_commit_timestamp=X*//*!*/;
+/*!80014 SET @@session.original_server_version=X*//*!*/;
+/*!80014 SET @@session.immediate_server_version=X*//*!*/;
+SET @@SESSION.GTID_NEXT= 'ANONYMOUS'/*!*/;
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
+SET TIMESTAMP=1000000000/*!*/;
+BEGIN
+/*!*/;
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Table_map: `test`.`t1` mapped to number #
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Update_rows: table id # flags: STMT_END_F
+### UPDATE `test`.`t1`
+### WHERE
+###   @1=0 /* TINYINT meta=0 nullable=1 is_null=0 */
+###   @2=0 /* SHORTINT meta=0 nullable=1 is_null=0 */
+###   @3=0 /* MEDIUMINT meta=0 nullable=1 is_null=0 */
+###   @4=0 /* INT meta=0 nullable=1 is_null=0 */
+###   @5=0 /* LONGINT meta=0 nullable=1 is_null=0 */
+###   @6='' /* STRING(40) meta=65064 nullable=1 is_null=0 */
+###   @7='' /* VARSTRING(80) meta=80 nullable=1 is_null=0 */
+###   @8='' /* BLOB/TEXT meta=2 nullable=1 is_null=0 */
+### SET
+###   @1=100 /* TINYINT meta=0 nullable=1 is_null=0 */
+###   @2=0 /* SHORTINT meta=0 nullable=1 is_null=0 */
+###   @3=0 /* MEDIUMINT meta=0 nullable=1 is_null=0 */
+###   @4=0 /* INT meta=0 nullable=1 is_null=0 */
+###   @5=0 /* LONGINT meta=0 nullable=1 is_null=0 */
+###   @6='' /* STRING(40) meta=65064 nullable=1 is_null=0 */
+###   @7='' /* VARSTRING(80) meta=80 nullable=1 is_null=0 */
+###   @8='' /* BLOB/TEXT meta=2 nullable=1 is_null=0 */
+### UPDATE `test`.`t1`
+### WHERE
+###   @1=1 /* TINYINT meta=0 nullable=1 is_null=0 */
+###   @2=2 /* SHORTINT meta=0 nullable=1 is_null=0 */
+###   @3=3 /* MEDIUMINT meta=0 nullable=1 is_null=0 */
+###   @4=4 /* INT meta=0 nullable=1 is_null=0 */
+###   @5=5 /* LONGINT meta=0 nullable=1 is_null=0 */
+###   @6='abc' /* STRING(40) meta=65064 nullable=1 is_null=0 */
+###   @7='abcdefg' /* VARSTRING(80) meta=80 nullable=1 is_null=0 */
+###   @8='abcedfghijklmnopqrstuvwxyz' /* BLOB/TEXT meta=2 nullable=1 is_null=0 */
+### SET
+###   @1=100 /* TINYINT meta=0 nullable=1 is_null=0 */
+###   @2=2 /* SHORTINT meta=0 nullable=1 is_null=0 */
+###   @3=3 /* MEDIUMINT meta=0 nullable=1 is_null=0 */
+###   @4=4 /* INT meta=0 nullable=1 is_null=0 */
+###   @5=5 /* LONGINT meta=0 nullable=1 is_null=0 */
+###   @6='abc' /* STRING(40) meta=65064 nullable=1 is_null=0 */
+###   @7='abcdefg' /* VARSTRING(80) meta=80 nullable=1 is_null=0 */
+###   @8='abcedfghijklmnopqrstuvwxyz' /* BLOB/TEXT meta=2 nullable=1 is_null=0 */
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Xid = #
+COMMIT/*!*/;
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Anonymous_GTID	last_committed=5	sequence_number=6	rbr_only=yes	original_committed_timestamp=X	immediate_commit_timestamp=X	transaction_length=X
+/*!50718 SET TRANSACTION ISOLATION LEVEL READ COMMITTED*//*!*/;
+# original_commit_timestamp=X (X-X-X X:X:X.X GMT)
+# immediate_commit_timestamp=X (X-X-X X:X:X.X GMT)
+/*!80001 SET @@session.original_commit_timestamp=X*//*!*/;
+/*!80014 SET @@session.original_server_version=X*//*!*/;
+/*!80014 SET @@session.immediate_server_version=X*//*!*/;
+SET @@SESSION.GTID_NEXT= 'ANONYMOUS'/*!*/;
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
+SET TIMESTAMP=1000000000/*!*/;
+BEGIN
+/*!*/;
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Table_map: `test`.`t1` mapped to number #
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Delete_rows: table id # flags: STMT_END_F
+### DELETE FROM `test`.`t1`
+### WHERE
+###   @1=100 /* TINYINT meta=0 nullable=1 is_null=0 */
+###   @2=0 /* SHORTINT meta=0 nullable=1 is_null=0 */
+###   @3=0 /* MEDIUMINT meta=0 nullable=1 is_null=0 */
+###   @4=0 /* INT meta=0 nullable=1 is_null=0 */
+###   @5=0 /* LONGINT meta=0 nullable=1 is_null=0 */
+###   @6='' /* STRING(40) meta=65064 nullable=1 is_null=0 */
+###   @7='' /* VARSTRING(80) meta=80 nullable=1 is_null=0 */
+###   @8='' /* BLOB/TEXT meta=2 nullable=1 is_null=0 */
+### DELETE FROM `test`.`t1`
+### WHERE
+###   @1=100 /* TINYINT meta=0 nullable=1 is_null=0 */
+###   @2=2 /* SHORTINT meta=0 nullable=1 is_null=0 */
+###   @3=3 /* MEDIUMINT meta=0 nullable=1 is_null=0 */
+###   @4=4 /* INT meta=0 nullable=1 is_null=0 */
+###   @5=5 /* LONGINT meta=0 nullable=1 is_null=0 */
+###   @6='abc' /* STRING(40) meta=65064 nullable=1 is_null=0 */
+###   @7='abcdefg' /* VARSTRING(80) meta=80 nullable=1 is_null=0 */
+###   @8='abcedfghijklmnopqrstuvwxyz' /* BLOB/TEXT meta=2 nullable=1 is_null=0 */
+### DELETE FROM `test`.`t1`
+### WHERE
+###   @1=127 /* TINYINT meta=0 nullable=1 is_null=0 */
+###   @2=32767 /* SHORTINT meta=0 nullable=1 is_null=0 */
+###   @3=8388607 /* MEDIUMINT meta=0 nullable=1 is_null=0 */
+###   @4=2147483647 /* INT meta=0 nullable=1 is_null=0 */
+###   @5=9223372036854775807 /* LONGINT meta=0 nullable=1 is_null=0 */
+###   @6='aaaaaaaaaa' /* STRING(40) meta=65064 nullable=1 is_null=0 */
+###   @7='aaaaaaaaaaaaaaaaaaaa' /* VARSTRING(80) meta=80 nullable=1 is_null=0 */
+###   @8='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' /* BLOB/TEXT meta=2 nullable=1 is_null=0 */
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Xid = #
+COMMIT/*!*/;
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Rotate to binlog.000002  pos: 4
+SET @@SESSION.GTID_NEXT= 'AUTOMATIC' /* added by mysqlbinlog */ /*!*/;
+DELIMITER ;
+# End of log file
+/*!50003 SET COMPLETION_TYPE=@OLD_COMPLETION_TYPE*/;
+/*!50530 SET @@SESSION.PSEUDO_SLAVE_MODE=0*/;
+# < CASE 1 >
+# Show mysqlbinlog result with -B
+#
+/*!50530 SET @@SESSION.PSEUDO_SLAVE_MODE=1*/;
+/*!50003 SET @OLD_COMPLETION_TYPE=@@COMPLETION_TYPE,COMPLETION_TYPE=0*/;
+DELIMITER /*!*/;
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Start: binlog v 4, server v #.##.## created 010909  9:46:40 at startup
+ROLLBACK/*!*/;
+/*!50616 SET @@SESSION.GTID_NEXT='AUTOMATIC'*//*!*/;
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Previous-GTIDs
+# [empty]
+# at #
+# at #
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Table_map: `test`.`t1` mapped to number #
+# at #
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Table_map: `test`.`t1` mapped to number #
+# at #
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Table_map: `test`.`t1` mapped to number #
+# at #
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Table_map: `test`.`t1` mapped to number #
+# at #
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Table_map: `test`.`t1` mapped to number #
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Rotate to binlog.000002  pos: 4
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Xid = #
+BEGIN/*!*/;
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Write_rows: table id # flags: STMT_END_F
+### INSERT INTO `test`.`t1`
+### SET
+###   @1=127 /* TINYINT meta=0 nullable=1 is_null=0 */
+###   @2=32767 /* SHORTINT meta=0 nullable=1 is_null=0 */
+###   @3=8388607 /* MEDIUMINT meta=0 nullable=1 is_null=0 */
+###   @4=2147483647 /* INT meta=0 nullable=1 is_null=0 */
+###   @5=9223372036854775807 /* LONGINT meta=0 nullable=1 is_null=0 */
+###   @6='aaaaaaaaaa' /* STRING(40) meta=65064 nullable=1 is_null=0 */
+###   @7='aaaaaaaaaaaaaaaaaaaa' /* VARSTRING(80) meta=80 nullable=1 is_null=0 */
+###   @8='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' /* BLOB/TEXT meta=2 nullable=1 is_null=0 */
+### INSERT INTO `test`.`t1`
+### SET
+###   @1=100 /* TINYINT meta=0 nullable=1 is_null=0 */
+###   @2=2 /* SHORTINT meta=0 nullable=1 is_null=0 */
+###   @3=3 /* MEDIUMINT meta=0 nullable=1 is_null=0 */
+###   @4=4 /* INT meta=0 nullable=1 is_null=0 */
+###   @5=5 /* LONGINT meta=0 nullable=1 is_null=0 */
+###   @6='abc' /* STRING(40) meta=65064 nullable=1 is_null=0 */
+###   @7='abcdefg' /* VARSTRING(80) meta=80 nullable=1 is_null=0 */
+###   @8='abcedfghijklmnopqrstuvwxyz' /* BLOB/TEXT meta=2 nullable=1 is_null=0 */
+### INSERT INTO `test`.`t1`
+### SET
+###   @1=100 /* TINYINT meta=0 nullable=1 is_null=0 */
+###   @2=0 /* SHORTINT meta=0 nullable=1 is_null=0 */
+###   @3=0 /* MEDIUMINT meta=0 nullable=1 is_null=0 */
+###   @4=0 /* INT meta=0 nullable=1 is_null=0 */
+###   @5=0 /* LONGINT meta=0 nullable=1 is_null=0 */
+###   @6='' /* STRING(40) meta=65064 nullable=1 is_null=0 */
+###   @7='' /* VARSTRING(80) meta=80 nullable=1 is_null=0 */
+###   @8='' /* BLOB/TEXT meta=2 nullable=1 is_null=0 */
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
+SET TIMESTAMP=1000000000/*!*/;
+COMMIT
+/*!*/;
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Xid = #
+BEGIN/*!*/;
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Update_rows: table id # flags: STMT_END_F
+### UPDATE `test`.`t1`
+### WHERE
+###   @1=100 /* TINYINT meta=0 nullable=1 is_null=0 */
+###   @2=2 /* SHORTINT meta=0 nullable=1 is_null=0 */
+###   @3=3 /* MEDIUMINT meta=0 nullable=1 is_null=0 */
+###   @4=4 /* INT meta=0 nullable=1 is_null=0 */
+###   @5=5 /* LONGINT meta=0 nullable=1 is_null=0 */
+###   @6='abc' /* STRING(40) meta=65064 nullable=1 is_null=0 */
+###   @7='abcdefg' /* VARSTRING(80) meta=80 nullable=1 is_null=0 */
+###   @8='abcedfghijklmnopqrstuvwxyz' /* BLOB/TEXT meta=2 nullable=1 is_null=0 */
+### SET
+###   @1=1 /* TINYINT meta=0 nullable=1 is_null=0 */
+###   @2=2 /* SHORTINT meta=0 nullable=1 is_null=0 */
+###   @3=3 /* MEDIUMINT meta=0 nullable=1 is_null=0 */
+###   @4=4 /* INT meta=0 nullable=1 is_null=0 */
+###   @5=5 /* LONGINT meta=0 nullable=1 is_null=0 */
+###   @6='abc' /* STRING(40) meta=65064 nullable=1 is_null=0 */
+###   @7='abcdefg' /* VARSTRING(80) meta=80 nullable=1 is_null=0 */
+###   @8='abcedfghijklmnopqrstuvwxyz' /* BLOB/TEXT meta=2 nullable=1 is_null=0 */
+### UPDATE `test`.`t1`
+### WHERE
+###   @1=100 /* TINYINT meta=0 nullable=1 is_null=0 */
+###   @2=0 /* SHORTINT meta=0 nullable=1 is_null=0 */
+###   @3=0 /* MEDIUMINT meta=0 nullable=1 is_null=0 */
+###   @4=0 /* INT meta=0 nullable=1 is_null=0 */
+###   @5=0 /* LONGINT meta=0 nullable=1 is_null=0 */
+###   @6='' /* STRING(40) meta=65064 nullable=1 is_null=0 */
+###   @7='' /* VARSTRING(80) meta=80 nullable=1 is_null=0 */
+###   @8='' /* BLOB/TEXT meta=2 nullable=1 is_null=0 */
+### SET
+###   @1=0 /* TINYINT meta=0 nullable=1 is_null=0 */
+###   @2=0 /* SHORTINT meta=0 nullable=1 is_null=0 */
+###   @3=0 /* MEDIUMINT meta=0 nullable=1 is_null=0 */
+###   @4=0 /* INT meta=0 nullable=1 is_null=0 */
+###   @5=0 /* LONGINT meta=0 nullable=1 is_null=0 */
+###   @6='' /* STRING(40) meta=65064 nullable=1 is_null=0 */
+###   @7='' /* VARSTRING(80) meta=80 nullable=1 is_null=0 */
+###   @8='' /* BLOB/TEXT meta=2 nullable=1 is_null=0 */
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
+SET TIMESTAMP=1000000000/*!*/;
+COMMIT
+/*!*/;
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Xid = #
+BEGIN/*!*/;
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Delete_rows: table id # flags: STMT_END_F
+### DELETE FROM `test`.`t1`
+### WHERE
+###   @1=127 /* TINYINT meta=0 nullable=1 is_null=0 */
+###   @2=32767 /* SHORTINT meta=0 nullable=1 is_null=0 */
+###   @3=8388607 /* MEDIUMINT meta=0 nullable=1 is_null=0 */
+###   @4=2147483647 /* INT meta=0 nullable=1 is_null=0 */
+###   @5=9223372036854775807 /* LONGINT meta=0 nullable=1 is_null=0 */
+###   @6='aaaaaaaaaa' /* STRING(40) meta=65064 nullable=1 is_null=0 */
+###   @7='aaaaaaaaaaaaaaaaaaaa' /* VARSTRING(80) meta=80 nullable=1 is_null=0 */
+###   @8='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' /* BLOB/TEXT meta=2 nullable=1 is_null=0 */
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
+SET TIMESTAMP=1000000000/*!*/;
+COMMIT
+/*!*/;
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Xid = #
+BEGIN/*!*/;
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Delete_rows: table id # flags: STMT_END_F
+### DELETE FROM `test`.`t1`
+### WHERE
+###   @1=1 /* TINYINT meta=0 nullable=1 is_null=0 */
+###   @2=2 /* SHORTINT meta=0 nullable=1 is_null=0 */
+###   @3=3 /* MEDIUMINT meta=0 nullable=1 is_null=0 */
+###   @4=4 /* INT meta=0 nullable=1 is_null=0 */
+###   @5=5 /* LONGINT meta=0 nullable=1 is_null=0 */
+###   @6='abc' /* STRING(40) meta=65064 nullable=1 is_null=0 */
+###   @7='abcdefg' /* VARSTRING(80) meta=80 nullable=1 is_null=0 */
+###   @8='abcedfghijklmnopqrstuvwxyz' /* BLOB/TEXT meta=2 nullable=1 is_null=0 */
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
+SET TIMESTAMP=1000000000/*!*/;
+COMMIT
+/*!*/;
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Xid = #
+BEGIN/*!*/;
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Delete_rows: table id # flags: STMT_END_F
+### DELETE FROM `test`.`t1`
+### WHERE
+###   @1=0 /* TINYINT meta=0 nullable=1 is_null=0 */
+###   @2=0 /* SHORTINT meta=0 nullable=1 is_null=0 */
+###   @3=0 /* MEDIUMINT meta=0 nullable=1 is_null=0 */
+###   @4=0 /* INT meta=0 nullable=1 is_null=0 */
+###   @5=0 /* LONGINT meta=0 nullable=1 is_null=0 */
+###   @6='' /* STRING(40) meta=65064 nullable=1 is_null=0 */
+###   @7='' /* VARSTRING(80) meta=80 nullable=1 is_null=0 */
+###   @8='' /* BLOB/TEXT meta=2 nullable=1 is_null=0 */
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
+SET TIMESTAMP=1000000000/*!*/;
+COMMIT
+/*!*/;
+# at #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0	Xid = #
+use `test`/*!*/;
+SET TIMESTAMP=1000000000/*!*/;
+SET @@session.pseudo_thread_id=#/*!*/;
+SET @@session.foreign_key_checks=1, @@session.sql_auto_is_null=0, @@session.unique_checks=1, @@session.autocommit=1/*!*/;
+SET @@session.sql_mode=X/*!*/;
+SET @@session.auto_increment_increment=1, @@session.auto_increment_offset=1/*!*/;
+/*!\C utf8mb4 *//*!*/;
+SET @@session.character_set_client=X,@@session.collation_connection=X,@@session.collation_server=X/*!*/;
+SET @@session.lc_time_names=0/*!*/;
+SET @@session.collation_database=DEFAULT/*!*/;
+/*!80011 SET @@session.default_collation_for_utf8mb4=255*//*!*/;
+/*!80013 SET @@session.sql_require_primary_key=0*//*!*/;
+COMMIT /* added by mysqlbinlog *//*!*/;
+DELIMITER ;
+# End of log file
+/*!50003 SET COMPLETION_TYPE=@OLD_COMPLETION_TYPE*/;
+/*!50530 SET @@SESSION.PSEUDO_SLAVE_MODE=0*/;
+# < CASE 1 >
+# Insert data to t1
+#
+TRUNCATE TABLE t1;
+INSERT INTO t1 VALUES(0,0,0,0,0,'','','');
+INSERT INTO t1 VALUES(1,2,3,4,5, "abc", "abcdefg", "abcedfghijklmnopqrstuvwxyz");
+INSERT INTO t1 VALUES(127, 32767, 8388607, 2147483647, 9223372036854775807, repeat('a', 10), repeat('a', 20), repeat('a', 60));
+# < CASE 1 >
+# Delete all existing binary logs.
+#
+RESET MASTER;
+SELECT * FROM t1;
+c01	c02	c03	c04	c05	c06	c07	c08
+0	0	0	0	0			
+1	2	3	4	5	abc	abcdefg	abcedfghijklmnopqrstuvwxyz
+127	32767	8388607	2147483647	9223372036854775807	aaaaaaaaaa	aaaaaaaaaaaaaaaaaaaa	aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+# < CASE 1 >
+# Operate some data
+#
+UPDATE t1 SET c01=20;
+UPDATE t1 SET c02=200;
+UPDATE t1 SET c03=2000;
+DELETE FROM t1;
+FLUSH LOGS;
+# < CASE 1 >
+# Flashback & Check the result
+#
+SELECT * FROM t1;
+c01	c02	c03	c04	c05	c06	c07	c08
+127	32767	8388607	2147483647	9223372036854775807	aaaaaaaaaa	aaaaaaaaaaaaaaaaaaaa	aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+1	2	3	4	5	abc	abcdefg	abcedfghijklmnopqrstuvwxyz
+0	0	0	0	0			
+RESET MASTER;
+# < CASE 2 >
+# UPDATE multi-rows in one event
+#
+BEGIN;
+UPDATE t1 SET c01=10 WHERE c01=0;
+UPDATE t1 SET c01=20 WHERE c01=10;
+COMMIT;
+FLUSH LOGS;
+# < CASE 2 >
+# Flashback & Check the result
+#
+SELECT * FROM t1;
+c01	c02	c03	c04	c05	c06	c07	c08
+127	32767	8388607	2147483647	9223372036854775807	aaaaaaaaaa	aaaaaaaaaaaaaaaaaaaa	aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+1	2	3	4	5	abc	abcdefg	abcedfghijklmnopqrstuvwxyz
+0	0	0	0	0			
+DROP TABLE t1;
+# < CASE 3 >
+# Self-referencing foreign keys
+#
+CREATE TABLE t1 (a INT PRIMARY KEY, b INT, FOREIGN KEY my_fk(b) REFERENCES t1(a)) ENGINE=InnoDB;
+BEGIN;
+INSERT INTO t1 VALUES (1, NULL);
+INSERT INTO t1 VALUES (2, 1), (3, 2), (4, 3);
+COMMIT;
+SELECT * FROM t1;
+a	b
+1	NULL
+2	1
+3	2
+4	3
+RESET MASTER;
+DELETE FROM t1 ORDER BY a DESC;
+FLUSH LOGS;
+# < CASE 3 >
+# Flashback & Check the result
+#
+SELECT * FROM t1;
+a	b
+1	NULL
+2	1
+3	2
+4	3
+DROP TABLE t1;
+# < CASE 4 >
+# Trigger
+#
+CREATE TABLE t1 (a INT PRIMARY KEY, b INT) ENGINE=InnoDB;
+CREATE TABLE t2 (a INT PRIMARY KEY, b INT) ENGINE=InnoDB;
+BEGIN;
+INSERT INTO t1 VALUES (1, NULL);
+INSERT INTO t1 VALUES (2, 1), (3, 2), (4, 3);
+INSERT INTO t2 VALUES (6, 7), (7, 8), (8, 9);
+COMMIT;
+SELECT * FROM t1;
+a	b
+1	NULL
+2	1
+3	2
+4	3
+SELECT * FROM t2;
+a	b
+6	7
+7	8
+8	9
+CREATE TRIGGER trg1 BEFORE INSERT ON t1 FOR EACH ROW DELETE FROM t2 WHERE a = NEW.b;
+RESET MASTER;
+INSERT INTO t1 VALUES (5, 6), (7, 8);
+SELECT * FROM t1;
+a	b
+1	NULL
+2	1
+3	2
+4	3
+5	6
+7	8
+SELECT * FROM t2;
+a	b
+7	8
+FLUSH LOGS;
+# < CASE 4 >
+# Flashback & Check the result
+#
+SELECT * FROM t1;
+a	b
+1	NULL
+2	1
+3	2
+4	3
+SELECT * FROM t2;
+a	b
+6	7
+7	8
+8	9
+DROP TRIGGER trg1;
+DROP TABLE t1;
+DROP TABLE t2;
+# < CASE 5 >
+# REPLCAE Queries
+#
+CREATE TABLE t1 (a INT PRIMARY KEY, b INT, UNIQUE uk(b)) ENGINE=InnoDB;
+BEGIN;
+INSERT INTO t1 VALUES (1, NULL);
+INSERT INTO t1 VALUES (2, 1), (3, 2), (4, 3);
+INSERT INTO t1 VALUES (5, 4), (6, 5), (7, 6);
+COMMIT;
+SELECT * FROM t1;
+a	b
+1	NULL
+2	1
+3	2
+4	3
+5	4
+6	5
+7	6
+RESET MASTER;
+REPLACE INTO t1 VALUES (3, 100);
+REPLACE INTO t1 SET a=4, b=200;
+SELECT * FROM t1;
+a	b
+1	NULL
+2	1
+5	4
+6	5
+7	6
+3	100
+4	200
+REPLACE INTO t1 VALUES (5,5);
+SELECT * FROM t1;
+a	b
+1	NULL
+2	1
+5	5
+7	6
+3	100
+4	200
+FLUSH LOGS;
+# < CASE 5 >
+# Flashback & Check the result
+#
+SELECT * FROM t1;
+a	b
+1	NULL
+2	1
+3	2
+4	3
+5	4
+6	5
+7	6
+DROP TABLE t1;
+# < CASE 6 >
+# Partial Tables Flashback
+#
+CREATE DATABASE world;
+CREATE TABLE world.city (
+ID INT AUTO_INCREMENT PRIMARY KEY,
+Name VARCHAR(64),
+CountryCode VARCHAR(64),
+District VARCHAR(64),
+Population INT
+) ENGINE=InnoDB;
+CREATE TABLE world.w1 (a INT PRIMARY KEY, b INT) ENGINE=InnoDB;
+CREATE TABLE test.test (
+ID INT AUTO_INCREMENT PRIMARY KEY,
+REC VARCHAR(64),
+ts TIMESTAMP
+) ENGINE=InnoDB;
+INSERT INTO world.city VALUES (NULL, 'Davenport', 'USA', 'Iowa', 100);
+INSERT INTO world.city VALUES (NULL, 'Boulder', 'USA', 'Colorado', 1000);
+INSERT INTO world.city VALUES (NULL, 'Gweru', 'ZWE', 'Midlands', 10000);
+INSERT INTO world.w1 VALUES (1, NULL);
+INSERT INTO world.w1 VALUES (2, 1), (3, 2), (4, 3);
+SELECT * FROM world.city;
+ID	Name	CountryCode	District	Population
+1	Davenport	USA	Iowa	100
+2	Boulder	USA	Colorado	1000
+3	Gweru	ZWE	Midlands	10000
+RESET MASTER;
+CHECKSUM TABLE world.city;
+Table	Checksum
+world.city	563256876
+INSERT INTO test.test VALUES (NULL, 'Good record 1', CURRENT_TIMESTAMP());
+INSERT INTO world.city VALUES (NULL, 'Wrong value 1', '000', 'Wrong', 0);
+INSERT INTO world.city VALUES (NULL, 'Wrong value 2', '000', 'Wrong', 0) , (NULL, 'Wrong value 3', '000', 'Wrong', 0);
+INSERT INTO test.test VALUES (NULL, 'Good record 2', CURRENT_TIMESTAMP());
+UPDATE world.city SET Population = 99999999 WHERE ID IN (1, 2, 3);
+INSERT INTO test.test VALUES (NULL, 'Good record 3', CURRENT_TIMESTAMP());
+DELETE FROM world.city WHERE ID BETWEEN 1 AND 2;
+INSERT INTO test.test VALUES (NULL, 'Good record 5', CURRENT_TIMESTAMP());
+REPLACE INTO world.city VALUES (4074, 'Wrong value 4', '000', 'Wrong', 0);
+REPLACE INTO world.city VALUES (4078, 'Wrong value 5', '000', 'Wrong', 0), (NULL, 'Wrong value 6', '000', 'Wrong', 0);
+INSERT INTO test.test VALUES (NULL, 'Good record 6', CURRENT_TIMESTAMP());
+INSERT INTO world.city
+SELECT NULL, Name, CountryCode, District, Population FROM world.city WHERE ID BETWEEN 2 AND 10;
+INSERT INTO test.test VALUES (NULL, 'Good record 7', CURRENT_TIMESTAMP());
+INSERT INTO test.test VALUES (NULL, 'Good record 8', CURRENT_TIMESTAMP());
+DELETE FROM world.city;
+INSERT INTO world.w1 VALUES (5, 4), (6, 5), (7, 6);
+INSERT INTO test.test VALUES (NULL, 'Good record 9', CURRENT_TIMESTAMP());
+SELECT * FROM test.test;
+ID	REC	ts
+1	Good record 1	2001-09-09 09:46:40
+2	Good record 2	2001-09-09 09:46:40
+3	Good record 3	2001-09-09 09:46:40
+4	Good record 5	2001-09-09 09:46:40
+5	Good record 6	2001-09-09 09:46:40
+6	Good record 7	2001-09-09 09:46:40
+7	Good record 8	2001-09-09 09:46:40
+8	Good record 9	2001-09-09 09:46:40
+SELECT * FROM world.w1;
+a	b
+1	NULL
+2	1
+3	2
+4	3
+5	4
+6	5
+7	6
+FLUSH LOGS;
+# < CASE 6 >
+# Flashback & Check the result
+#
+SELECT * FROM world.city;
+ID	Name	CountryCode	District	Population
+1	Davenport	USA	Iowa	100
+2	Boulder	USA	Colorado	1000
+3	Gweru	ZWE	Midlands	10000
+SELECT * FROM test.test;
+ID	REC	ts
+1	Good record 1	2001-09-09 09:46:40
+2	Good record 2	2001-09-09 09:46:40
+3	Good record 3	2001-09-09 09:46:40
+4	Good record 5	2001-09-09 09:46:40
+5	Good record 6	2001-09-09 09:46:40
+6	Good record 7	2001-09-09 09:46:40
+7	Good record 8	2001-09-09 09:46:40
+8	Good record 9	2001-09-09 09:46:40
+SELECT * FROM world.w1;
+a	b
+1	NULL
+2	1
+3	2
+4	3
+5	4
+6	5
+7	6
+CHECKSUM TABLE world.city;
+Table	Checksum
+world.city	563256876
+DROP TABLE test.test;
+DROP TABLE world.city;
+DROP TABLE world.w1;
+DROP DATABASE world;
+# < CASE 7 >
+# Update join, Delete join
+#
+create table school(
+schoolID int not null default 0 primary key,
+schoolName blob not null
+)ENGINE=InnoDB;
+create table class(
+classID int not null default 0 primary key,
+className blob not null,
+schoolID int not null default 0
+)ENGINE=InnoDB;
+create table student(
+stdID int not null default 0 primary key,
+stdName blob not null,
+classID int not null default 0,
+schoolID int not null default 0
+)ENGINE=InnoDB;
+INSERT INTO school (schoolID,schoolName) VALUES (1,"S-a"),(2,"S-b");
+INSERT INTO class(classID,className,schoolID) VALUES (1,"C-a",1),(2,"C-b",1),(3,"C-c",1),(4,"C-d",1);
+INSERT INTO student(stdID,stdName,classID,schoolID) VALUES (1,"S-a",1,1),(2,"S-b",1,1),(3,"S-c",1,1),(4,"S-d",4,1),(5,"S-e",2,1),(6,"S-f",3,1),(7,"S-g",4,1);
+SELECT * FROM school;
+schoolID	schoolName
+1	S-a
+2	S-b
+SELECT * FROM class;
+classID	className	schoolID
+1	C-a	1
+2	C-b	1
+3	C-c	1
+4	C-d	1
+SELECT * FROM student;
+stdID	stdName	classID	schoolID
+1	S-a	1	1
+2	S-b	1	1
+3	S-c	1	1
+4	S-d	4	1
+5	S-e	2	1
+6	S-f	3	1
+7	S-g	4	1
+RESET MASTER;
+BEGIN;
+UPDATE school,student,class 
+SET school.schoolName='school_deleted',student.schoolID=2,class.schoolID=2
+WHERE school.schoolID= class.schoolID AND class.schoolID = student.schoolID AND school.schoolID=1;
+DELETE school,student,class
+FROM school INNER JOIN student INNER JOIN class  
+WHERE school.schoolID IN (2);
+COMMIT;
+SELECT * FROM school;
+schoolID	schoolName
+1	school_deleted
+SELECT * FROM class;
+classID	className	schoolID
+SELECT * FROM student;
+stdID	stdName	classID	schoolID
+FLUSH LOGS;
+# < CASE 7 >
+# Flashback & Check the result
+#
+SELECT * FROM school;
+schoolID	schoolName
+1	school_deleted
+SELECT * FROM class;
+classID	className	schoolID
+1	C-a	1
+2	C-b	1
+3	C-c	1
+4	C-d	1
+SELECT * FROM student;
+stdID	stdName	classID	schoolID
+1	S-a	1	1
+2	S-b	1	1
+3	S-c	1	1
+4	S-d	4	1
+5	S-e	2	1
+6	S-f	3	1
+7	S-g	4	1
+DROP TABLE school;
+DROP TABLE class;
+DROP TABLE student;

--- a/mysql-test/suite/binlog/t/flashback-master.opt
+++ b/mysql-test/suite/binlog/t/flashback-master.opt
@@ -1,0 +1,3 @@
+--timezone=GMT-8
+--binlog-format=row
+--binlog-row-image=full

--- a/mysql-test/suite/binlog/t/flashback.test
+++ b/mysql-test/suite/binlog/t/flashback.test
@@ -1,0 +1,441 @@
+--source include/have_binlog_format_row.inc
+#--source include/have_innodb.inc
+
+SET  binlog_row_image=full;
+let $BINLOG_FORMAT= `select @@binlog_format`;
+let $BINLOG_ROW_IMAGE= `select @@binlog_row_image`;
+--echo # BINLOG_FORMAT = $BINLOG_FORMAT
+--echo # BINLOG_ROW_IMAGE = $BINLOG_ROW_IMAGE
+
+--echo #
+--echo # Preparatory cleanup.
+--echo #
+--disable_warnings
+DROP TABLE IF EXISTS t1;
+--enable_warnings
+
+--echo #
+--echo # We need a fixed timestamp to avoid varying results.
+--echo #
+SET timestamp=1000000000;
+
+--echo # < CASE 1 >
+--echo # Delete all existing binary logs.
+--echo #
+RESET MASTER;
+
+CREATE TABLE t1 (
+  c01 tinyint,
+  c02 smallint,
+  c03 mediumint,
+  c04 int,
+  c05 bigint,
+  c06 char(10),
+  c07 varchar(20),
+  c08 TEXT
+) ENGINE=InnoDB;
+
+--echo # < CASE 1 >
+--echo # Insert data to t1
+--echo #
+INSERT INTO t1 VALUES(0,0,0,0,0,'','','');
+INSERT INTO t1 VALUES(1,2,3,4,5, "abc", "abcdefg", "abcedfghijklmnopqrstuvwxyz");
+INSERT INTO t1 VALUES(127, 32767, 8388607, 2147483647, 9223372036854775807, repeat('a', 10), repeat('a', 20), repeat('a', 255));
+
+
+--echo # < CASE 1 >
+--echo # Update t1
+--echo #
+UPDATE t1 SET c01=100 WHERE c02=0 OR c03=3;
+
+--echo # < CASE 1 >
+--echo # Clear t1
+--echo #
+DELETE FROM t1;
+
+FLUSH LOGS;
+
+--echo # < CASE 1 >
+--echo # Show mysqlbinlog result without -B
+--echo #
+
+let $MYSQLD_DATADIR= `select @@datadir`;
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--replace_regex /SQL_LOAD_MB-[0-9]-[0-9]/SQL_LOAD_MB-#-#/ /exec_time=[0-9]*/exec_time=#/ /end_log_pos [0-9]*/end_log_pos #/ /# at [0-9]*/# at #/ /Xid = [0-9]*/Xid = #/ /thread_id=[0-9]*/thread_id=#/ /table id [0-9]*/table id #/ /mapped to number [0-9]*/mapped to number #/ /server v [^ ]*/server v #.##.##/ /CRC32 0x[0-9a-f]*/CRC32 XXX/ /collation_server=[0-9]+/collation_server=X/ /character_set_client=[0-9]+/character_set_client=X/ /collation_connection=[0-9]+/collation_connection=X/ /sql_mode=[0-9]+/sql_mode=X/ /(original_commit[a-z]*_timestamp)=[0-9]+/\1=X/ /immediate_commit_timestamp=[0-9]+/immediate_commit_timestamp=X/ /transaction_length=[0-9]+/transaction_length=X/ /[0-9]+-[0-9]+-[0-9]+ [0-9]+:[0-9]+:[0-9]+.[0-9]* GMT/X-X-X X:X:X.X GMT/ /(original_server_version)=[0-9]+/\1=X/ /(immediate_server_version)=[0-9]+/\1=X/
+--exec $MYSQL_BINLOG --base64-output=decode-rows -v -v $MYSQLD_DATADIR/binlog.000001
+
+--echo # < CASE 1 >
+--echo # Show mysqlbinlog result with -B
+--echo #
+
+let $MYSQLD_DATADIR= `select @@datadir`;
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--replace_regex /SQL_LOAD_MB-[0-9]-[0-9]/SQL_LOAD_MB-#-#/ /exec_time=[0-9]*/exec_time=#/ /end_log_pos [0-9]*/end_log_pos #/ /# at [0-9]*/# at #/ /Xid = [0-9]*/Xid = #/ /thread_id=[0-9]*/thread_id=#/ /table id [0-9]*/table id #/ /mapped to number [0-9]*/mapped to number #/ /server v [^ ]*/server v #.##.##/ /CRC32 0x[0-9a-f]*/CRC32 XXX/ /collation_server=[0-9]+/collation_server=X/ /character_set_client=[0-9]+/character_set_client=X/ /collation_connection=[0-9]+/collation_connection=X/ /sql_mode=[0-9]+/sql_mode=X/ /(original_commit[a-z]*_timestamp)=[0-9]+/\1=X/ /immediate_commit_timestamp=[0-9]+/immediate_commit_timestamp=X/ /transaction_length=[0-9]+/transaction_length=X/ /[0-9]+-[0-9]+-[0-9]+ [0-9]+:[0-9]+:[0-9]+.[0-9]* GMT/X-X-X X:X:X.X GMT/ /(original_server_version)=[0-9]+/\1=X/ /(immediate_server_version)=[0-9]+/\1=X/
+--exec $MYSQL_BINLOG -B --base64-output=decode-rows -v -v $MYSQLD_DATADIR/binlog.000001
+
+--echo # < CASE 1 >
+--echo # Insert data to t1
+--echo #
+TRUNCATE TABLE t1;
+INSERT INTO t1 VALUES(0,0,0,0,0,'','','');
+INSERT INTO t1 VALUES(1,2,3,4,5, "abc", "abcdefg", "abcedfghijklmnopqrstuvwxyz");
+INSERT INTO t1 VALUES(127, 32767, 8388607, 2147483647, 9223372036854775807, repeat('a', 10), repeat('a', 20), repeat('a', 60));
+
+--echo # < CASE 1 >
+--echo # Delete all existing binary logs.
+--echo #
+RESET MASTER;
+SELECT * FROM t1;
+
+--echo # < CASE 1 >
+--echo # Operate some data
+--echo #
+
+UPDATE t1 SET c01=20;
+UPDATE t1 SET c02=200;
+UPDATE t1 SET c03=2000;
+
+DELETE FROM t1;
+
+FLUSH LOGS;
+
+--echo # < CASE 1 >
+--echo # Flashback & Check the result
+--echo #
+
+let $MYSQLD_DATADIR= `select @@datadir`;
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--exec $MYSQL_BINLOG -vv $MYSQLD_DATADIR/binlog.000001 > $MYSQLTEST_VARDIR/tmp/mysqlbinlog_row_flashback_original_1.sql
+--exec $MYSQL_BINLOG -B -vv $MYSQLD_DATADIR/binlog.000001 > $MYSQLTEST_VARDIR/tmp/mysqlbinlog_row_flashback_1.sql
+--exec $MYSQL -e "SET binlog_format= ROW; source $MYSQLTEST_VARDIR/tmp/mysqlbinlog_row_flashback_1.sql;"
+
+SELECT * FROM t1;
+
+RESET MASTER;
+
+--echo # < CASE 2 >
+--echo # UPDATE multi-rows in one event
+--echo #
+
+BEGIN;
+UPDATE t1 SET c01=10 WHERE c01=0;
+UPDATE t1 SET c01=20 WHERE c01=10;
+COMMIT;
+
+FLUSH LOGS;
+
+--echo # < CASE 2 >
+--echo # Flashback & Check the result
+--echo #
+
+let $MYSQLD_DATADIR= `select @@datadir`;
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--exec $MYSQL_BINLOG -vv $MYSQLD_DATADIR/binlog.000001 > $MYSQLTEST_VARDIR/tmp/mysqlbinlog_row_flashback_original_2.sql
+--exec $MYSQL_BINLOG -B -vv $MYSQLD_DATADIR/binlog.000001 > $MYSQLTEST_VARDIR/tmp/mysqlbinlog_row_flashback_2.sql
+--exec $MYSQL -e "SET binlog_format= ROW; source $MYSQLTEST_VARDIR/tmp/mysqlbinlog_row_flashback_2.sql;"
+
+SELECT * FROM t1;
+
+DROP TABLE t1;
+
+--echo # < CASE 3 >
+--echo # Self-referencing foreign keys
+--echo #
+
+CREATE TABLE t1 (a INT PRIMARY KEY, b INT, FOREIGN KEY my_fk(b) REFERENCES t1(a)) ENGINE=InnoDB;
+
+BEGIN;
+INSERT INTO t1 VALUES (1, NULL);
+INSERT INTO t1 VALUES (2, 1), (3, 2), (4, 3);
+COMMIT;
+
+SELECT * FROM t1;
+
+# New binlog
+RESET MASTER;
+
+DELETE FROM t1 ORDER BY a DESC;
+
+FLUSH LOGS;
+
+--echo # < CASE 3 >
+--echo # Flashback & Check the result
+--echo #
+
+let $MYSQLD_DATADIR= `select @@datadir`;
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--exec $MYSQL_BINLOG -vv $MYSQLD_DATADIR/binlog.000001 > $MYSQLTEST_VARDIR/tmp/mysqlbinlog_row_flashback_original_3.sql
+--exec $MYSQL_BINLOG -B -vv $MYSQLD_DATADIR/binlog.000001 > $MYSQLTEST_VARDIR/tmp/mysqlbinlog_row_flashback_3.sql
+--exec $MYSQL -e "SET binlog_format= ROW; source $MYSQLTEST_VARDIR/tmp/mysqlbinlog_row_flashback_3.sql;"
+
+SELECT * FROM t1;
+
+DROP TABLE t1;
+
+--echo # < CASE 4 >
+--echo # Trigger
+--echo #
+
+CREATE TABLE t1 (a INT PRIMARY KEY, b INT) ENGINE=InnoDB;
+CREATE TABLE t2 (a INT PRIMARY KEY, b INT) ENGINE=InnoDB;
+
+BEGIN;
+INSERT INTO t1 VALUES (1, NULL);
+INSERT INTO t1 VALUES (2, 1), (3, 2), (4, 3);
+INSERT INTO t2 VALUES (6, 7), (7, 8), (8, 9);
+COMMIT;
+
+SELECT * FROM t1;
+SELECT * FROM t2;
+
+CREATE TRIGGER trg1 BEFORE INSERT ON t1 FOR EACH ROW DELETE FROM t2 WHERE a = NEW.b;
+
+# New binlog
+RESET MASTER;
+
+INSERT INTO t1 VALUES (5, 6), (7, 8);
+
+SELECT * FROM t1;
+SELECT * FROM t2;
+
+FLUSH LOGS;
+
+--echo # < CASE 4 >
+--echo # Flashback & Check the result
+--echo #
+
+let $MYSQLD_DATADIR= `select @@datadir`;
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--exec $MYSQL_BINLOG -vv $MYSQLD_DATADIR/binlog.000001 > $MYSQLTEST_VARDIR/tmp/mysqlbinlog_row_flashback_original_4.sql
+--exec $MYSQL_BINLOG -B $MYSQLD_DATADIR/binlog.000001 > $MYSQLTEST_VARDIR/tmp/mysqlbinlog_row_flashback_4.sql
+--exec $MYSQL -e "SET binlog_format= ROW; source $MYSQLTEST_VARDIR/tmp/mysqlbinlog_row_flashback_4.sql;"
+
+SELECT * FROM t1;
+SELECT * FROM t2;
+
+DROP TRIGGER trg1;
+DROP TABLE t1;
+DROP TABLE t2;
+
+--echo # < CASE 5 >
+--echo # REPLCAE Queries
+--echo #
+
+CREATE TABLE t1 (a INT PRIMARY KEY, b INT, UNIQUE uk(b)) ENGINE=InnoDB;
+
+BEGIN;
+INSERT INTO t1 VALUES (1, NULL);
+INSERT INTO t1 VALUES (2, 1), (3, 2), (4, 3);
+INSERT INTO t1 VALUES (5, 4), (6, 5), (7, 6);
+COMMIT;
+
+SELECT * FROM t1;
+
+# New binlog
+RESET MASTER;
+
+REPLACE INTO t1 VALUES (3, 100);
+REPLACE INTO t1 SET a=4, b=200;
+
+SELECT * FROM t1;
+
+REPLACE INTO t1 VALUES (5,5);
+
+SELECT * FROM t1;
+
+FLUSH LOGS;
+
+--echo # < CASE 5 >
+--echo # Flashback & Check the result
+--echo #
+
+let $MYSQLD_DATADIR= `select @@datadir`;
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--exec $MYSQL_BINLOG -vv $MYSQLD_DATADIR/binlog.000001 > $MYSQLTEST_VARDIR/tmp/mysqlbinlog_row_flashback_original_5.sql
+--exec $MYSQL_BINLOG -B $MYSQLD_DATADIR/binlog.000001 > $MYSQLTEST_VARDIR/tmp/mysqlbinlog_row_flashback_5.sql
+--exec $MYSQL -e "SET binlog_format= ROW; source $MYSQLTEST_VARDIR/tmp/mysqlbinlog_row_flashback_5.sql;"
+
+SELECT * FROM t1;
+
+DROP TABLE t1;
+
+--echo # < CASE 6 >
+--echo # Partial Tables Flashback
+--echo #
+
+# Init Structure
+CREATE DATABASE world;
+CREATE TABLE world.city (
+     ID INT AUTO_INCREMENT PRIMARY KEY,
+     Name VARCHAR(64),
+     CountryCode VARCHAR(64),
+     District VARCHAR(64),
+     Population INT
+) ENGINE=InnoDB;
+CREATE TABLE world.w1 (a INT PRIMARY KEY, b INT) ENGINE=InnoDB;
+CREATE TABLE test.test (
+     ID INT AUTO_INCREMENT PRIMARY KEY,
+     REC VARCHAR(64),
+     ts TIMESTAMP
+) ENGINE=InnoDB;
+
+INSERT INTO world.city VALUES (NULL, 'Davenport', 'USA', 'Iowa', 100);
+INSERT INTO world.city VALUES (NULL, 'Boulder', 'USA', 'Colorado', 1000);
+INSERT INTO world.city VALUES (NULL, 'Gweru', 'ZWE', 'Midlands', 10000);
+INSERT INTO world.w1 VALUES (1, NULL);
+INSERT INTO world.w1 VALUES (2, 1), (3, 2), (4, 3);
+
+SELECT * FROM world.city;
+
+RESET MASTER;
+
+CHECKSUM TABLE world.city;
+
+# Insert test data
+INSERT INTO test.test VALUES (NULL, 'Good record 1', CURRENT_TIMESTAMP());
+
+INSERT INTO world.city VALUES (NULL, 'Wrong value 1', '000', 'Wrong', 0);
+INSERT INTO world.city VALUES (NULL, 'Wrong value 2', '000', 'Wrong', 0) , (NULL, 'Wrong value 3', '000', 'Wrong', 0);
+
+INSERT INTO test.test VALUES (NULL, 'Good record 2', CURRENT_TIMESTAMP());
+
+UPDATE world.city SET Population = 99999999 WHERE ID IN (1, 2, 3);
+
+INSERT INTO test.test VALUES (NULL, 'Good record 3', CURRENT_TIMESTAMP());
+
+DELETE FROM world.city WHERE ID BETWEEN 1 AND 2;
+
+INSERT INTO test.test VALUES (NULL, 'Good record 5', CURRENT_TIMESTAMP());
+
+REPLACE INTO world.city VALUES (4074, 'Wrong value 4', '000', 'Wrong', 0);
+REPLACE INTO world.city VALUES (4078, 'Wrong value 5', '000', 'Wrong', 0), (NULL, 'Wrong value 6', '000', 'Wrong', 0);
+
+INSERT INTO test.test VALUES (NULL, 'Good record 6', CURRENT_TIMESTAMP());
+
+INSERT INTO world.city
+SELECT NULL, Name, CountryCode, District, Population FROM world.city WHERE ID BETWEEN 2 AND 10;
+
+INSERT INTO test.test VALUES (NULL, 'Good record 7', CURRENT_TIMESTAMP());
+
+INSERT INTO test.test VALUES (NULL, 'Good record 8', CURRENT_TIMESTAMP());
+
+DELETE FROM world.city;
+INSERT INTO world.w1 VALUES (5, 4), (6, 5), (7, 6);
+
+INSERT INTO test.test VALUES (NULL, 'Good record 9', CURRENT_TIMESTAMP());
+
+SELECT * FROM test.test;
+
+SELECT * FROM world.w1;
+
+FLUSH LOGS;
+
+--echo # < CASE 6 >
+--echo # Flashback & Check the result
+--echo #
+
+let $MYSQLD_DATADIR= `select @@datadir`;
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--exec $MYSQL_BINLOG  -vv $MYSQLD_DATADIR/binlog.000001 > $MYSQLTEST_VARDIR/tmp/mysqlbinlog_row_flashback_original_6.sql
+--exec $MYSQL_BINLOG --flashback --database=world --flashback-tables=city -vv $MYSQLD_DATADIR/binlog.000001 > $MYSQLTEST_VARDIR/tmp/mysqlbinlog_row_flashback_6.sql
+--exec $MYSQL -e "SET binlog_format= ROW; source $MYSQLTEST_VARDIR/tmp/mysqlbinlog_row_flashback_6.sql;"
+
+SELECT * FROM world.city;
+
+SELECT * FROM test.test;
+
+SELECT * FROM world.w1;
+
+CHECKSUM TABLE world.city;
+
+DROP TABLE test.test;
+DROP TABLE world.city;
+DROP TABLE world.w1;
+DROP DATABASE world;
+
+--echo # < CASE 7 >
+--echo # Update join, Delete join
+--echo #
+
+create table school(
+        schoolID int not null default 0 primary key,
+        schoolName blob not null
+)ENGINE=InnoDB;
+create table class(
+        classID int not null default 0 primary key,
+        className blob not null,
+        schoolID int not null default 0
+)ENGINE=InnoDB;
+create table student(
+        stdID int not null default 0 primary key,
+        stdName blob not null,
+        classID int not null default 0,
+        schoolID int not null default 0
+)ENGINE=InnoDB;
+INSERT INTO school (schoolID,schoolName) VALUES (1,"S-a"),(2,"S-b");
+INSERT INTO class(classID,className,schoolID) VALUES (1,"C-a",1),(2,"C-b",1),(3,"C-c",1),(4,"C-d",1);
+INSERT INTO student(stdID,stdName,classID,schoolID) VALUES (1,"S-a",1,1),(2,"S-b",1,1),(3,"S-c",1,1),(4,"S-d",4,1),(5,"S-e",2,1),(6,"S-f",3,1),(7,"S-g",4,1);
+
+SELECT * FROM school;
+
+SELECT * FROM class;
+
+SELECT * FROM student;
+
+RESET MASTER;
+
+# Update and Delete test data
+BEGIN;
+
+UPDATE school,student,class 
+SET school.schoolName='school_deleted',student.schoolID=2,class.schoolID=2
+WHERE school.schoolID= class.schoolID AND class.schoolID = student.schoolID AND school.schoolID=1;
+
+DELETE school,student,class
+FROM school INNER JOIN student INNER JOIN class  
+WHERE school.schoolID IN (2);
+
+COMMIT;
+
+SELECT * FROM school;
+
+SELECT * FROM class;
+
+SELECT * FROM student;
+
+FLUSH LOGS;
+
+--echo # < CASE 7 >
+--echo # Flashback & Check the result
+--echo #
+
+let $MYSQLD_DATADIR= `select @@datadir`;
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--exec $MYSQL_BINLOG  -vv $MYSQLD_DATADIR/binlog.000001 > $MYSQLTEST_VARDIR/tmp/mysqlbinlog_row_flashback_original_7.sql
+--exec $MYSQL_BINLOG --flashback --flashback-tables=student,class -vv $MYSQLD_DATADIR/binlog.000001 > $MYSQLTEST_VARDIR/tmp/mysqlbinlog_row_flashback_7.sql
+--exec $MYSQL -e "SET binlog_format= ROW; source $MYSQLTEST_VARDIR/tmp/mysqlbinlog_row_flashback_7.sql;"
+
+SELECT * FROM school;
+
+SELECT * FROM class;
+
+SELECT * FROM student;
+
+DROP TABLE school;
+DROP TABLE class;
+DROP TABLE student;
+
+remove_file $MYSQLTEST_VARDIR/tmp/mysqlbinlog_row_flashback_original_1.sql;
+remove_file $MYSQLTEST_VARDIR/tmp/mysqlbinlog_row_flashback_1.sql;
+remove_file $MYSQLTEST_VARDIR/tmp/mysqlbinlog_row_flashback_original_2.sql;
+remove_file $MYSQLTEST_VARDIR/tmp/mysqlbinlog_row_flashback_2.sql;
+remove_file $MYSQLTEST_VARDIR/tmp/mysqlbinlog_row_flashback_original_3.sql;
+remove_file $MYSQLTEST_VARDIR/tmp/mysqlbinlog_row_flashback_3.sql;
+remove_file $MYSQLTEST_VARDIR/tmp/mysqlbinlog_row_flashback_original_4.sql;
+remove_file $MYSQLTEST_VARDIR/tmp/mysqlbinlog_row_flashback_4.sql;
+remove_file $MYSQLTEST_VARDIR/tmp/mysqlbinlog_row_flashback_original_5.sql;
+remove_file $MYSQLTEST_VARDIR/tmp/mysqlbinlog_row_flashback_5.sql;
+remove_file $MYSQLTEST_VARDIR/tmp/mysqlbinlog_row_flashback_original_6.sql;
+remove_file $MYSQLTEST_VARDIR/tmp/mysqlbinlog_row_flashback_6.sql;
+remove_file $MYSQLTEST_VARDIR/tmp/mysqlbinlog_row_flashback_original_7.sql;
+remove_file $MYSQLTEST_VARDIR/tmp/mysqlbinlog_row_flashback_7.sql;

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -75,6 +75,9 @@
 #include "sql_const.h"
 #include "sql_string.h"
 #include "template_utils.h"
+#include "sql/sql_lex.h"
+#include "sql/sql_class.h"
+#include "sql/sql_parse.h"
 
 #ifndef MYSQL_SERVER
 #include "client/mysqlbinlog.h"
@@ -438,11 +441,36 @@ static bool set_thd_db(THD *thd, const char *db, size_t db_len) {
 
 #endif
 
+#ifndef MYSQL_SERVER
+
+bool copy_event_cache_to_string_and_reinit(IO_CACHE *cache, LEX_STRING *to)
+{
+    reinit_io_cache(cache, READ_CACHE, 0L, false, false);
+    if (cache->end_of_file > SIZE_T_MAX ||
+        !(to->str= (char*) my_malloc(key_memory_log_event,(to->length= (size_t)cache->end_of_file), MYF(0))))
+    {
+        perror("Out of memory: can't allocate memory in copy_event_cache_to_string_and_reinit().");
+        goto err;
+    }
+    if (my_b_read(cache, (uchar*) to->str, to->length))
+    {
+        my_free(to->str);
+        perror("Can't read data from IO_CACHE");
+        return true;
+    }
+    reinit_io_cache(cache, WRITE_CACHE, 0, false, true);
+    return false;
+
+    err:
+    to->str= 0;
+    to->length= 0;
+    return true;
+}
+
 /*
   pretty_print_str()
 */
 
-#ifndef MYSQL_SERVER
 static inline void pretty_print_str(IO_CACHE *cache, const char *str,
                                     size_t len, bool identifier) {
   const char *end = str + len;
@@ -2194,6 +2222,7 @@ static size_t log_event_print_value(IO_CACHE *file, const uchar *ptr, uint type,
   @param[in] cols_bitmap       Column bitmaps.
   @param[in] value             Pointer to packed row
   @param[in] prefix            Row's SQL clause ("SET", "WHERE", etc)
+  @param[in] no_fill_output    true: just get row size,no output to file(used by flashback); false: output data to file
 
   @retval   - number of bytes scanned.
 */
@@ -2201,7 +2230,7 @@ static size_t log_event_print_value(IO_CACHE *file, const uchar *ptr, uint type,
 size_t Rows_log_event::print_verbose_one_row(
     IO_CACHE *file, table_def *td, PRINT_EVENT_INFO *print_event_info,
     MY_BITMAP *cols_bitmap, const uchar *value, const uchar *prefix,
-    enum_row_image_type row_image_type) {
+    enum_row_image_type row_image_type,const bool no_fill_output) {
   const uchar *value0 = value;
   char typestr[64] = "";
 
@@ -2231,7 +2260,8 @@ size_t Rows_log_event::print_verbose_one_row(
   Bit_reader null_bits(value);
   value += (bitmap_bits_set(cols_bitmap) + 7) / 8;
 
-  my_b_printf(file, "%s", prefix);
+  if(!no_fill_output)
+    my_b_printf(file, "%s", prefix);
 
   for (size_t i = 0; i < td->size(); i++) {
     /*
@@ -2246,8 +2276,10 @@ size_t Rows_log_event::print_verbose_one_row(
     if (bitmap_is_set(cols_bitmap, i) == 0) continue;
 
     bool is_null = null_bits.get();
+    size_t size;
 
-    my_b_printf(file, "###   @%d=", static_cast<int>(i + 1));
+    if(!no_fill_output)
+      my_b_printf(file, "###   @%d=", static_cast<int>(i + 1));
     if (!is_null) {
       size_t fsize =
           td->calc_field_size((uint)i, pointer_cast<const uchar *>(value));
@@ -2262,14 +2294,23 @@ size_t Rows_log_event::print_verbose_one_row(
     }
     char col_name[256];
     sprintf(col_name, "@%lu", (unsigned long)i + 1);
-    size_t size = log_event_print_value(
-        file, is_null ? nullptr : value, td->type(i), td->field_metadata(i),
-        typestr, sizeof(typestr), col_name, is_partial);
+    if(!no_fill_output){
+      size = log_event_print_value(
+          file, is_null ? nullptr : value, td->type(i), td->field_metadata(i),
+          typestr, sizeof(typestr), col_name, is_partial);
+    }else{
+      IO_CACHE tmp_cache;
+      open_cached_file(&tmp_cache, nullptr, nullptr, 0, MYF(MY_WME | MY_NABP));
+      size = log_event_print_value(&tmp_cache, is_null ? nullptr : value,
+                                   td->type(i), td->field_metadata(i), typestr,
+                                   sizeof(typestr), col_name, is_partial);
+      close_cached_file(&tmp_cache);
+    }
     if (!size) return 0;
 
     if (!is_null) value += size;
 
-    if (print_event_info->verbose > 1) {
+    if (print_event_info->verbose > 1 && !no_fill_output) {
       my_b_printf(file, " /* ");
 
       my_b_printf(file, "%s ", typestr);
@@ -2279,9 +2320,138 @@ size_t Rows_log_event::print_verbose_one_row(
       my_b_printf(file, "*/");
     }
 
-    my_b_printf(file, "\n");
+    if(!no_fill_output)
+      my_b_printf(file, "\n");
   }
   return value - value0;
+}
+
+/**
+  Exchange the SET part and WHERE part for the Update events.
+  Revert the operations order for the Write and Delete events.
+  And then revert the events order from the last one to the first one.
+
+  @param[in] print_event_info   PRINT_EVENT_INFO
+  @param[in] rows_buff          Packed event buff
+*/
+void Rows_log_event::change_to_flashback_event(
+    PRINT_EVENT_INFO *print_event_info, uchar *rows_buff,
+    Log_event_type ev_type) {
+  Table_map_log_event *map;
+  table_def *td;
+  std::vector<LEX_STRING> rows_arr;
+  uchar *swap_buff1, *swap_buff2;
+  uchar *rows_pos = rows_buff + m_rows_before_size;
+
+  enum_row_image_type row_image_type =
+      get_general_type_code() == binary_log::WRITE_ROWS_EVENT
+          ? enum_row_image_type::WRITE_AI
+          : get_general_type_code() == binary_log::DELETE_ROWS_EVENT
+                ? enum_row_image_type::DELETE_BI
+                : enum_row_image_type::UPDATE_BI;
+
+  if (!(map = print_event_info->m_table_map.get_table(m_table_id)) ||
+      !(td = map->create_table_def())) {
+    return;
+  }
+
+  /* If the write rows event contained no values for the AI */
+  if (((get_general_type_code() == binary_log::WRITE_ROWS_EVENT) &&
+       (m_rows_buf == m_rows_end)))
+    goto end;
+
+  for (uchar *value = m_rows_buf; value < m_rows_end;) {
+    uchar *start_pos = value;
+    size_t length1 = 0;
+    if (!(length1 = print_verbose_one_row(nullptr, td, print_event_info,
+                                          &m_cols, value, (const uchar *)"",
+                                          row_image_type, true))) {
+      fprintf(
+          stderr,
+          "\nError row length: %zu\nCould not exchange to flashback event.\n",
+          length1);
+      exit(1);
+    }
+
+    value += length1;
+    swap_buff1 = (uchar *)my_malloc(key_memory_log_event, length1, MYF(0));
+    if (!swap_buff1) {
+      fprintf(stderr,
+              "\nError: Out of memory. "
+              "Could not exchange to flashback event.\n");
+      exit(1);
+    }
+    memcpy(swap_buff1, start_pos, length1);
+
+    // For Update_event, we have the second part
+    size_t length2 = 0;
+    if (ev_type == binary_log::UPDATE_ROWS_EVENT ||
+        ev_type == binary_log::UPDATE_ROWS_EVENT_V1) {
+      if (!(length2 = print_verbose_one_row(
+                NULL, td, print_event_info, &m_cols, value, (const uchar *)"",
+                enum_row_image_type::UPDATE_BI, true))) {
+        fprintf(
+            stderr,
+            "\nError row length: %zu\nCould not exchange to flashback event.\n",
+            length2);
+        exit(1);
+      }
+      value += length2;
+
+      swap_buff2 = (uchar *)my_malloc(key_memory_log_event, length2, MYF(0));
+      if (!swap_buff2) {
+        fprintf(stderr,
+                "\nError: Out of memory. "
+                "Could not exchange to flashback event.\n");
+        exit(1);
+      }
+      memcpy(swap_buff2, start_pos + length1, length2);  // WHERE part
+    }
+
+    if (ev_type == binary_log::UPDATE_ROWS_EVENT ||
+        ev_type == binary_log::UPDATE_ROWS_EVENT_V1) {
+      /* Swap SET and WHERE part */
+      memcpy(start_pos, swap_buff2, length2);
+      memcpy(start_pos + length2, swap_buff1, length1);
+    }
+
+    /* Free tmp buffers */
+    my_free(swap_buff1);
+    if (ev_type == binary_log::UPDATE_ROWS_EVENT ||
+        ev_type == binary_log::UPDATE_ROWS_EVENT_V1)
+      my_free(swap_buff2);
+
+    /* Copying one row into a buff, and pushing into the array */
+    LEX_STRING one_row;
+
+    one_row.length = length1 + length2;
+    one_row.str =
+        (char *)my_malloc(key_memory_log_event, one_row.length, MYF(0));
+    memcpy(one_row.str, start_pos, one_row.length);
+    // if (one_row.str == NULL || push_dynamic(&rows_arr, (uchar *) &one_row))
+    if (one_row.str == NULL) {
+      fprintf(stderr,
+              "\nError: Out of memory. "
+              "Could not push flashback event into array.\n");
+      exit(1);
+    } else {
+      rows_arr.push_back(one_row);
+    }
+  }
+  /* Copying rows from the end to the begining into event */
+  // for (uint i= rows_arr.elements; i > 0; --i)
+  for (uint i = rows_arr.size(); i > 0; --i) {
+    // LEX_STRING *one_row= dynamic_element(&rows_arr, i - 1, LEX_STRING*);
+    LEX_STRING *one_row = &rows_arr[i - 1];
+
+    memcpy(rows_pos, (uchar *)one_row->str, one_row->length);
+    rows_pos += one_row->length;
+    my_free(one_row->str);
+  }
+  // delete_dynamic(&rows_arr);
+
+end:
+  delete td;
 }
 
 /**
@@ -2417,9 +2587,50 @@ end:
 
 void Log_event::print_base64(IO_CACHE *file, PRINT_EVENT_INFO *print_event_info,
                              bool more) const {
-  const uchar *ptr = (const uchar *)temp_buf;
+  uchar *ptr = (uchar *)temp_buf;
   uint32 size = uint4korr(ptr + EVENT_LEN_OFFSET);
   DBUG_TRACE;
+
+  enum_binlog_checksum_alg ev_checksum_alg = common_footer->checksum_alg;
+  Format_description_event fd_evt =
+      Format_description_event(BINLOG_VERSION, server_version);
+  fd_evt.footer()->checksum_alg = ev_checksum_alg;
+
+  if(is_flashback){
+    Rows_log_event *ev= NULL;
+    Log_event_type ev_type = (enum Log_event_type) ptr[EVENT_TYPE_OFFSET];
+    switch (ev_type)
+    {
+    case binary_log::WRITE_ROWS_EVENT:
+      ptr[EVENT_TYPE_OFFSET] = binary_log::DELETE_ROWS_EVENT;
+      ev=new Delete_rows_log_event((const char *)ptr, &fd_evt);
+      ev->change_to_flashback_event(print_event_info,ptr,ev_type);
+      break;
+    case binary_log::WRITE_ROWS_EVENT_V1:
+      ptr[EVENT_TYPE_OFFSET] = binary_log::DELETE_ROWS_EVENT_V1;
+      ev=new Delete_rows_log_event((const char *)ptr, &fd_evt);
+      ev->change_to_flashback_event(print_event_info,ptr,ev_type);
+      break;
+    case binary_log::DELETE_ROWS_EVENT:
+      ptr[EVENT_TYPE_OFFSET] = binary_log::WRITE_ROWS_EVENT;
+      ev=new Write_rows_log_event((const char *)ptr, &fd_evt);
+      ev->change_to_flashback_event(print_event_info,ptr,ev_type);
+      break;
+    case binary_log::DELETE_ROWS_EVENT_V1:
+      ptr[EVENT_TYPE_OFFSET] = binary_log::WRITE_ROWS_EVENT_V1;
+      ev=new Write_rows_log_event((const char *)ptr, &fd_evt);
+      ev->change_to_flashback_event(print_event_info,ptr,ev_type);
+      break;
+    case binary_log::UPDATE_ROWS_EVENT:
+    case binary_log::UPDATE_ROWS_EVENT_V1:
+      ev=new Update_rows_log_event((const char *)ptr, &fd_evt);
+      ev->change_to_flashback_event(print_event_info,ptr,ev_type);
+      break;
+    default:
+      break;
+    }
+    delete ev;
+  }
 
   uint64 const tmp_str_sz = base64_needed_encoded_length((uint64)size);
   char *const tmp_str =
@@ -2443,14 +2654,10 @@ void Log_event::print_base64(IO_CACHE *file, PRINT_EVENT_INFO *print_event_info,
     if (!more) my_b_printf(file, "'%s\n", print_event_info->delimiter);
   }
 
-  if (print_event_info->verbose) {
+  // Flashback need the table_map to parse the event
+  if (print_event_info->verbose || is_flashback) {
     Rows_log_event *ev = nullptr;
     Log_event_type et = (Log_event_type)ptr[EVENT_TYPE_OFFSET];
-
-    enum_binlog_checksum_alg ev_checksum_alg = common_footer->checksum_alg;
-    Format_description_event fd_evt =
-        Format_description_event(BINLOG_VERSION, server_version);
-    fd_evt.footer()->checksum_alg = ev_checksum_alg;
 
     switch (et) {
       case binary_log::TABLE_MAP_EVENT: {
@@ -2480,7 +2687,8 @@ void Log_event::print_base64(IO_CACHE *file, PRINT_EVENT_INFO *print_event_info,
     }
 
     if (ev) {
-      ev->print_verbose(&print_event_info->footer_cache, print_event_info);
+      if(print_event_info->verbose)
+        ev->print_verbose(&print_event_info->footer_cache, print_event_info);
       delete ev;
     }
   }
@@ -4402,8 +4610,18 @@ void Query_log_event::print(FILE *, PRINT_EVENT_INFO *print_event_info) const {
   DBUG_EXECUTE_IF("simulate_file_write_error",
                   { head->write_pos = head->write_end - 500; });
   print_query_header(head, print_event_info);
-  my_b_write(head, pointer_cast<const uchar *>(query), q_len);
-  my_b_printf(head, "\n%s\n", print_event_info->delimiter);
+  if(!is_flashback){
+    my_b_write(head, pointer_cast<const uchar *>(query), q_len);
+    my_b_printf(head, "\n%s\n", print_event_info->delimiter);
+  }else{
+    if (strcmp("BEGIN", query) == 0) {
+      my_b_write(head, (const uchar *)"COMMIT", 6) ||
+          my_b_printf(head, "\n%s\n", print_event_info->delimiter);
+    } else if (strcmp("COMMIT", query) == 0) {
+      my_b_write(head, (const uchar *)"BEGIN", 5) ||
+          my_b_printf(head, "\n%s\n", print_event_info->delimiter);
+    }
+  }
 }
 #endif /* !MYSQL_SERVER */
 
@@ -6044,7 +6262,7 @@ void Xid_log_event::print(FILE *, PRINT_EVENT_INFO *print_event_info) const {
     print_header(head, print_event_info, false);
     my_b_printf(head, "\tXid = %s\n", buf);
   }
-  my_b_printf(head, "COMMIT%s\n", print_event_info->delimiter);
+  my_b_printf(head, is_flashback ? "BEGIN%s\n" : "COMMIT%s\n",print_event_info->delimiter);
 }
 #endif /* !MYSQL_SERVER */
 
@@ -10282,10 +10500,32 @@ void Rows_log_event::print_helper(FILE *,
                                   PRINT_EVENT_INFO *print_event_info) const {
   IO_CACHE *const head = &print_event_info->head_cache;
   IO_CACHE *const body = &print_event_info->body_cache;
+  const char *event_type_str = "";
+  if (is_flashback) {
+    switch (common_header->type_code) {
+      case binary_log::WRITE_ROWS_EVENT:
+        event_type_str = get_type_str(binary_log::DELETE_ROWS_EVENT);
+        break;
+      case binary_log::DELETE_ROWS_EVENT:
+        event_type_str = get_type_str(binary_log::WRITE_ROWS_EVENT);
+        break;
+      case binary_log::WRITE_ROWS_EVENT_V1:
+        event_type_str = get_type_str(binary_log::DELETE_ROWS_EVENT_V1);
+        break;
+      case binary_log::DELETE_ROWS_EVENT_V1:
+        event_type_str = get_type_str(binary_log::WRITE_ROWS_EVENT_V1);
+        break;
+      default:
+        event_type_str = get_type_str();
+        break;
+    }
+  } else {
+    event_type_str = get_type_str();
+  }
   if (!print_event_info->short_form) {
     bool const last_stmt_event = get_flags(STMT_END_F);
     print_header(head, print_event_info, !last_stmt_event);
-    my_b_printf(head, "\t%s: table id %llu%s\n", get_type_str(),
+    my_b_printf(head, "\t%s: table id %llu%s\n", event_type_str,
                 m_table_id.id(), last_stmt_event ? " flags: STMT_END_F" : "");
     print_base64(body, print_event_info, !last_stmt_event);
   }
@@ -12713,6 +12953,10 @@ size_t Gtid_log_event::to_string(char *buf) const {
 
 #ifndef MYSQL_SERVER
 void Gtid_log_event::print(FILE *, PRINT_EVENT_INFO *print_event_info) const {
+  if(is_flashback){
+    return;
+  }
+
   char buffer[MAX_SET_STRING_LENGTH + 1];
   IO_CACHE *const head = &print_event_info->head_cache;
   if (!print_event_info->short_form) {


### PR DESCRIPTION
    1. mysqlbinlog flashback
    Introduction to implementation ideas, DML operations in binlog:
    - delete => insert
    - insert => delete
    - update exchanges the set and where parts;
    - Reversal of the overall binlog: The latest binlog file reversal result is first executed in the MySQL server,
    and the oldest binlog file reversal result is finally executed in the MySQL server.
    
    2. mysqlbinlog add options: --flashback/-B,--flashback-tables
    --flashback/-B:  turn on flashback ;
    --flashback-tables: Indicate the target flashback tables;
    
    3. mysqlbinlog extends  --database option to allow --database to support plural values,like --database=D1,D2;
    
    4. Special attention:
    -  Necessary options: binlog_format=ROW, binlog_row_image=FULL, binlog_row_value_options=''.
    - The statement in the binlog file will be directly ignored (including DDL).
    - In the FOREIGN KEY CASCADE DELETE/UPDATE scenario, because the child table related updates will not record the binlog,
    the Child table cannot use flashback to recover data.
    - mysqlbinlog --flashback may take up more memory, it is recommended to set max_binlog_size not too large;
    particularly large transactions are not recommended too.