### PR TITLE
rpcgen.cmake: always build xdr_sizeof.c on macOS

### DIFF
--- a/plugin/group_replication/libmysqlgcs/cmake/rpcgen.cmake
+++ b/plugin/group_replication/libmysqlgcs/cmake/rpcgen.cmake
@@ -43,13 +43,10 @@ IF(WIN32)
 ENDIF()
 
 IF(APPLE)
-  # OSX missing xdr_sizeof() since clang 10.0.1.10010046
-  IF(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS "10.0.1.10010046")
-
-    SET(SUNRPC_SRCS
-      ${XCOM_BASEDIR}/windeps/sunrpc/xdr_sizeof.c
-      )
-  ENDIF()
+  # macOS 10.14 and later do not provide xdr_sizeof()
+  SET(SUNRPC_SRCS
+    ${XCOM_BASEDIR}/windeps/sunrpc/xdr_sizeof.c
+    )
 ENDIF()
 
 # Generate the RPC files if needed


### PR DESCRIPTION
The availability of `xdr_sizeof()` is dependent on the macOS version, not the compiler version; `xdr_sizeof()` was provided by macOS 10.13 and earlier through the libsystem_info.dylib system library. Rather than adjusting the check to reflect this, xdr_sizeof.c can be built unconditionally on macOS, since MySQL has dropped support for macOS 10.13 and earlier as of 2020-01-13: https://www.mysql.com/support/eol-notice.html.