### PR TITLE
Fix memory leak when host_cache_size is 0.

### DIFF
--- a/sql/hostname.cc
+++ b/sql/hostname.cc
@@ -199,6 +199,9 @@ static void add_hostname_impl(const char *ip_key, const char *hostname,
 
   if (likely(entry == NULL))
   {
+    if (!hostname_cache->size())
+      return;
+
     entry= (Host_entry *) malloc(sizeof (Host_entry));
     if (entry == NULL)
       return;
@@ -264,8 +267,10 @@ static void add_hostname_impl(const char *ip_key, const char *hostname,
 
   entry->m_errors.aggregate(errors);
 
-  if (need_add)
-    hostname_cache->add(entry);
+  if (need_add && hostname_cache->add(entry))
+  {
+    free(entry);
+  }
 
   return;
 }


### PR DESCRIPTION
## MySQL version: 

**mysql  Ver 14.14 Distrib 5.7.32, for Linux (x86_64) using  EditLine wrapper**

## Background:

As described in the [documentation](https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_host_cache_size), we set `host_cache_size` to 0 instead of `--skip-host-cache`.

```
Using the --skip-host-cache option is similar to setting the host_cache_size system variable to 0, 
but host_cache_size is more flexible because it can also be used to resize, enable, and disable the host cache at 
runtime, not just at server startup. 
```

But after a long run, we found a serious memory leak. Here is the valgrind log:

```
==12835== 1,354,080 bytes in 4,030 blocks are definitely lost in loss record 2,243 of 2,281
==12835== at 0x4C2DB8F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==12835== by 0xD774F9: add_hostname_impl (hostname.cc:209)
==12835== by 0xD774F9: add_hostname(char const*, char const*, bool, Host_errors*) [clone .part.7] [clone .constprop.9] (hostname.cc:290)
==12835== by 0xD786D2: add_hostname (hash_filo.h:133)
==12835== by 0xD786D2: ip_to_hostname(sockaddr_storage*, char const*, char**, unsigned int*) (hostname.cc:1017)
==12835== by 0xBAB1A4: check_connection(THD*, bool) [clone .constprop.12] (sql_connect.cc:1234)
==12835== by 0xBACE78: login_connection (sql_connect.cc:1368)
==12835== by 0xBACE78: thd_prepare_connection(THD*, bool) (sql_connect.cc:1531)
==12835== by 0xCB71FC: handle_connection (connection_handler_per_thread.cc:319)
==12835== by 0xEC89A3: pfs_spawn_thread (pfs.cc:2198)
==12835== by 0x52476B9: start_thread (pthread_create.c:333)
==12835== by 0x713B41C: clone (clone.S:109)

==12835== LEAK SUMMARY:
==12835== definitely lost: 1,354,080 bytes in 4,030 blocks
==12835== indirectly lost: 0 bytes in 0 blocks
==12835== possibly lost: 124,136,716 bytes in 42,518 blocks
==12835== still reachable: 113,162,426 bytes in 8,313 blocks
==12835== of which reachable via heuristic:
==12835== newarray : 1,104 bytes in 2 blocks
==12835== suppressed: 0 bytes in 0 blocks
```

## Reason:

While `host_cache_size` is 0, `hostname_cache->add(entry)` will always fail, but we did not free memory of entry.