### PR TITLE
Fix typo in header comment for alloc_copy_buffer()

### DIFF
--- a/plugin/clone/include/clone_server.h
+++ b/plugin/clone/include/clone_server.h
@@ -74,7 +74,7 @@ class Server {
   @return server thread */
   THD *get_thd() { return (m_server_thd); }
 
-  /** Allocate and return buufer for data copy
+  /** Allocate and return buffer for data copy
   @param[in]	len	buffer length
   @return allocated pointer */
   uchar *alloc_copy_buffer(uint len) {


### PR DESCRIPTION
Fix trivial minor typo in the header comment.