### PR TITLE
[bugfix] alter table crash when ddl log lost

### DIFF
--- a/storage/innobase/row/row0mysql.cc
+++ b/storage/innobase/row/row0mysql.cc
@@ -2855,6 +2855,14 @@ error_handling:
     case DB_SUCCESS:
     case DB_IO_NO_PUNCH_HOLE_FS:
       break;
+    case DB_ERROR:
+      mutex_enter(&dict_sys->mutex);
+
+      dict_table_remove_from_cache(table);
+
+      mutex_exit(&dict_sys->mutex);
+
+      break;
 
     case DB_OUT_OF_FILE_SPACE:
     case DB_TOO_MANY_CONCURRENT_TRXS:


### PR DESCRIPTION
if mysqld run in non-file-per-table mode, alter table may
lead to mysqld crashed when ddl log get lost