### PR TITLE
Extend TLS/SSL functionality with SNI and using system roots

### DIFF
--- a/include/violite.h
+++ b/include/violite.h
@@ -265,7 +265,7 @@ struct st_VioSSLFd *new_VioSSLConnectorFd(
     const char *key_file, const char *cert_file, const char *ca_file,
     const char *ca_path, const char *cipher, const char *ciphersuites,
     enum enum_ssl_init_error *error, const char *crl_file, const char *crl_path,
-    const long ssl_ctx_flags, const char *server_host, bool verify_identity);
+    const long ssl_ctx_flags, const char *server_host, int verify, bool verify_identity);
 
 long process_tls_version(const char *tls_version);
 

--- a/include/violite.h
+++ b/include/violite.h
@@ -253,6 +253,7 @@ const char *sslGetErrString(enum enum_ssl_init_error err);
 
 struct st_VioSSLFd {
   SSL_CTX *ssl_context;
+  const char *hostname;
 };
 
 int sslaccept(struct st_VioSSLFd *, MYSQL_VIO, long timeout,
@@ -264,7 +265,7 @@ struct st_VioSSLFd *new_VioSSLConnectorFd(
     const char *key_file, const char *cert_file, const char *ca_file,
     const char *ca_path, const char *cipher, const char *ciphersuites,
     enum enum_ssl_init_error *error, const char *crl_file, const char *crl_path,
-    const long ssl_ctx_flags, const char *server_host);
+    const long ssl_ctx_flags, const char *server_host, bool verify_identity);
 
 long process_tls_version(const char *tls_version);
 

--- a/plugin/x/client/xconnection_impl.cc
+++ b/plugin/x/client/xconnection_impl.cc
@@ -675,8 +675,10 @@ XError Connection_impl::activate_tls() {
   auto ssl_ctx_flags = process_tls_version(
       details::null_when_empty(m_context->m_ssl_config.m_tls_version));
 
+  const int verify = m_context->m_ssl_config.m_mode >= Ssl_config::Mode::Ssl_verify_ca ? SSL_VERIFY_PEER : SSL_VERIFY_NONE;
   const bool verify_identity =
       Ssl_config::Mode::Ssl_verify_identity == m_context->m_ssl_config.m_mode;
+
   m_vioSslFd = new_VioSSLConnectorFd(
       details::null_when_empty(m_context->m_ssl_config.m_key),
       details::null_when_empty(m_context->m_ssl_config.m_cert),
@@ -686,7 +688,7 @@ XError Connection_impl::activate_tls() {
       &m_ssl_init_error,
       details::null_when_empty(m_context->m_ssl_config.m_crl),
       details::null_when_empty(m_context->m_ssl_config.m_crl_path),
-      ssl_ctx_flags, m_hostname.c_str(), verify_identity);
+      ssl_ctx_flags, m_hostname.c_str(), verify, verify_identity);
 
   if (nullptr == m_vioSslFd) return get_ssl_init_error(m_ssl_init_error);
 

--- a/plugin/x/client/xconnection_impl.cc
+++ b/plugin/x/client/xconnection_impl.cc
@@ -686,7 +686,7 @@ XError Connection_impl::activate_tls() {
       &m_ssl_init_error,
       details::null_when_empty(m_context->m_ssl_config.m_crl),
       details::null_when_empty(m_context->m_ssl_config.m_crl_path),
-      ssl_ctx_flags, verify_identity ? m_hostname.c_str() : nullptr);
+      ssl_ctx_flags, m_hostname.c_str(), verify_identity);
 
   if (nullptr == m_vioSslFd) return get_ssl_init_error(m_ssl_init_error);
 

--- a/sql-common/client.cc
+++ b/sql-common/client.cc
@@ -4227,7 +4227,7 @@ static int cli_establish_ssl(MYSQL *mysql) {
               options->extension ? options->extension->ssl_crl : nullptr,
               options->extension ? options->extension->ssl_crlpath : nullptr,
               options->extension ? options->extension->ssl_ctx_flags : 0,
-              verify_identity ? mysql->host : nullptr))) {
+              mysql->host, verify_identity))) {
       set_mysql_extended_error(mysql, CR_SSL_CONNECTION_ERROR, unknown_sqlstate,
                                ER_CLIENT(CR_SSL_CONNECTION_ERROR),
                                sslGetErrString(ssl_init_error));
@@ -4385,7 +4385,7 @@ static net_async_status cli_establish_ssl_nonblocking(MYSQL *mysql, int *res) {
                 options->extension ? options->extension->ssl_crl : nullptr,
                 options->extension ? options->extension->ssl_crlpath : nullptr,
                 options->extension ? options->extension->ssl_ctx_flags : 0,
-                verify_identity ? mysql->host : nullptr))) {
+                mysql->host, verify_identity))) {
         set_mysql_extended_error(mysql, CR_SSL_CONNECTION_ERROR,
                                  unknown_sqlstate,
                                  ER_CLIENT(CR_SSL_CONNECTION_ERROR),

--- a/vio/test-ssl.cc
+++ b/vio/test-ssl.cc
@@ -88,7 +88,8 @@ int main(int argc, char **argv) {
   ssl_acceptor =
       new_VioSSLAcceptorFd(server_key, server_cert, ca_file, ca_path, cipher);
   ssl_connector = new_VioSSLConnectorFd(client_key, client_cert, ca_file,
-                                        ca_path, cipher, &ssl_init_error);
+                                        ca_path, cipher, NULL, &ssl_init_error,
+                                        0, 0, 0, 0, false);
 
   client_vio = (Vio *)my_malloc(sizeof(Vio), MYF(0));
   client_vio->sd = sv[0];

--- a/vio/test-ssl.cc
+++ b/vio/test-ssl.cc
@@ -89,7 +89,7 @@ int main(int argc, char **argv) {
       new_VioSSLAcceptorFd(server_key, server_cert, ca_file, ca_path, cipher);
   ssl_connector = new_VioSSLConnectorFd(client_key, client_cert, ca_file,
                                         ca_path, cipher, NULL, &ssl_init_error,
-                                        0, 0, 0, 0, false);
+                                        NULL, NULL, 0, NULL, SSL_VERIFY_NONE, false);
 
   client_vio = (Vio *)my_malloc(sizeof(Vio), MYF(0));
   client_vio->sd = sv[0];

--- a/vio/test-sslclient.cc
+++ b/vio/test-sslclient.cc
@@ -63,7 +63,9 @@ int main(int argc MY_ATTRIBUTE((unused)), char **argv) {
   if (ca_path != 0) printf("CApath          : %s\n", ca_path);
 
   ssl_connector = new_VioSSLConnectorFd(client_key, client_cert, ca_file,
-                                        ca_path, cipher, &ssl_init_error);
+                                        ca_path, cipher, NULL, &ssl_init_error,
+                                        0, 0, 0, 0, false);
+
   if (!ssl_connector) {
     fatal_error("client:new_VioSSLConnectorFd failed");
   }

--- a/vio/test-sslclient.cc
+++ b/vio/test-sslclient.cc
@@ -64,7 +64,7 @@ int main(int argc MY_ATTRIBUTE((unused)), char **argv) {
 
   ssl_connector = new_VioSSLConnectorFd(client_key, client_cert, ca_file,
                                         ca_path, cipher, NULL, &ssl_init_error,
-                                        0, 0, 0, 0, false);
+                                        NULL, NULL, 0, NULL, SSL_VERIFY_NONE, false);
 
   if (!ssl_connector) {
     fatal_error("client:new_VioSSLConnectorFd failed");

--- a/vio/viossl.cc
+++ b/vio/viossl.cc
@@ -630,6 +630,11 @@ static int ssl_do(struct st_VioSSLFd *ptr, Vio *vio, long timeout,
     DBUG_PRINT("info", ("ssl: %p timeout: %ld", ssl, timeout));
     SSL_clear(ssl);
     SSL_SESSION_set_timeout(SSL_get_session(ssl), timeout);
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+    if (ptr->hostname) {
+        SSL_set_tlsext_host_name(ssl, const_cast<char *>(ptr->hostname));
+    }
+#endif
     SSL_set_fd(ssl, sd);
 #if defined(SSL_OP_NO_COMPRESSION)
     SSL_set_options(ssl, SSL_OP_NO_COMPRESSION); /* OpenSSL >= 1.0 only */

--- a/vio/viosslfactories.cc
+++ b/vio/viosslfactories.cc
@@ -801,15 +801,8 @@ struct st_VioSSLFd *new_VioSSLConnectorFd(
     const char *key_file, const char *cert_file, const char *ca_file,
     const char *ca_path, const char *cipher, const char *ciphersuites,
     enum enum_ssl_init_error *error, const char *crl_file, const char *crl_path,
-    const long ssl_ctx_flags, const char *server_host, bool verify_identity) {
+    const long ssl_ctx_flags, const char *server_host, int verify, bool verify_identity) {
   struct st_VioSSLFd *ssl_fd;
-  int verify = SSL_VERIFY_PEER;
-
-  /*
-    Turn off verification of servers certificate if both
-    ca_file and ca_path is set to NULL
-  */
-  if (ca_file == nullptr && ca_path == nullptr) verify = SSL_VERIFY_NONE;
 
   if (!(ssl_fd = new_VioSSLFd(key_file, cert_file, ca_file, ca_path, cipher,
                               ciphersuites, true, error, crl_file, crl_path,

--- a/vio/viotest-ssl.cc
+++ b/vio/viotest-ssl.cc
@@ -90,7 +90,8 @@ int main(int argc, char **argv) {
   ssl_acceptor =
       new_VioSSLAcceptorFd(server_key, server_cert, ca_file, ca_path);
   ssl_connector = new_VioSSLConnectorFd(client_key, client_cert, ca_file,
-                                        ca_path, &ssl_init_error);
+                                        ca_path, NULL, &ssl_init_error, NULL,
+                                        NULL, 0, SSL_VERIFY_NONE, false);
 
   client_vio = (Vio *)my_malloc(sizeof(Vio), MYF(0));
   client_vio->sd = sv[0];


### PR DESCRIPTION
This changes enables sending along the SNI extension to the server when connecting over TLS with a client. It's best practice these days to send SNI as a TLS client.

Usage of SNI would also enable uses cases like routing of MySQL connections to different backends behind a single IP.

This change only implements the client side parts. Server side there is also value in providing different certificates on different SNI names, for example for multi homed MySQL servers with different DNS entries to connect combined with verify_identity semantics.

At first though, clients should start sending the extension before it's useful to implement anything on the server side.

Additionally, the second commit here enables usage of the system roots when no CA file or path is configured. Right now a CA chain is required to be provided in verify_ca or verify_identity mode. This makes it much more cumbersome when writing a     client that connects to a server where the certificate in the system roots and when it provides a proper certificate signed by such an authority.

By falling back to the system roots, deployments are greatly simplified because it removes the need to manually specify the root chain. The root chain is highly operating system and deployment dependent, so it requires a different configuration flag on each platform.

By setting up the system roots through OpenSSL, deploying a MySQL server with a root signed installed on a system is greatly simplified for client configuration.

Many clients in other languages / on other platforms already follow a similar behavior where system roots are used if no specific CA chain is configured. This applies to for example Java, Go, Node.js, Rust & .NET.

This change also makes it simpler for drivers that use libmysqlclient such as the ones often used in Ruby and Python to simplify configuration for developers there as well.