### PR TITLE
Fix incorrect value of CACHELINESIZE on s390x

### DIFF
--- a/sql/memory/aligned_atomic.h
+++ b/sql/memory/aligned_atomic.h
@@ -35,6 +35,7 @@
 #include <windows.h>
 #elif defined(__linux__)
 #include <unistd.h>
+#include <cstdio>
 #endif
 
 namespace memory {
@@ -79,6 +80,13 @@ static inline size_t _cache_line_size() {
 static inline size_t _cache_line_size() {
   long size = sysconf(_SC_LEVEL1_DCACHE_LINESIZE);
   if (size == -1) return 64;
+  if (!size) {
+    FILE* p = fopen("/sys/devices/system/cpu/cpu0/cache/index0/coherency_line_size", "r");
+    if (p) {
+      fscanf(p, "%ld", &size);
+      fclose(p);
+    }
+  }
   return static_cast<size_t>(size);
 }
 


### PR DESCRIPTION
The `sysconf(_SC_LEVEL1_DCACHE_LINESIZE)` call which is used to get the CPU cache line size returns 0 on s390x RHEL 7.x, which is an incorrect value. This causes `rpl_commit_order_queue` and `integrals_lockfree_queue` to fail. This PR is for fixing the same.