### PR TITLE
fix some error handlers in mysqlpump

### DIFF
--- a/client/dump/file_writer.cc
+++ b/client/dump/file_writer.cc
@@ -41,9 +41,15 @@ void File_writer::append(const std::string& data_to_append)
 File_writer::~File_writer()
 {
   // Check for I/O errors and close file.
-  if (ferror(m_file) != 0 || fclose(m_file) != 0)
+  if (ferror(m_file) != 0)
   {
     this->pass_message(Mysql::Tools::Base::Message_data(ferror(m_file),
+      "Error occurred while finishing writing to output.",
+      Mysql::Tools::Base::Message_type_error));
+  }
+  if (fclose(m_file) != 0)
+  {
+    this->pass_message(Mysql::Tools::Base::Message_data(errno,
       "Error occurred while finishing writing to output.",
       Mysql::Tools::Base::Message_type_error));
   }

--- a/client/dump/mysqldump_tool_chain_maker.cc
+++ b/client/dump/mysqldump_tool_chain_maker.cc
@@ -98,9 +98,12 @@ I_object_reader* Mysqldump_tool_chain_maker::create_chain(
         compression_writer_as_writer= compression_writer;
       }
       else
+      {
         this->pass_message(Mysql::Tools::Base::Message_data(
           0, "Unknown compression method: " + algorithm_name,
           Mysql::Tools::Base::Message_type_error));
+        return NULL;
+      }
 
       compression_writer_as_wrapper->register_output_writer(writer);
       writer= compression_writer_as_writer;

--- a/client/dump/object_queue.cc
+++ b/client/dump/object_queue.cc
@@ -114,6 +114,8 @@ void Object_queue::read_object(Item_processing_data* item_to_process)
       Mysql::Tools::Base::Message_data(
       0, "Not supported operation called.",
       Mysql::Tools::Base::Message_type_error));
+
+    return;
   }
 
   my_boost::mutex::scoped_lock lock(m_queue_mutex);

--- a/client/dump/sql_formatter.cc
+++ b/client/dump/sql_formatter.cc
@@ -399,9 +399,13 @@ void Sql_formatter::format_plain_sql_object(
   if (new_priv_task != NULL)
   {
     if (m_options->m_drop_user)
-      this->append_output("DROP USER "
-       + (dynamic_cast<Abstract_data_object*>(new_priv_task))->get_name()
-       + ";\n");
+    {
+      Abstract_data_object* data_obj = dynamic_cast<Abstract_data_object*>(new_priv_task);
+      if (data_obj != NULL)
+        this->append_output("DROP USER "
+         + data_obj->get_name()
+         + ";\n");
+    }
   }
 
   this->append_output(plain_sql_dump_task->get_sql_formatted_definition()


### PR DESCRIPTION
1. ferror(m_file) when fclose(m_file) error;
2. compression_writer_as_wrapper NULL dereferenced in"Unknown compression method";
3. dump_task NULL checked and dereferenced;
4. dynamic_cast<Abstract_data_object*>(new_priv_task)) maybe NULL but not checked.