### PR TITLE
Fix srv_buf_pool_def_size

### DIFF
--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -385,7 +385,7 @@ ulint srv_buf_pool_size = ULINT_MAX;
 /** Minimum pool size in bytes */
 const ulint srv_buf_pool_min_size = 5 * 1024 * 1024;
 /** Default pool size in bytes */
-const ulint srv_buf_pool_def_size = 128 * 1024 * 1024;
+const ulint srv_buf_pool_def_size = 1024 * 1024 * 1024;
 /** Maximum pool size in bytes */
 const longlong srv_buf_pool_max_size = LLONG_MAX;
 /** Requested buffer pool chunk size. Each buffer pool instance consists


### PR DESCRIPTION
srv_buf_pool_def_size was set to 128MB on 11 Jun 2015 
but according to my Sysbench test, 1GB(1024*1024*1024) of default buf_pool_size was about 4~5 times much faster than 128MB(128*1024*1024).
![image](https://user-images.githubusercontent.com/46064193/119937947-92aa5b80-bfc6-11eb-892d-c251f44f7476.png)
