### PR TITLE
Bug#30031130: MYSQL SERVER SEGFAULTS AT

### DIFF
--- a/cmake/os/SunOS.cmake
+++ b/cmake/os/SunOS.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
 # 
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License, version 2.0,
@@ -28,6 +28,8 @@ INCLUDE(CheckCXXSourceCompiles)
 SET(SOLARIS 1)
 IF(CMAKE_SYSTEM_PROCESSOR MATCHES "sparc")
   SET(SOLARIS_SPARC 1)
+ELSE()
+  SET(SOLARIS_INTEL 1)
 ENDIF()
 
 IF (NOT "${CMAKE_C_FLAGS}${CMAKE_CXX_FLAGS}" MATCHES "-m32|-m64")

--- a/storage/ndb/CMakeLists.txt
+++ b/storage/ndb/CMakeLists.txt
@@ -93,6 +93,15 @@ SET(NDBCLUSTER_SOURCES
 # Include directories used when building ha_ndbcluster
 INCLUDE_DIRECTORIES(${CMAKE_SOURCE_DIR}/storage/ndb/include)
 
+IF(SOLARIS_INTEL)
+  # Sun Studio 12.6 on x86 machines creates a bogus code
+  # when -xO2 is used and crashes the executable whenever
+  # it calls std::condition_variable::wait_for()
+  STRING_APPEND(CMAKE_CXX_FLAGS_RELWITHDEBINFO " -xO1")
+  STRING_APPEND(CMAKE_CXX_FLAGS_RELEASE " -xO1")
+  STRING_APPEND(CMAKE_CXX_FLAGS_MINSIZEREL " -xO1")
+ENDIF()
+
 IF(NOT WITHOUT_SERVER)
   MYSQL_ADD_PLUGIN(ndbcluster ${NDBCLUSTER_SOURCES} STORAGE_ENGINE
     DEFAULT STATIC_ONLY


### PR DESCRIPTION
STD::CONDITION_VARIABLE::WAIT_FOR IN SOLARIS/X86

When a MySQL Server built with ndbcluster engine is run in a
Solaris/x86 platform, it crashes everytime when
NDB_SCHEMA_OBJECT::client_wait_completed() method is called. The
segfault happens when this method calls the
std::condition_variable::wait_for() method. This particular crash
happens only in the release builds. The reason seems to be an issue with
the compiler used in Solaris. When the optimization level -xO2 is used,
it fills the wait_for() call with a bogus code that triggers this
segfault during runtime.

Fixed the issue by making the release builds use optimization
level -xO1 for ndbcluster instead.

Change-Id: I8471970169cd971958ac2f5aa6dcb0ccd8d083a3