### PR TITLE
Bug#101448when the input of net_length_size is 251, return 3

### DIFF
--- a/mysys/pack.cc
+++ b/mysys/pack.cc
@@ -158,7 +158,7 @@ uchar *net_store_length(uchar *packet, ulonglong length) {
 */
 
 uint net_length_size(ulonglong num) {
-  if (num < (ulonglong)252LL) return 1;
+  if (num < (ulonglong)251LL) return 1;
   if (num < (ulonglong)65536LL) return 3;
   if (num < (ulonglong)16777216LL) return 4;
   return 9;


### PR DESCRIPTION
The implementation of net_length_size might be wrong when input of num is 251.

Since 251 is reserved for NULL, when 251 is the input of net_store_length's 2nd parameter(i.e. length), it store 252 in the first byte of buffer, and store the 251 in the next 2 bytes.

I checked one usage in Session_gtids_ctx_encoder_string::encode, the calculated len is used to prepare the buffer(buf.prep_append).

So I think in very rare condition, the code might cause buffer overflow.

Signed-off-by: Zhao Junwang <zhjwpku@gmail.com>