### PR TITLE
Memleaks fixes

### DIFF
--- a/components/library_mysys/my_memory.cc
+++ b/components/library_mysys/my_memory.cc
@@ -72,6 +72,8 @@ extern "C" void *my_malloc(PSI_memory_key key, size_t size, int flags) {
     mh->m_key = PSI_MEMORY_CALL(memory_alloc)(key, size, &mh->m_owner);
     user_ptr = HEADER_TO_USER(mh);
     MEM_MALLOCLIKE_BLOCK(user_ptr, size, 0, (flags & MY_ZEROFILL));
+	  
+    free(mh);
     return user_ptr;
   }
   return nullptr;

--- a/plugin/innodb_memcached/innodb_memcache/cache-src/default_engine.c
+++ b/plugin/innodb_memcached/innodb_memcache/cache-src/default_engine.c
@@ -201,6 +201,9 @@ ENGINE_ERROR_CODE create_instance(uint64_t interface,
    *engine = default_engine;
 
    *handle = (ENGINE_HANDLE*)&engine->engine;
+	
+   free(engine);
+
    return ENGINE_SUCCESS;
 }
 

--- a/plugin/innodb_memcached/innodb_memcache/src/innodb_engine.cc
+++ b/plugin/innodb_memcached/innodb_memcache/src/innodb_engine.cc
@@ -291,6 +291,8 @@ create_instance(
 
   *handle = (ENGINE_HANDLE *)&innodb_eng->engine;
 
+  free(engine);
+
   return (ENGINE_SUCCESS);
 }
 static void innodb_close_cursors(innodb_conn_data_t *conn_data) {


### PR DESCRIPTION
- Fix innodb_engine create_instance innodb_eng unfreed pointer.
- Fix default_engine create_instance engine unfreed pointer.
- Fix library_mysys my_alloc mh unfreed pointer.