### PR TITLE
fix: error: no matching function for call to 'my_atomic_store64'

### DIFF
--- a/sql/locks/shared_spin_lock.cc
+++ b/sql/locks/shared_spin_lock.cc
@@ -239,7 +239,7 @@ lock::Shared_spin_lock &lock::Shared_spin_lock::try_or_spin_exclusive_lock(
   {
     this->spin_exclusive_lock();
   }
-  my_atomic_store64(&this->m_exclusive_owner, self);
+  my_atomic_store64(&this->m_exclusive_owner, int64(self));
   return (*this);
 }
 


### PR DESCRIPTION
The build fails with clang on macOS.

```
2021-01-25T21:02:44.4854840Z [ 52%] Building CXX object sql/CMakeFiles/sqlgunitlib.dir/locks/shared_spin_lock.cc.o
2021-01-25T21:02:45.3935320Z /Users/runner/work/_temp/mysql-server-mysql-5.7.33/sql/locks/shared_spin_lock.cc:242:3: error: no matching function for call to 'my_atomic_store64'
2021-01-25T21:02:45.3979580Z   my_atomic_store64(&this->m_exclusive_owner, self);
2021-01-25T21:02:45.3983160Z   ^~~~~~~~~~~~~~~~~
2021-01-25T21:02:45.4089000Z /Users/runner/work/_temp/mysql-server-mysql-5.7.33/include/atomic/gcc_atomic.h:91:20: note: candidate function not viable: no known conversion from 'my_thread_t' (aka '_opaque_pthread_t *') to 'int64' (aka 'long long') for 2nd argument
2021-01-25T21:02:45.4090340Z static inline void my_atomic_store64(int64 volatile *a, int64 v)
2021-01-25T21:02:45.4090780Z                    ^
2021-01-25T21:02:45.4091110Z 1 error generated.
2021-01-25T21:02:45.4138100Z make[2]: *** [sql/CMakeFiles/sqlgunitlib.dir/locks/shared_spin_lock.cc.o] Error 1
2021-01-25T21:02:45.4140300Z make[1]: *** [sql/CMakeFiles/sqlgunitlib.dir/all] Error 2
2021-01-25T21:02:45.4141340Z make[1]: *** Waiting for unfinished jobs....
```

full build log is here: https://github.com/shogo82148/actions-setup-mysql/runs/1764882372?check_suite_focus=true
