### PR TITLE
Fix tiny typo in docs related to Corking

### DIFF
--- a/plugin/x/protocol/doc/mysqlx-protocol-implementation.dox
+++ b/plugin/x/protocol/doc/mysqlx-protocol-implementation.dox
@@ -168,7 +168,7 @@ On Unix this is handled by ``writev(2)``, on Windows exists
 
 @par Corking
 
-Further control about how when to actual send data to the other endpoint
+Further control about how and when to actually send data to the other endpoint
 can be achieved with "corking":
 
 -  linux: ``TCP_CORK`` http://linux.die.net/man/7/tcp


### PR DESCRIPTION
A minor change to the text which looks it needs fixing.