### PR TITLE
if keyring migration failed, its destructor will delete m_argv wasn't…

### DIFF
--- a/sql/migrate_keyring.cc
+++ b/sql/migrate_keyring.cc
@@ -559,8 +559,10 @@ bool Migrate_keyring::enable_keyring_operations() {
   Standard destructor to close connection handle.
 */
 Migrate_keyring::~Migrate_keyring() {
-  delete[] m_argv;
-  m_argv = nullptr;
+  if (m_argv) {
+  	delete[] m_argv;
+  	m_argv = nullptr;
+  }
   if (mysql) {
     mysql_close(mysql);
     mysql = nullptr;


### PR DESCRIPTION
when I compile source with asan, then using ./mysqld -p 4567 , add appeared this
![image](https://user-images.githubusercontent.com/108502388/176813714-5b8c56f8-901f-4aea-9bd2-4cca47ae9cd5.png)
