### PR TITLE
BUG#106567: fix the function Item_func_in which returns incorrect result

### DIFF
--- a/mysql-test/r/func_in_datetimes.result
+++ b/mysql-test/r/func_in_datetimes.result
@@ -1,0 +1,23 @@
+DROP TABLE IF EXISTS t1;
+CREATE TABLE t1 ( pk INTEGER PRIMARY KEY, col_date date DEFAULT NULL,col_datetime datetime DEFAULT NULL, col_varchar VARCHAR(1) DEFAULT NULL, KEY (col_varchar));
+INSERT INTO t1 VALUES(5, '2022-02-25', '2022-02-25 11:01:14', 'I');
+INSERT INTO t1 VALUES(6, '2022-02-26', '2022-02-26 21:11:24', 'J');
+SELECT * FROM t1 wHERE pk = 5 AND (col_datetime, col_varchar) IN (('2022-02-25 11:01:14', 'Y'), (92, 'W'));
+pk	col_date	col_datetime	col_varchar
+Warnings:
+Warning	1292	Incorrect datetime value: '92' for column 'col_datetime' at row 1
+SELECT * FROM t1 wHERE pk = 5 AND (col_varchar, col_datetime) IN (('Y', '2022-02-25 11:01:14'), ('W', 92));
+pk	col_date	col_datetime	col_varchar
+Warnings:
+Warning	1292	Incorrect datetime value: '92' for column 'col_datetime' at row 1
+SELECT * FROM t1 wHERE pk = 5 AND (col_datetime, col_varchar) IN (('2022-02-25 11:01:14', 'I'), (92, 'W'));
+pk	col_date	col_datetime	col_varchar
+5	2022-02-25	2022-02-25 11:01:14	I
+Warnings:
+Warning	1292	Incorrect datetime value: '92' for column 'col_datetime' at row 1
+SELECT * FROM t1 wHERE pk = 5 AND (col_varchar, col_datetime) IN (('I', '2022-02-25 11:01:14'), ('W', 92));
+pk	col_date	col_datetime	col_varchar
+5	2022-02-25	2022-02-25 11:01:14	I
+Warnings:
+Warning	1292	Incorrect datetime value: '92' for column 'col_datetime' at row 1
+DROP TABLE t1;

--- a/mysql-test/t/func_in_datetimes.test
+++ b/mysql-test/t/func_in_datetimes.test
@@ -1,0 +1,19 @@
+# Bug#XXXXXX: It return the incorrect result by using function Item_func_in, 
+# when the type of field is datetime 
+--disable_warnings
+DROP TABLE IF EXISTS t1;
+--enable_warnings
+
+CREATE TABLE t1 ( pk INTEGER PRIMARY KEY, col_date date DEFAULT NULL,col_datetime datetime DEFAULT NULL, col_varchar VARCHAR(1) DEFAULT NULL, KEY (col_varchar));
+
+INSERT INTO t1 VALUES(5, '2022-02-25', '2022-02-25 11:01:14', 'I');
+INSERT INTO t1 VALUES(6, '2022-02-26', '2022-02-26 21:11:24', 'J');
+
+# 0 rows in result
+SELECT * FROM t1 wHERE pk = 5 AND (col_datetime, col_varchar) IN (('2022-02-25 11:01:14', 'Y'), (92, 'W'));
+SELECT * FROM t1 wHERE pk = 5 AND (col_varchar, col_datetime) IN (('Y', '2022-02-25 11:01:14'), ('W', 92));
+# 1 rows in result
+SELECT * FROM t1 wHERE pk = 5 AND (col_datetime, col_varchar) IN (('2022-02-25 11:01:14', 'I'), (92, 'W'));
+SELECT * FROM t1 wHERE pk = 5 AND (col_varchar, col_datetime) IN (('I', '2022-02-25 11:01:14'), ('W', 92));
+
+DROP TABLE t1; 

--- a/sql/item_cmpfunc.cc
+++ b/sql/item_cmpfunc.cc
@@ -5148,11 +5148,22 @@ bool Item_func_in::resolve_type(THD *thd) {
         Item_field *field_item = (Item_field *)(args[0]->real_item());
         if (field_item->field->can_be_compared_as_longlong()) {
           bool all_converted = true;
+
+          if (field_item->is_temporal()) {
+            all_converted = false;
+          }
+
           for (Item **arg = args + 1; arg != arg_end; arg++) {
             bool converted;
             if (convert_constant_item(thd, field_item, &arg[0], &converted))
               return true;
-            all_converted &= converted;
+            
+            if (field_item->is_temporal()) {
+              all_converted |= converted;
+            } else {
+              all_converted &= converted;
+            }
+            
           }
           if (all_converted) {
             cmp_type = INT_RESULT;

--- a/sql/item_cmpfunc.cc
+++ b/sql/item_cmpfunc.cc
@@ -4945,7 +4945,7 @@ void Item_func_in::fix_after_pullout(Query_block *parent_query_block,
 
 bool Item_func_in::resolve_type(THD *thd) {
   if (Item_func_opt_neg::resolve_type(thd)) return true;
-  bool datetime_found = false;
+  
   /* true <=> arguments values will be compared as DATETIMEs. */
   bool compare_as_datetime = false;
   Item *date_arg = nullptr;
@@ -5064,6 +5064,8 @@ bool Item_func_in::resolve_type(THD *thd) {
 
       for (uint col = 0; col < cols; col++) {
         bool skip_column = false;
+        bool datetime_found = false;
+        
         /*
           Check that all items to be compared has the STRING result type and at
           least one of them is a DATE/DATETIME item.

--- a/sql/item_cmpfunc.cc
+++ b/sql/item_cmpfunc.cc
@@ -5148,22 +5148,11 @@ bool Item_func_in::resolve_type(THD *thd) {
         Item_field *field_item = (Item_field *)(args[0]->real_item());
         if (field_item->field->can_be_compared_as_longlong()) {
           bool all_converted = true;
-
-          if (field_item->is_temporal()) {
-            all_converted = false;
-          }
-
           for (Item **arg = args + 1; arg != arg_end; arg++) {
             bool converted;
             if (convert_constant_item(thd, field_item, &arg[0], &converted))
               return true;
-            
-            if (field_item->is_temporal()) {
-              all_converted |= converted;
-            } else {
-              all_converted &= converted;
-            }
-            
+            all_converted &= converted;
           }
           if (all_converted) {
             cmp_type = INT_RESULT;


### PR DESCRIPTION
the function Item_func_in returns incorrect result where the compared field type is datetime.

mysql> CREATE TABLE t1 ( pk INTEGER PRIMARY KEY, col_date date DEFAULT NULL,col_datetime datetime DEFAULT NULL, col_varchar VARCHAR(1) DEFAULT NULL, KEY (col_varchar));

mysql> INSERT INTO t1 VALUES(5, '2022-02-25', '2022-02-25 11:01:14', 'I');

mysql> INSERT INTO t1 VALUES(6, '2022-02-26', '2022-02-26 21:11:24', 'J');

mysql> SELECT * FROM t1 wHERE pk = 5 AND (col_datetime, col_varchar) IN (('2022-02-25 11:01:14', 'Y'), (92, 'W'));
+----+------------+---------------------+-------------+
| pk | col_date   | col_datetime        | col_varchar |
+----+------------+---------------------+-------------+
|  5 | 2022-02-25 | 2022-02-25 11:01:14 | I           |
+----+------------+---------------------+-------------+

mysql> SELECT * FROM t1 wHERE pk = 5 AND (col_varchar, col_datetime) IN (('Y', '2022-02-25 11:01:14'), ('W', 92));
Empty set, 1 warning (0.00 sec)

we get incorrect result by the query: SELECT * FROM t1 wHERE pk = 5 AND (col_datetime, col_varchar) IN (('2022-02-25 11:01:14', 'Y'), (92, 'W'));

For more detailed information, please refer to [https://bugs.mysql.com/bug.php?id=106567](url)