### PR TITLE
fix for replication , because sub_iv may be NULL in extreme scenario

### DIFF
--- a/sql/rpl_gtid_set.cc
+++ b/sql/rpl_gtid_set.cc
@@ -1148,6 +1148,9 @@ bool Gtid_set::is_interval_subset(Const_interval_iterator *sub,
   */
   do
   {
+    if (sub_iv == NULL)
+      DBUG_RETURN(true);
+
     if (super_iv == NULL)
       DBUG_RETURN(false);
 


### PR DESCRIPTION
fix for replication , because sub_iv may be NULL in extreme scenario