### PR TITLE
fix fts_optimize_thread missing in performance_schema.threads

### DIFF
--- a/storage/innobase/fts/fts0opt.cc
+++ b/storage/innobase/fts/fts0opt.cc
@@ -2851,7 +2851,7 @@ fts_optimize_sync_table(
 Optimize all FTS tables.
 @return Dummy return */
 os_thread_ret_t
-fts_optimize_thread(
+DECLARE_THREAD(fts_optimize_thread)(
 /*================*/
 	void*		arg)			/*!< in: work queue*/
 {
@@ -2863,6 +2863,10 @@ fts_optimize_thread(
 
 	ut_ad(!srv_read_only_mode);
 	my_thread_init();
+
+#ifdef UNIV_PFS_THREAD
+    pfs_register_thread(fts_optimize_thread_key);
+#endif /* UNIV_PFS_THREAD */
 
 	ut_ad(fts_slots);
 

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -503,6 +503,7 @@ static PSI_thread_info	all_innodb_threads[] = {
 	PSI_KEY(srv_purge_thread),
 	PSI_KEY(srv_worker_thread),
 	PSI_KEY(trx_rollback_clean_thread),
+	PSI_KEY(fts_optimize_thread),
 };
 # endif /* UNIV_PFS_THREAD */
 

--- a/storage/innobase/include/srv0srv.h
+++ b/storage/innobase/include/srv0srv.h
@@ -490,6 +490,7 @@ extern mysql_pfs_key_t	srv_monitor_thread_key;
 extern mysql_pfs_key_t	srv_purge_thread_key;
 extern mysql_pfs_key_t	srv_worker_thread_key;
 extern mysql_pfs_key_t	trx_rollback_clean_thread_key;
+extern mysql_pfs_key_t	fts_optimize_thread_key;
 
 /* This macro register the current thread and its key with performance
 schema */

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -198,6 +198,7 @@ mysql_pfs_key_t	srv_master_thread_key;
 mysql_pfs_key_t	srv_monitor_thread_key;
 mysql_pfs_key_t	srv_purge_thread_key;
 mysql_pfs_key_t	srv_worker_thread_key;
+mysql_pfs_key_t	fts_optimize_thread_key;
 #endif /* UNIV_PFS_THREAD */
 
 #ifdef HAVE_PSI_STAGE_INTERFACE


### PR DESCRIPTION
fts_optimize_thread and buf_resize_thread are missing in the output of select * from performance_schema.threads.

See: https://bugs.mysql.com/bug.php?id=104582