### PR TITLE
Bug#107462 Failed upgrade attempt to 8.0.29 corrupts the data dictionary

### DIFF
--- a/share/messages_to_error_log.txt
+++ b/share/messages_to_error_log.txt
@@ -11641,6 +11641,9 @@ ER_THREAD_POOL_DEDICATED_LISTENERS_INVALID
 ER_GRP_RPL_FAILED_TO_LOG_VIEW_CHANGE
   eng "This member was unable to log the View_change_log_event into the binary log, hence it will leave the group. Please check that there is available disk space and add the member back to the group."
 
+ER_IB_MSG_DOWNGRADING_LOG_FILE
+  eng "Upgrade failed, recreating redo logs with previous version"
+
 # DO NOT add server-to-client messages here;
 # they go in messages_to_clients.txt
 # in the same directory as this file.

--- a/sql/dd/impl/upgrade/server.cc
+++ b/sql/dd/impl/upgrade/server.cc
@@ -583,6 +583,7 @@ static bool check_tables(THD *thd, std::unique_ptr<Schema> &schema,
         }
       }
     }
+    DBUG_EXECUTE_IF("upgrade_failed_during_init", (*error_count)++;);
     return error_count->has_too_many_errors();
   };
 

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -1207,6 +1207,7 @@ bool opt_no_monitor = false;
 bool opt_no_dd_upgrade = false;
 long opt_upgrade_mode = UPGRADE_AUTO;
 bool opt_initialize = false;
+bool dd_init_failed_during_upgrade = false;
 bool opt_skip_replica_start = false;  ///< If set, slave is not autostarted
 bool opt_enable_named_pipe = false;
 bool opt_local_infile, opt_replica_compressed_protocol;
@@ -6327,6 +6328,10 @@ static int init_server_components() {
     if (!is_help_or_validate_option() &&
         dd::init(dd::enum_dd_init_type::DD_RESTART_OR_UPGRADE)) {
       LogErr(ERROR_LEVEL, ER_DD_INIT_FAILED);
+
+      if (!dd::upgrade::no_server_upgrade_required()) {
+        dd_init_failed_during_upgrade = true;
+      }
 
       /* If clone recovery fails, we rollback the files to previous
       dataset and attempt to restart server. */

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -181,6 +181,7 @@ extern MYSQL_PLUGIN_IMPORT std::atomic<int32>
 extern bool opt_no_dd_upgrade;
 extern long opt_upgrade_mode;
 extern bool opt_initialize;
+extern bool dd_init_failed_during_upgrade;
 extern bool opt_safe_user_create;
 extern bool opt_local_infile, opt_myisam_use_mmap;
 extern bool opt_replica_compressed_protocol;

--- a/storage/innobase/include/log0log.h
+++ b/storage/innobase/include/log0log.h
@@ -931,10 +931,9 @@ void log_files_header_fill(byte *buf, lsn_t start_lsn, const char *creator,
 void log_files_header_flush(log_t &log, uint32_t nth_file, lsn_t start_lsn);
 
 /** Changes format of redo files to previous format version.
-
-@note Note this will work between the two formats 5_7_9 & current because
-the only change is the version number */
-void log_files_downgrade(log_t &log);
+@param[in]      log             redo log
+@param[in]      log_format      previous format version */
+void log_files_downgrade(log_t &log, uint32_t log_format);
 
 /** Writes the next checkpoint info to header of the first log file.
 Note that two pages of the header are used alternately for consecutive


### PR DESCRIPTION
https://bugs.mysql.com/bug.php?id=107462

Problem:
Failed upgrade attempt to 8.0.29 corrupts the data dictionary
Analysis:
8.0.29 has changed the redo log format and shuffle the redo type code,
so lower version can't parse redo log file in case of failed upgrade
Fix:
Recreate the empty redo log file during failed upgrade
so lower version does not need to parse redo file