### PR TITLE
Add default variable value information to performance_schema.variable…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ source_downloads
 
 # Configuration files for Visual Studio Code
 .vscode/
+
+# CLion config and build files
+.idea/
+cmake-build-debug/

--- a/storage/perfschema/pfs_variable.cc
+++ b/storage/perfschema/pfs_variable.cc
@@ -555,6 +555,7 @@ System_variable::System_variable()
       m_path_length(0),
       m_min_value_length(0),
       m_max_value_length(0),
+      m_default_value_length(0),
       m_set_time(0),
       m_set_user_str_length(0),
       m_set_host_str_length(0),
@@ -563,6 +564,7 @@ System_variable::System_variable()
   m_path_str[0] = '\0';
   m_min_value_str[0] = '\0';
   m_max_value_str[0] = '\0';
+  m_default_value_str[0] = '\0';
   m_set_user_str[0] = '\0';
   m_set_host_str[0] = '\0';
 }
@@ -582,6 +584,7 @@ System_variable::System_variable(THD *target_thd, const SHOW_VAR *show_var,
       m_path_length(0),
       m_min_value_length(0),
       m_max_value_length(0),
+      m_default_value_length(0),
       m_set_time(0),
       m_set_user_str_length(0),
       m_set_host_str_length(0),
@@ -590,6 +593,7 @@ System_variable::System_variable(THD *target_thd, const SHOW_VAR *show_var,
   m_path_str[0] = '\0';
   m_min_value_str[0] = '\0';
   m_max_value_str[0] = '\0';
+  m_default_value_str[0] = '\0';
   m_set_user_str[0] = '\0';
   m_set_host_str[0] = '\0';
   init(target_thd, show_var, query_scope);
@@ -609,6 +613,7 @@ System_variable::System_variable(THD *target_thd, const SHOW_VAR *show_var)
       m_path_length(0),
       m_min_value_length(0),
       m_max_value_length(0),
+      m_default_value_length(0),
       m_set_time(0),
       m_set_user_str_length(0),
       m_set_host_str_length(0),
@@ -617,6 +622,7 @@ System_variable::System_variable(THD *target_thd, const SHOW_VAR *show_var)
   m_path_str[0] = '\0';
   m_min_value_str[0] = '\0';
   m_max_value_str[0] = '\0';
+  m_default_value_str[0] = '\0';
   m_set_user_str[0] = '\0';
   m_set_host_str[0] = '\0';
   init(target_thd, show_var);
@@ -698,6 +704,14 @@ void System_variable::init(THD *target_thd, const SHOW_VAR *show_var) {
   m_charset = system_var->charset(target_thd);
   m_type = system_var->show_type();
   m_scope = system_var->scope();
+  const CHARSET_INFO *fromcs;
+  char val_buf[1024];
+  size_t def_str_len;
+  bool is_null = false;
+  const char * var_default = get_one_variable(current_thread, show_var,
+                                             OPT_DEFAULT, show_var->type,
+                                             nullptr, &fromcs, val_buf,
+                                             &def_str_len, &is_null);
 
   m_value_str[0] = '\0';
   m_value_length = 0;
@@ -720,6 +734,9 @@ void System_variable::init(THD *target_thd, const SHOW_VAR *show_var) {
   snprintf(m_max_value_str, sizeof(m_max_value_str), "%llu",
            system_var->get_max_value());
   m_max_value_length = strlen(m_max_value_str);
+  snprintf(m_default_value_str, sizeof(m_default_value_str), "%s",
+           var_default);
+  m_default_value_length = strlen(m_default_value_str);
 
   m_set_time = system_var->get_timestamp();
   m_set_user_str_length = strlen(system_var->get_user());

--- a/storage/perfschema/pfs_variable.h
+++ b/storage/perfschema/pfs_variable.h
@@ -187,6 +187,8 @@ class System_variable {
   size_t m_min_value_length;
   char m_max_value_str[SHOW_VAR_FUNC_BUFF_SIZE + 1];
   size_t m_max_value_length;
+  char m_default_value_str[SHOW_VAR_FUNC_BUFF_SIZE + 1];
+  size_t m_default_value_length;
   ulonglong m_set_time;
   char m_set_user_str[USERNAME_LENGTH];
   size_t m_set_user_str_length;

--- a/storage/perfschema/table_variables_info.cc
+++ b/storage/perfschema/table_variables_info.cc
@@ -58,6 +58,7 @@ Plugin_table table_variables_info::m_table_def(
     "  VARIABLE_PATH varchar(1024),\n"
     "  MIN_VALUE varchar(64),\n"
     "  MAX_VALUE varchar(64),\n"
+    "  DEFAULT_VALUE varchar(1024),\n"
     "  SET_TIME TIMESTAMP(6) default null,\n"
     "  SET_USER CHAR(32) collate utf8mb4_bin default null,\n"
     "  SET_HOST CHAR(255) CHARACTER SET ASCII default null\n",
@@ -157,6 +158,10 @@ int table_variables_info::make_row(const System_variable *system_var) {
          system_var->m_max_value_length);
   m_row.m_max_value_length = system_var->m_max_value_length;
 
+  memcpy(m_row.m_default_value, system_var->m_default_value_str,
+         system_var->m_default_value_length);
+  m_row.m_default_value_length = system_var->m_default_value_length;
+
   m_row.m_set_time = system_var->m_set_time;
 
   memcpy(m_row.m_set_user_str, system_var->m_set_user_str,
@@ -200,14 +205,18 @@ int table_variables_info::read_row_values(TABLE *table, unsigned char *buf,
           set_field_varchar_utf8(f, m_row.m_max_value,
                                  m_row.m_max_value_length);
           break;
-        case 5: /* SET_TIME */
+        case 5: /* DEFAULT_VALUE */
+          set_field_varchar_utf8(f, m_row.m_default_value,
+                                 m_row.m_default_value_length);
+          break;
+        case 6: /* SET_TIME */
           if (m_row.m_set_time != 0) {
             set_field_timestamp(f, m_row.m_set_time);
           } else {
             f->set_null();
           }
           break;
-        case 6: /* SET_USER */
+        case 7: /* SET_USER */
           if (m_row.m_set_user_str_length != 0) {
             set_field_char_utf8(f, m_row.m_set_user_str,
                                 m_row.m_set_user_str_length);
@@ -215,7 +224,7 @@ int table_variables_info::read_row_values(TABLE *table, unsigned char *buf,
             f->set_null();
           }
           break;
-        case 7: /* SET_HOST */
+        case 8: /* SET_HOST */
           if (m_row.m_set_host_str_length != 0) {
             set_field_char_utf8(f, m_row.m_set_host_str,
                                 m_row.m_set_host_str_length);

--- a/storage/perfschema/table_variables_info.h
+++ b/storage/perfschema/table_variables_info.h
@@ -62,6 +62,9 @@ struct row_variables_info {
   /** Column MAX_VALUE. */
   char m_max_value[COL_SOURCE_SIZE];
   uint m_max_value_length;
+  /** Column DEFAULT_VALUE. */
+  char m_default_value[COL_INFO_SIZE];
+  uint m_default_value_length;
   /** Column SET_TIME. */
   ulonglong m_set_time;
   /** Column SET_USER. */


### PR DESCRIPTION
This PR addresses the feature request reported under [bug #103779](https://bugs.mysql.com/bug.php?id=103779). Basically, it allows the client to obtain information about the default value of all variables.

It does so by adding column `default_value` to `performance_schema.variables_info`:

```sql
mysql> select variable_name, default_value from variables_info where variable_name = 'autocommit';
+---------------+---------------+
| variable_name | default_value |
+---------------+---------------+
| autocommit    | ON            |
+---------------+---------------+
1 row in set (0.00 sec)

mysql> select variable_name, default_value from variables_info where variable_name = 'innodb_buffer_pool_size';
+-------------------------+---------------+
| variable_name           | default_value |
+-------------------------+---------------+
| innodb_buffer_pool_size | 134217728     |
+-------------------------+---------------+
1 row in set (0.01 sec)
```