### PR TITLE
Implement logic to be able to get a consistent GTID

### DIFF
--- a/sql/rpl_context.cc
+++ b/sql/rpl_context.cc
@@ -133,6 +133,17 @@ bool Session_consistency_gtids_ctx::notify_after_gtid_executed_update(
   return res;
 }
 
+void Session_consistency_gtids_ctx::notify_start_gtid_determined(const THD *thd) {
+  DBUG_TRACE;
+  assert(thd);
+
+  if (m_listener == nullptr || m_curr_session_track_gtids != SESSION_TRACK_GTIDS_START_GTID) return;
+
+  if (m_gtid_set->add_gtid_set(gtid_state->get_executed_gtids()) == RETURN_STATUS_OK) {
+    notify_ctx_change_listener();
+  }
+}
+
 void Session_consistency_gtids_ctx::
     update_tracking_activeness_from_session_variable(const THD *thd) {
   m_curr_session_track_gtids = thd->variables.session_track_gtids;

--- a/sql/rpl_context.h
+++ b/sql/rpl_context.h
@@ -206,6 +206,17 @@ class Session_consistency_gtids_ctx {
   */
   void update_tracking_activeness_from_session_variable(const THD *thd);
 
+  /**
+     This function SHALL be called once the starting GTID for the given transaction has
+     has been determined.
+
+     This function SHALL store the data if the
+     thd->variables.session_track_gtids is set to START_GTID.
+
+     @param thd   The thread context.
+   */
+  virtual void notify_start_gtid_determined(const THD *thd);
+
  private:
   // not implemented
   Session_consistency_gtids_ctx(const Session_consistency_gtids_ctx &rsc);

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -1514,7 +1514,7 @@ static bool on_session_track_gtids_update(sys_var *, THD *thd, enum_var_type) {
 }
 
 static const char *session_track_gtids_names[] = {"OFF", "OWN_GTID",
-                                                  "ALL_GTIDS", NullS};
+                                                  "ALL_GTIDS", "START_GTID", NullS};
 static Sys_var_enum Sys_session_track_gtids(
     "session_track_gtids",
     "Controls the amount of global transaction ids to be "

--- a/sql/system_variables.h
+++ b/sql/system_variables.h
@@ -90,7 +90,8 @@ enum enum_transaction_write_set_hashing_algorithm {
 enum enum_session_track_gtids {
   SESSION_TRACK_GTIDS_OFF = 0,
   SESSION_TRACK_GTIDS_OWN_GTID = 1,
-  SESSION_TRACK_GTIDS_ALL_GTIDS = 2
+  SESSION_TRACK_GTIDS_ALL_GTIDS = 2,
+  SESSION_TRACK_GTIDS_START_GTID = 3
 };
 
 /** Values for use_secondary_engine sysvar. */


### PR DESCRIPTION
This adds logic so that with a `START TRANSACTION WITH CONSISTENT SNAPSHOT`, we can also get a correct GTID that is appropriate at the time the transaction is started.

It locks around the logic when a consistent snapshot is created in the underlying storage engine and grabs the current GTID under lock at that point.

That means that no other threads can update the GTID at the exact same point in time avoiding the race that currently exists if you execute `SELECT @@global.gtid_executed` which doesn't enforce such locking.

The locking overhead is should be relatively small. When using a consistent read snapshots, systems (like Vitess) often want to get a consistent GTID. Today that's only possible by then also locking all tables which is much more expensive.

The implementation here opts to use a new specific `START_GTID` option. There are other options though here. I can also see the argument for if we'd want to return when `OWN_GTID` or `ALL_GTID` is enabled to also return this on starting transactions this way. There could be a compatibility concern there since a client might not expect a GTID in the `OK` packet on a transaction start. It should still be able to parse a generic `OK` packet though, so maybe this is fine.

I'm all open for changing that up if that is preferred instead (and we can update our PlanetScale fork also accordingly since we'd like to stick as close to mainline as we can :smile:). 

cc @lefred since you asked in https://github.com/planetscale/mysql-server/commit/9fa67ec3ebdeda923a67963260a9e744aa635a3a#commitcomment-82813813