### PR TITLE
Download Boost from Artifactory

### DIFF
--- a/cmake/boost.cmake
+++ b/cmake/boost.cmake
@@ -41,7 +41,7 @@
 SET(BOOST_PACKAGE_NAME "boost_1_73_0")
 SET(BOOST_TARBALL "${BOOST_PACKAGE_NAME}.tar.gz")
 SET(BOOST_DOWNLOAD_URL
-  "https://dl.bintray.com/boostorg/release/1.73.0/source/${BOOST_TARBALL}"
+  "https://boostorg.jfrog.io/artifactory/main/release/1.73.0/source/${BOOST_TARBALL}"
   )
 
 SET(OLD_PACKAGE_NAMES


### PR DESCRIPTION
[Bintray is gone](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/) and Boost has migrated over to a jfrog.io Artifactory instance. This fixes the download URL so that the -DDOWNLOAD_BOOST functionality works.

I have signed the Oracle CLA.