### PR TITLE
Make blackhole max index key length comparable to InnoDB

### DIFF
--- a/storage/blackhole/ha_blackhole.h
+++ b/storage/blackhole/ha_blackhole.h
@@ -71,7 +71,7 @@ class ha_blackhole : public handler {
   /* The following defines can be increased if necessary */
 #define BLACKHOLE_MAX_KEY 64     /* Max allowed keys */
 #define BLACKHOLE_MAX_KEY_SEG 16 /* Max segments for key */
-#define BLACKHOLE_MAX_KEY_LENGTH 1000
+#define BLACKHOLE_MAX_KEY_LENGTH 3072
   uint max_supported_keys() const override { return BLACKHOLE_MAX_KEY; }
   uint max_supported_key_length() const override {
     return BLACKHOLE_MAX_KEY_LENGTH;


### PR DESCRIPTION
Currently the maximum index key length for an InnoDB table is 3072 bytes.
We typically use the Blackhole storage engine on various replicas with low storage space, or other requirements.
The expectation is there that you should be able to run an ALTER TABLE ... ENGINE=BLACKHOLE; command without issues on any InnoDB table. However, if the index length is > 1000 bytes this fails.
This PR aligns the maximum key length with the InnoDB storage engine.