### PR TITLE
Each slow log prints out the database name

### DIFF
--- a/sql/log.cc
+++ b/sql/log.cc
@@ -878,7 +878,7 @@ bool File_query_log::write_slow(THD *thd, ulonglong current_utime,
                   (ulong) thd->get_sent_row_count(),
                   (ulong) thd->get_examined_row_count()) == (uint) -1)
     goto err;
-  if (thd->db().str && strcmp(thd->db().str, db))
+  if (thd->db().str)
   {						// Database changed
     if (my_b_printf(&log_file,"use %s;\n",thd->db().str) == (uint) -1)
       goto err;


### PR DESCRIPTION
MySQL's slow log does not support rotate. So we go to rotate the slow.log by ourselves, but when we analyze the new slow.log separately, we cannot get the db of the sql because there is no use db.
E.g:
slow.log records:
use db;
select * from t1;

rotate slow.log

new slow.log records:
select * from t2;

We can't get the db of that sql from new slow.log.
