### PR TITLE
enable multi-valued index in view

### DIFF
--- a/mysql-test/r/multi-valued-index-in-view.result
+++ b/mysql-test/r/multi-valued-index-in-view.result
@@ -1,0 +1,61 @@
+DROP TABLE IF EXISTS t1;
+DROP VIEW IF EXISTS v1;
+CREATE TABLE t1 (
+f1 VARCHAR(50) NOT NULL PRIMARY KEY,
+f2 JSON NOT NULL,
+INDEX idx2 ( (CAST(f2 AS CHAR(50) ARRAY)) )
+);
+CREATE VIEW v1 AS
+SELECT * FROM t1, JSON_TABLE(f2, '$[*]' COLUMNS(i FOR ORDINALITY, id VARCHAR(50) PATH '$')) AS ids;
+INSERT INTO t1 VALUES ('foo', '["aa", "bb"]');
+INSERT INTO t1 VALUES ('bar', '["xx", "yy"]');
+SELECT * FROM t1;
+f1	f2
+bar	["xx", "yy"]
+foo	["aa", "bb"]
+EXPLAIN SELECT * FROM t1 WHERE 'xx' member of (f2);
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	NULL	ref	idx2	idx2	203	const	1	100.00	Using where
+EXPLAIN SELECT * FROM t1 WHERE json_contains(f2, '"xx"');
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	NULL	range	idx2	idx2	203	NULL	1	100.00	Using where
+EXPLAIN SELECT * FROM v1 WHERE 'xx' member of (f2);
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	NULL	ref	idx2	idx2	203	const	1	100.00	Using where
+1	SIMPLE	ids	NULL	ALL	NULL	NULL	NULL	NULL	2	100.00	Table function: json_table; Using temporary
+EXPLAIN SELECT * FROM v1 WHERE json_contains(f2, '"xx"');
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	NULL	range	idx2	idx2	203	NULL	1	100.00	Using where
+1	SIMPLE	ids	NULL	ALL	NULL	NULL	NULL	NULL	2	100.00	Table function: json_table; Using temporary
+EXPLAIN SELECT * FROM t1, JSON_TABLE(f2, '$[*]' COLUMNS(i FOR ORDINALITY, id VARCHAR(50) PATH '$')) AS ids WHERE 'xx' member of (f2);
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	NULL	ref	idx2	idx2	203	const	1	100.00	Using where
+1	SIMPLE	ids	NULL	ALL	NULL	NULL	NULL	NULL	2	100.00	Table function: json_table; Using temporary
+EXPLAIN SELECT * FROM t1, JSON_TABLE(f2, '$[*]' COLUMNS(i FOR ORDINALITY, id VARCHAR(50) PATH '$')) AS ids WHERE json_contains(f2, '"xx"');
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	NULL	range	idx2	idx2	203	NULL	1	100.00	Using where
+1	SIMPLE	ids	NULL	ALL	NULL	NULL	NULL	NULL	2	100.00	Table function: json_table; Using temporary
+SELECT * FROM t1 WHERE 'xx' member of (f2);
+f1	f2
+bar	["xx", "yy"]
+SELECT * FROM t1 WHERE json_contains(f2, '"xx"');
+f1	f2
+bar	["xx", "yy"]
+SELECT * FROM v1 WHERE 'xx' member of (f2);
+f1	f2	i	id
+bar	["xx", "yy"]	1	xx
+bar	["xx", "yy"]	2	yy
+SELECT * FROM v1 WHERE json_contains(f2, '"xx"');
+f1	f2	i	id
+bar	["xx", "yy"]	1	xx
+bar	["xx", "yy"]	2	yy
+SELECT * FROM t1, JSON_TABLE(f2, '$[*]' COLUMNS(i FOR ORDINALITY, id VARCHAR(50) PATH '$')) AS ids WHERE 'xx' member of (f2);
+f1	f2	i	id
+bar	["xx", "yy"]	1	xx
+bar	["xx", "yy"]	2	yy
+SELECT * FROM t1, JSON_TABLE(f2, '$[*]' COLUMNS(i FOR ORDINALITY, id VARCHAR(50) PATH '$')) AS ids WHERE json_contains(f2, '"xx"');
+f1	f2	i	id
+bar	["xx", "yy"]	1	xx
+bar	["xx", "yy"]	2	yy
+DROP TABLE t1;
+DROP VIEW v1;

--- a/mysql-test/t/multi-valued-index-in-view.test
+++ b/mysql-test/t/multi-valued-index-in-view.test
@@ -1,0 +1,37 @@
+--disable_warnings
+
+DROP TABLE IF EXISTS t1;
+DROP VIEW IF EXISTS v1;
+
+CREATE TABLE t1 (
+  f1 VARCHAR(50) NOT NULL PRIMARY KEY,
+  f2 JSON NOT NULL,
+  INDEX idx2 ( (CAST(f2 AS CHAR(50) ARRAY)) )
+);
+
+CREATE VIEW v1 AS
+  SELECT * FROM t1, JSON_TABLE(f2, '$[*]' COLUMNS(i FOR ORDINALITY, id VARCHAR(50) PATH '$')) AS ids;
+
+INSERT INTO t1 VALUES ('foo', '["aa", "bb"]');
+INSERT INTO t1 VALUES ('bar', '["xx", "yy"]');
+
+SELECT * FROM t1;
+
+EXPLAIN SELECT * FROM t1 WHERE 'xx' member of (f2);
+EXPLAIN SELECT * FROM t1 WHERE json_contains(f2, '"xx"');
+EXPLAIN SELECT * FROM v1 WHERE 'xx' member of (f2);
+EXPLAIN SELECT * FROM v1 WHERE json_contains(f2, '"xx"');
+EXPLAIN SELECT * FROM t1, JSON_TABLE(f2, '$[*]' COLUMNS(i FOR ORDINALITY, id VARCHAR(50) PATH '$')) AS ids WHERE 'xx' member of (f2);
+EXPLAIN SELECT * FROM t1, JSON_TABLE(f2, '$[*]' COLUMNS(i FOR ORDINALITY, id VARCHAR(50) PATH '$')) AS ids WHERE json_contains(f2, '"xx"');
+
+SELECT * FROM t1 WHERE 'xx' member of (f2);
+SELECT * FROM t1 WHERE json_contains(f2, '"xx"');
+SELECT * FROM v1 WHERE 'xx' member of (f2);
+SELECT * FROM v1 WHERE json_contains(f2, '"xx"');
+SELECT * FROM t1, JSON_TABLE(f2, '$[*]' COLUMNS(i FOR ORDINALITY, id VARCHAR(50) PATH '$')) AS ids WHERE 'xx' member of (f2);
+SELECT * FROM t1, JSON_TABLE(f2, '$[*]' COLUMNS(i FOR ORDINALITY, id VARCHAR(50) PATH '$')) AS ids WHERE json_contains(f2, '"xx"');
+
+DROP TABLE t1;
+DROP VIEW v1;
+
+--enable_warnings

--- a/sql/item.cc
+++ b/sql/item.cc
@@ -7040,7 +7040,7 @@ bool Item::cache_const_expr_analyzer(uchar **arg) {
 }
 
 bool Item::can_be_substituted_for_gc(bool array) const {
-  switch (type()) {
+  switch (const_cast<Item *>(this)->real_item()->type()) {
     case FUNC_ITEM:
     case COND_ITEM:
       return true;

--- a/sql/item_func.cc
+++ b/sql/item_func.cc
@@ -908,6 +908,7 @@ static bool is_function_of_type(const Item *item, Item_func::Functype type) {
 
 Item_field *get_gc_for_expr(const Item *func, Field *fld, Item_result type,
                             Field **found) {
+  func = const_cast<Item *>(func)->real_item();
   Item *expr = fld->gcol_info->expr_item;
 
   /*


### PR DESCRIPTION
REF_ITEM was not considered in Item::can_be_substituted_for_gc() and get_gc_for_expr(),
so optimizer failed to use multi-valued index in view.