### PR TITLE
Fixed conv function max_ length bug

### DIFF
--- a/sql/item_strfunc.cc
+++ b/sql/item_strfunc.cc
@@ -3734,7 +3734,7 @@ err:
 void Item_func_conv::fix_length_and_dec()
 {
   collation.set(default_charset());
-  max_length=64;
+  fix_char_length(64);
   maybe_null= 1;
   reject_geometry_args(arg_count, args, this);
 }


### PR DESCRIPTION
The max_length of the conv function is 64 bytes. In a multi-byte characters, the result may be truncated.

### For example:

set names utf8mb4;
drop table if exists test;
create table test(id varchar(10));
insert into test values('abcdef');

#### correct result:
mysql> select conv(id, 16, 2) id from test;
+--------------------------+
| id                       |
+--------------------------+
| 101010111100110111101111 |
+--------------------------+
1 row in set (0.00 sec)

#### truncated:
mysql> select conv(id, 16, 2) id from test group by id;
+------------------+
| id               |
+------------------+
| 1010101111001101 |
+------------------+
1 row in set, 1 warning (0.00 sec)

mysql> create table tmp select conv(id, 16, 2) id from test;
ERROR 1406 (22001): Data too long for column 'id' at row 1