### PR TITLE
Bug#100750: Unknown error is given when trying to alter engine to arc…

### DIFF
--- a/storage/archive/ha_archive.cc
+++ b/storage/archive/ha_archive.cc
@@ -617,7 +617,8 @@ int ha_archive::create(const char *name, TABLE *table_arg,
       Field *field = key_part->field;
 
       if (!field->is_flag_set(AUTO_INCREMENT_FLAG)) {
-        error = -1;
+        // Archive Engine does not support command without AUTO_INCREMENT_FLAG
+        error = 200;
         DBUG_PRINT("ha_archive", ("Index error in creating archive table"));
         goto error;
       }


### PR DESCRIPTION
…hive

Currently when user try to change engine from InnoDB to ARCHIVE, It will
return Unknown error which is not meaningful.

MySQL return this error becuase this operation/command not yet supported
in the MySQL Archive Engine.

Fix is to use proper error code which will display meaningful error message
to user.

Signed-off-by: Gaurav Kumar Garg <garg.gaurav52@gmail.com>