### PR TITLE
Fixed scientific notation bug

### DIFF
--- a/sql/sql_lex.cc
+++ b/sql/sql_lex.cc
@@ -1699,8 +1699,7 @@ static int lex_one_token(Lexer_yystype *yylval, THD *thd) {
           c = lip->yyGet();
           if (c == '-' || c == '+') c = lip->yyGet();  // Skip sign
           if (!my_isdigit(cs, c)) {                    // No digit after sign
-            state = MY_LEX_CHAR;
-            break;
+            return (ABORT_SYM);
           }
           while (my_isdigit(cs, lip->yyGet()))
             ;


### PR DESCRIPTION
## Description
There is a scientific notation bug that uses the e notation which was discovered many years ago and was used to bypass some Web Application Firewall.

With more research, I found out more use case to this bug and that it is possible to bypass modern WAF as the query seems to be invalid but is valid.

So the following query that seems to be invalid:

```
mysql> select id 1.e, char 10.e(id 2.e), concat 3.e('a'12356.e,'b'1.e,'c'1.1234e)1.e, 12 1.e*2 1.e, 12 1.e/2 1.e, 12 1.e|2 1.e, 12 1.e^2 1.e, 12 1.e%2 1.e, 12 1.e&2 from test;
+------+--------------------------------------+------------------------------------------+----------+----------+----------+----------+----------+----------+
| id   | char 10.e(id 2.e)                    | concat 3.e('a'12356.e,'b'1.e,'c'1.1234e) | 12 1.e*2 | 12 1.e/2 | 12 1.e|2 | 12 1.e^2 | 12 1.e%2 | 12 1.e&2 |
+------+--------------------------------------+------------------------------------------+----------+----------+----------+----------+----------+----------+
|    1 | 0x01                                 | abc                                      |       24 |   6.0000 |       14 |       14 |        0 |        0 |
|    2 | 0x02                                 | abc                                      |       24 |   6.0000 |       14 |       14 |        0 |        0 |
|    3 | 0x03                                 | abc                                      |       24 |   6.0000 |       14 |       14 |        0 |        0 |
+------+--------------------------------------+------------------------------------------+----------+----------+----------+----------+----------+----------+
3 rows in set (0.00 sec)
```

Is in fact valid and the same as this query:

```
mysql> select id, char(id), concat('a','b','c'), 12*2, 12/2, 12|2, 12^2, 12%2, 12&2 from test.test;
+------+--------------------+---------------------+------+--------+------+------+------+------+
| id   | char(id)           | concat('a','b','c') | 12*2 | 12/2   | 12|2 | 12^2 | 12%2 | 12&2 |
+------+--------------------+---------------------+------+--------+------+------+------+------+
|    1 | 0x01               | abc                 |   24 | 6.0000 |   14 |   14 |    0 |    0 |
|    2 | 0x02               | abc                 |   24 | 6.0000 |   14 |   14 |    0 |    0 |
|    3 | 0x03               | abc                 |   24 | 6.0000 |   14 |   14 |    0 |    0 |
+------+--------------------+---------------------+------+--------+------+------+------+------+
3 rows in set (0.00 sec)
```

The bug is that when the code think that it is a float token containing a dot and the e notion, it does a check if the following character is a digit and if not, set the state to "MY_LEX_CHAR" which is the equivalent to "MY_LEX_SKIP" and drop the token completely. Therefore, all the "1.e" that you see in the previous query are dropped from the query completely. Note that that number in front or after the dot does not matter and that the dot is mandatory for it to work.

The bug works by following any of these characters to the notation:
```
( ) . , | & % * ^ /
```

The fix should be enough to simply abort the query if no digit follows the "dot e notation". I tested it locally and it worked, however, more tests should be done to make sure it does not break anything else.

## How can this PR be tested?
Since the bug happens only with the "dot e notation" followed by any of these characters:

```
( ) . , | & % * ^ /
```

It would only require you to write a query with any of these about. Also, the query provided in the description could be used (or any part of it individually).