### PR TITLE
InnoDB: Include thread number in message about per thread file checks

### DIFF
--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -11381,7 +11381,8 @@ void Tablespace_dirs::duplicate_check(const Const_iter &start,
   }
 
   if (printed_msg) {
-    ib::info(ER_IB_MSG_376) << "Checked " << count << " files";
+    ib::info(ER_IB_MSG_376) << "Thread# " << thread_id
+                            << " - Finished checking " << count << " files";
   }
 }
 


### PR DESCRIPTION
Example of this issue:
```
2020-12-30T07:08:06.545750Z 0 [Note] [MY-012200] [InnoDB] Thread# 6 - Checked 17119/17789 files
2020-12-30T07:08:06.547361Z 0 [Note] [MY-012200] [InnoDB] Thread# 2 - Checked 17281/17789 files
2020-12-30T07:08:06.548703Z 0 [Note] [MY-012200] [InnoDB] Thread# 3 - Checked 16753/17789 files
2020-12-30T07:08:06.549908Z 0 [Note] [MY-012200] [InnoDB] Thread# 1 - Checked 16685/17789 files
2020-12-30T07:08:06.551128Z 0 [Note] [MY-012200] [InnoDB] Thread# 7 - Checked 16737/17789 files
2020-12-30T07:08:06.552367Z 0 [Note] [MY-012200] [InnoDB] Thread# 0 - Checked 16686/17789 files
2020-12-30T07:08:12.464921Z 0 [Note] [MY-012201] [InnoDB] Checked 17789 files
2020-12-30T07:08:13.731848Z 0 [Note] [MY-012201] [InnoDB] Checked 17789 files
2020-12-30T07:08:13.822747Z 0 [Note] [MY-012201] [InnoDB] Checked 17789 files
2020-12-30T07:08:15.349944Z 0 [Note] [MY-012201] [InnoDB] Checked 17789 files
2020-12-30T07:08:15.843490Z 0 [Note] [MY-012201] [InnoDB] Checked 17789 files
2020-12-30T07:08:16.533903Z 0 [Note] [MY-012200] [InnoDB] Thread# 11 - Checked 17655/17789 files
2020-12-30T07:08:16.535349Z 0 [Note] [MY-012200] [InnoDB] Thread# 15 - Checked 17031/17789 files
2020-12-30T07:08:16.536611Z 0 [Note] [MY-012200] [InnoDB] Thread# 13 - Checked 17237/17789 files
2020-12-30T07:08:16.537930Z 0 [Note] [MY-012200] [InnoDB] Thread# 4 - Checked 17597/17789 files
2020-12-30T07:08:16.539372Z 0 [Note] [MY-012200] [InnoDB] Thread# 3 - Checked 17379/17789 files
2020-12-30T07:08:16.540635Z 0 [Note] [MY-012200] [InnoDB] Thread# 5 - Checked 17578/17789 files
2020-12-30T07:08:16.544324Z 0 [Note] [MY-012200] [InnoDB] Thread# 14 - Checked 17448/17789 files
2020-12-30T07:08:16.545586Z 0 [Note] [MY-012200] [InnoDB] Thread# 1 - Checked 17240/17789 files
2020-12-30T07:08:16.552261Z 0 [Note] [MY-012200] [InnoDB] Thread# 7 - Checked 17403/17789 files
2020-12-30T07:08:16.570306Z 0 [Note] [MY-012200] [InnoDB] Thread# 8 - Checked 17755/17789 files
2020-12-30T07:08:16.582861Z 0 [Note] [MY-012200] [InnoDB] Thread# 0 - Checked 17441/17789 files
2020-12-30T07:08:17.070937Z 0 [Note] [MY-012201] [InnoDB] Checked 17789 files
2020-12-30T07:08:18.101477Z 0 [Note] [MY-012201] [InnoDB] Checked 17789 files
2020-12-30T07:08:18.623328Z 0 [Note] [MY-012201] [InnoDB] Checked 17789 files
2020-12-30T07:08:18.742400Z 0 [Note] [MY-012201] [InnoDB] Checked 17789 files
2020-12-30T07:08:19.724419Z 0 [Note] [MY-012201] [InnoDB] Checked 17789 files
2020-12-30T07:08:19.770295Z 0 [Note] [MY-012201] [InnoDB] Checked 17789 files
2020-12-30T07:08:19.785911Z 0 [Note] [MY-012201] [InnoDB] Checked 17789 files
2020-12-30T07:08:19.961705Z 0 [Note] [MY-012201] [InnoDB] Checked 17789 files
2020-12-30T07:08:21.048092Z 0 [Note] [MY-012201] [InnoDB] Checked 17789 files
2020-12-30T07:08:21.094791Z 0 [Note] [MY-012201] [InnoDB] Checked 17789 files
2020-12-30T07:08:24.856984Z 0 [Note] [MY-012201] [InnoDB] Checked 17789 files
```

Here there is a thread number included in the progress messages, but not in the final
message, which makes it difficult to identify from which thread the message originates.