### PR TITLE
Use system CA roots for client if no option provided

### DIFF
--- a/sql-common/client.cc
+++ b/sql-common/client.cc
@@ -4162,20 +4162,6 @@ static int cli_establish_ssl(MYSQL *mysql) {
   }
 
   /*
-    If the ssl_mode is VERIFY_CA or VERIFY_IDENTITY, make sure that the
-    connection doesn't succeed without providing the CA certificate.
-  */
-  if (mysql->options.extension &&
-      mysql->options.extension->ssl_mode > SSL_MODE_REQUIRED &&
-      !(mysql->options.ssl_ca || mysql->options.ssl_capath)) {
-    set_mysql_extended_error(mysql, CR_SSL_CONNECTION_ERROR, unknown_sqlstate,
-                             ER_CLIENT(CR_SSL_CONNECTION_ERROR),
-                             "CA certificate is required if ssl-mode "
-                             "is VERIFY_CA or VERIFY_IDENTITY");
-    goto error;
-  }
-
-  /*
     Attempt SSL connection if ssl_mode != SSL_MODE_DISABLED and the
     server supports SSL. Fallback on unencrypted connection otherwise.
   */
@@ -4302,21 +4288,6 @@ static net_async_status cli_establish_ssl_nonblocking(MYSQL *mysql, int *res) {
                                ER_CLIENT(CR_SSL_CONNECTION_ERROR),
                                "SSL is required but the server doesn't "
                                "support it");
-      goto error;
-    }
-
-    /*
-      If the ssl_mode is VERIFY_CA or VERIFY_IDENTITY, make sure
-      that the connection doesn't succeed without providing the
-      CA certificate.
-    */
-    if (mysql->options.extension &&
-        mysql->options.extension->ssl_mode > SSL_MODE_REQUIRED &&
-        !(mysql->options.ssl_ca || mysql->options.ssl_capath)) {
-      set_mysql_extended_error(mysql, CR_SSL_CONNECTION_ERROR, unknown_sqlstate,
-                               ER_CLIENT(CR_SSL_CONNECTION_ERROR),
-                               "CA certificate is required if ssl-mode "
-                               "is VERIFY_CA or VERIFY_IDENTITY");
       goto error;
     }
 


### PR DESCRIPTION
Right now a CA chain is required to be provided in verify_ca or verify_identity mode. This makes it much more cumbersome when writing a client that connects to a server where the certificate in the system roots and when it provides a proper certificate signed by such an authority.

By falling back to the system roots, deployments are greatly simplified because it removes the need to manually specify the root chain. The root chain is highly operating system and deployment dependent, so it requires a different configuration flag on each platform.

By setting up the system roots through OpenSSL, deploying a MySQL server with a root signed installed on a system is greatly simplified for client configuration.

Many clients in other languages / on other platforms already follow a similar behavior where system roots are used if no specific CA chain is configured. This applies to for example Java, Go, Node.js, Rust & .NET.

This change also makes it simpler for drivers that use libmysqlclient such as the ones often used in Ruby and Python to simplify configuration for developers there as well.