### PR TITLE
change TRUE to true

### DIFF
--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -6988,7 +6988,7 @@ int mysqld_main(int argc, char **argv)
   if (opt_keyring_migration_source || opt_keyring_migration_destination ||
       migrate_connect_options) {
     Migrate_keyring mk;
-    my_getopt_skip_unknown = TRUE;
+    my_getopt_skip_unknown = true;
     if (mk.init(remaining_argc, remaining_argv, opt_keyring_migration_source,
                 opt_keyring_migration_destination, opt_keyring_migration_user,
                 opt_keyring_migration_host, opt_keyring_migration_password,


### PR DESCRIPTION
When I install `mysql` on my computer, there was an error in `TRUE`, when I change it to `true`, then everything will be fine.
My make version is 4.3, gcc version is 10.2.0, OS is Gentoo Linux 5.9.12
The error message:
```bash
[ 70%] Building CXX object sql/CMakeFiles/sql_main.dir/opt_explain_json.cc.o
cd /var/tmp/portage/dev-db/mysql-8.0.22/work/mysql-8.0.22_build/sql && /usr/bin/x86_64-pc-linux-gnu-g++ -DHAVE_CONFIG_H -DHAVE_TLSv13 -DLZ4_DISABLE_DEPRECATE_WARNINGS -DMYSQL_SERVER -DRAPIDJSON_NO_SIZETYPEDEFINE -DRAPIDJSON_SCHEMA_USE_INTERNALREGEX=0 -DRAPIDJSON_SCHEMA_USE_STDREGEX=1 -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D_USE_MATH_DEFINES -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I/var/tmp/portage/dev-db/mysql-8.0.22/work/mysql-8.0.22_build -I/var/tmp/portage/dev-db/mysql-8.0.22/work/mysql-8.0.22_build/include -I/var/tmp/portage/dev-db/mysql-8.0.22/work/mysql -I/var/tmp/portage/dev-db/mysql-8.0.22/work/mysql/include -isystem /var/tmp/portage/dev-db/mysql-8.0.22/work/mysql/extra/rapidjson/include -isystem /var/tmp/portage/dev-db/mysql-8.0.22/work/mysql/extra/libedit/libedit-20190324-3.1/src/editline -isystem /var/tmp/portage/dev-db/mysql-8.0.22/work/mysql/include/boost_1_73_0/patches -isystem /var/tmp/portage/dev-db/mysql-8.0.22/work/mysql/boost/boost_1_73_0  -march=skylake -O2 -pipe -felide-constructors -fno-strict-aliasing -Wall -Wextra -Wformat-security -Wvla -Wundef -Wmissing-format-attribute -Woverloaded-virtual -Wcast-qual -Wimplicit-fallthrough=2 -Wstringop-truncation -Wsuggest-override -Wlogical-op -DDBUG_OFF -DNDEBUG -fPIC -Wshadow=local -o CMakeFiles/sql_main.dir/opt_explain_json.cc.o -c /var/tmp/portage/dev-db/mysql-8.0.22/work/mysql/sql/opt_explain_json.cc
/var/tmp/portage/dev-db/mysql-8.0.22/work/mysql/sql/mysqld.cc: In function ‘int mysqld_main(int, char**)’:
/var/tmp/portage/dev-db/mysql-8.0.22/work/mysql/sql/mysqld.cc:6993:30: error:  TRUE’ was not declared in this scope
 6993 |     my_getopt_skip_unknown = TRUE;
      |                              ^~~~
[ 70%] Building CXX object sql/CMakeFiles/sql_main.dir/opt_hints.cc.o
cd /var/tmp/portage/dev-db/mysql-8.0.22/work/mysql-8.0.22_build/sql && /usr/bin/x86_64-pc-linux-gnu-g++ -DHAVE_CONFIG_H -DHAVE_TLSv13 -DLZ4_DISABLE_DEPRECATE_WARNINGS -DMYSQL_SERVER -DRAPIDJSON_NO_SIZETYPEDEFINE -DRAPIDJSON_SCHEMA_USE_INTERNALREGEX=0 -DRAPIDJSON_SCHEMA_USE_STDREGEX=1 -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D_USE_MATH_DEFINES -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I/var/tmp/portage/dev-db/mysql-8.0.22/work/mysql-8.0.22_build -I/var/tmp/portage/dev-db/mysql-8.0.22/work/mysql-8.0.22_build/include -I/var/tmp/portage/dev-db/mysql-8.0.22/work/mysql -I/var/tmp/portage/dev-db/mysql-8.0.22/work/mysql/include -isystem /var/tmp/portage/dev-db/mysql-8.0.22/work/mysql/extra/rapidjson/include -isystem /var/tmp/portage/dev-db/mysql-8.0.22/work/mysql/extra/libedit/libedit-20190324-3.1/src/editline -isystem /var/tmp/portage/dev-db/mysql-8.0.22/work/mysql/include/boost_1_73_0/patches -isystem /var/tmp/portage/dev-db/mysql-8.0.22/work/mysql/boost/boost_1_73_0  -march=skylake -O2 -pipe -felide-constructors -fno-strict-aliasing -Wall -Wextra -Wformat-security -Wvla -Wundef -Wmissing-format-attribute -Woverloaded-virtual -Wcast-qual -Wimplicit-fallthrough=2 -Wstringop-truncation -Wsuggest-override -Wlogical-op -DDBUG_OFF -DNDEBUG -fPIC -Wshadow=local -o CMakeFiles/sql_main.dir/opt_hints.cc.o -c /var/tmp/portage/dev-db/mysql-8.0.22/work/mysql/sql/opt_hints.cc
make[2]: *** [sql/CMakeFiles/sql_main.dir/build.make:1331: sql/CMakeFiles/sql_main.dir/mysqld.cc.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[2]: Leaving directory '/var/tmp/portage/dev-db/mysql-8.0.22/work/mysql-8.0.22_build'
make[1]: *** [CMakeFiles/Makefile2:7788: sql/CMakeFiles/sql_main.dir/all] Error 2
make[1]: Leaving directory '/var/tmp/portage/dev-db/mysql-8.0.22/work/mysql-8.0.22_build'
make: *** [Makefile:171: all] Error 2
```