### PR TITLE
innodb_dedicated_server = 1 with VM with 2GB of RAM causes startup to fail

### DIFF
--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -4270,8 +4270,8 @@ static int innodb_log_file_size_init() {
             var_name_log_files,
             static_cast<unsigned int>(strlen(var_name_log_files)), &source)) {
       if (source == COMPILED) {
-        if (auto_buf_pool_size_in_gb < 1.0) {
-          ;
+        if (auto_buf_pool_size_in_gb < 2.0) {
+          srv_n_log_files = 2;
         } else if (auto_buf_pool_size_in_gb < 8.0) {
           srv_n_log_files = static_cast<ulong>(round(auto_buf_pool_size_in_gb));
         } else if (auto_buf_pool_size_in_gb <= 128.0) {


### PR DESCRIPTION
If the VM has 2GB of RAM, and you use the innodb_dedicated_server = 1 declaration, then the server fails to boot as it only creates a single log file.
This is because the current code doesn't cater for when the automatic buffer pool size is set to 1GB.
The amended code ensures that at least 2 log files are created.