### PR TITLE
fix buf_resize_thread missing in performance_schema.threads

### DIFF
--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -3018,6 +3018,10 @@ DECLARE_THREAD(buf_resize_thread)(
 {
 	my_thread_init();
 
+#ifdef UNIV_PFS_THREAD
+    pfs_register_thread(buf_resize_thread_key);
+#endif /* UNIV_PFS_THREAD */
+
 	srv_buf_resize_thread_active = true;
 
 	while (srv_shutdown_state == SRV_SHUTDOWN_NONE) {

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -503,6 +503,7 @@ static PSI_thread_info	all_innodb_threads[] = {
 	PSI_KEY(srv_purge_thread),
 	PSI_KEY(srv_worker_thread),
 	PSI_KEY(trx_rollback_clean_thread),
+	PSI_KEY(buf_resize_thread),
 };
 # endif /* UNIV_PFS_THREAD */
 

--- a/storage/innobase/include/srv0srv.h
+++ b/storage/innobase/include/srv0srv.h
@@ -490,6 +490,7 @@ extern mysql_pfs_key_t	srv_monitor_thread_key;
 extern mysql_pfs_key_t	srv_purge_thread_key;
 extern mysql_pfs_key_t	srv_worker_thread_key;
 extern mysql_pfs_key_t	trx_rollback_clean_thread_key;
+extern mysql_pfs_key_t	buf_resize_thread_key;
 
 /* This macro register the current thread and its key with performance
 schema */

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -198,6 +198,7 @@ mysql_pfs_key_t	srv_master_thread_key;
 mysql_pfs_key_t	srv_monitor_thread_key;
 mysql_pfs_key_t	srv_purge_thread_key;
 mysql_pfs_key_t	srv_worker_thread_key;
+mysql_pfs_key_t	buf_resize_thread_key;
 #endif /* UNIV_PFS_THREAD */
 
 #ifdef HAVE_PSI_STAGE_INTERFACE


### PR DESCRIPTION
buf_resize_thread are missing in the output of select * from performance_schema.threads.

See: https://bugs.mysql.com/bug.php?id=104583