### PR TITLE
Bug #101465: mysql doesn't release index sx latch properly in page split operation

### DIFF
--- a/storage/innobase/mtr/mtr0mtr.cc
+++ b/storage/innobase/mtr/mtr0mtr.cc
@@ -99,7 +99,7 @@ struct Find {
 
   /** @return false if the object was found. */
   bool operator()(mtr_memo_slot_t *slot) {
-    if (m_object == slot->object && m_type == slot->type) {
+    if (m_object == slot->object && (m_type & slot->type)) {
       m_slot = slot;
       return (false);
     }


### PR DESCRIPTION
Sometimes, it's safe to release index sx latch before mtr commit. mysql calls below statement to release sx latch:
```
    mtr->memo_release(dict_index_get_lock(cursor->index),
                      MTR_MEMO_X_LOCK | MTR_MEMO_SX_LOCK);
```
but in mtr->memo_release,  the type is MTR_MEMO_X_LOCK | MTR_MEMO_SX_LOCK = 128 + 256 = 384.  Function mtr::memo_release uses Find::operator() to find the sx latch, and in Find::operator() it uses below condition:
```
struct Find {
  /** Constructor */
  Find(const void *object, ulint type)
      : m_slot(), m_type(type), m_object(object) {
    ut_a(object != nullptr);
  }

  /** @return false if the object was found. */
  bool operator()(mtr_memo_slot_t *slot) {
    if (m_object == slot->object && m_type == slot->type) {
      m_slot = slot;
      return (false);
    }

    return (true);
  }

```
It uses m_type == slot->type to find the index lock object, that is slot->type == MTR_MEMO_X_LOCK | MTR_MEMO_SX_LOCK = 128 + 256 = 384, which doesn't exist. It should use conditon m_type & slot->type.

So, all the places with calls 
`    mtr->memo_release(dict_index_get_lock(cursor->index),
                      MTR_MEMO_X_LOCK | MTR_MEMO_SX_LOCK);
`
to release index sx latch doesn't succeed.