### PR TITLE
correct wrong debug assert in cmp_rec_rec_simple

### DIFF
--- a/storage/innobase/rem/rem0cmp.cc
+++ b/storage/innobase/rem/rem0cmp.cc
@@ -936,7 +936,7 @@ int cmp_rec_rec_simple(const rec_t *rec1, const rec_t *rec2,
   bool null_eq = false;
 
   ut_ad(rec_offs_n_fields(offsets1) >= n_uniq);
-  ut_ad(rec_offs_n_fields(offsets2) == rec_offs_n_fields(offsets2));
+  ut_ad(rec_offs_n_fields(offsets1) == rec_offs_n_fields(offsets2));
 
   ut_ad(rec_offs_comp(offsets1) == rec_offs_comp(offsets2));
 


### PR DESCRIPTION
The debug assertion wil be no effect since two params are exactly the same.
This must be a typo.