### PR TITLE
Improved the expired password logging sent to the error log

### DIFF
--- a/share/messages_to_error_log.txt
+++ b/share/messages_to_error_log.txt
@@ -11404,6 +11404,9 @@ ER_WARN_AUDIT_LOG_FORMAT_UNIX_TIMESTAMP_ONLY_WHEN_JSON_LOG
 ER_PREPARE_FOR_PRIMARY_ENGINE
   eng "Retry the statement using the primary storage engine."
 
+ER_USER_LOGIN_WITH_EXPIRED_PASSWORD
+  eng "Login failed for user '%-.48s'@'%-.64s' due to an expired password."
+
 # DO NOT add server-to-client messages here;
 # they go in messages_to_clients.txt
 # in the same directory as this file.

--- a/sql/auth/sql_authentication.cc
+++ b/sql/auth/sql_authentication.cc
@@ -3598,7 +3598,8 @@ int acl_authenticate(THD *thd, enum_server_command command) {
         my_error(ER_MUST_CHANGE_PASSWORD_LOGIN, MYF(0));
         query_logger.general_log_print(
             thd, COM_CONNECT, "%s", ER_DEFAULT(ER_MUST_CHANGE_PASSWORD_LOGIN));
-        LogErr(INFORMATION_LEVEL, ER_MUST_CHANGE_EXPIRED_PASSWORD);
+        LogErr(INFORMATION_LEVEL, ER_USER_LOGIN_WITH_EXPIRED_PASSWORD,
+               mpvio.acl_user->user, mpvio.auth_info.host_or_ip);
 
         errors.m_authentication = 1;
         inc_host_errors(mpvio.ip, &errors);


### PR DESCRIPTION
The previous text provided no information on who the user was or where it was logging in from.

Previous sample logging showed:

```
2021-07-22T10:54:09.718676Z 2671647 [Note] [MY-010928] [Server] Your password has expired. To log in you must change it using a client that supports expired passwords.
```

Modified logging shows:

```
2021-07-27T12:00:32.420060Z 105 [Note] [MY-013776] [Server] Login failed for user 'someuser'@'somehost.example.com' due to an expired password.
```

I'm not sure if anything else is needed. If so please let me know.