### PR TITLE
Bug #105761:mysqldump make a non-consistent backup with --single-tran…

### DIFF
--- a/client/mysqldump.c
+++ b/client/mysqldump.c
@@ -5885,7 +5885,7 @@ static void set_session_binlog()
 
   @param[in]  mysql_con     connection to the server
 
-  @param[in]  flag          if FALST, get GTID_EXECUTED sets.
+  @param[in]  flag          if FALSE, get GTID_EXECUTED sets.
                             if TRUE, print GTID_PURGED sets 
                             to the dump file.
 


### PR DESCRIPTION
…saction option

Description: Using mysqldump to backup data with the following command:
mysqldump --single-transaction --master-data=2 >1.sql
it will lead to a backup which when restored will result in inconsistent data.

Analysis: Issue in the reported case is the following:
1. Do FTWL.
2. Start transaction with consistent snapshot.
3. Unlock table.
4. Begin data dump.
5. A new transaction commit while dumping data.
6. Finish data dump.
7. Excute `SELECT @@GLOBLE.GTID_EXCUTED`.

The data return by `mysqldump` at the state before new transaction committed.But the GTID_EXCUTED value return by `mysqldump` at the state after the new transaction committed.

The time of  excute `SELECT @@GLOBLE.GTID_EXCUTED` changed since the following pull:
https://github.com/mysql/mysql-server/commit/3bc436203a600129fa41159df03b4c92dc3bff59


Fix :Excute SELECT @@GLOBAL.GTID_EXECUTED before unlock table and store the result in memory. Print SET @@GTID_PURGED statment to dumpfile later.