### PR TITLE
Fix auth_sec.keyring_file_data_qa test in docker

### DIFF
--- a/mysql-test/suite/auth_sec/r/keyring_file_data_qa.result
+++ b/mysql-test/suite/auth_sec/r/keyring_file_data_qa.result
@@ -8,6 +8,7 @@ call mtr.add_suppression("\\[ERROR\\] \\[[^]]*\\] \\[[^]]*\\] Plugin keyring_fil
 call mtr.add_suppression("\\[ERROR\\] \\[[^]]*\\] \\[[^]]*\\] Plugin keyring_file reported: 'File .*keyring/' not found .*");
 call mtr.add_suppression("\\[ERROR\\] \\[[^]]*\\] \\[[^]]*\\] Plugin keyring_file reported: 'File 'MYSQL_test_invalid/dir/' not found .*");
 call mtr.add_suppression("\\[ERROR\\] \\[[^]]*\\] \\[[^]]*\\] Plugin keyring_file reported: 'File '/' not found .*");
+call mtr.add_suppression("\\[ERROR\\] \\[[^]]*\\] \\[[^]]*\\] Plugin keyring_file reported: 'Cannot seek in file '/'");
 call mtr.add_suppression("\\[ERROR\\] \\[[^]]*\\] \\[[^]]*\\] Plugin keyring_file reported: 'Incorrect Keyring file");
 INSTALL PLUGIN keyring_file SONAME 'keyring_file.so';
 SELECT PLUGIN_NAME,PLUGIN_VERSION,PLUGIN_STATUS

--- a/mysql-test/suite/auth_sec/t/keyring_file_data_qa.test
+++ b/mysql-test/suite/auth_sec/t/keyring_file_data_qa.test
@@ -12,6 +12,7 @@ call mtr.add_suppression("\\[ERROR\\] \\[[^]]*\\] \\[[^]]*\\] Plugin keyring_fil
 call mtr.add_suppression("\\[ERROR\\] \\[[^]]*\\] \\[[^]]*\\] Plugin keyring_file reported: 'File .*keyring/' not found .*");
 call mtr.add_suppression("\\[ERROR\\] \\[[^]]*\\] \\[[^]]*\\] Plugin keyring_file reported: 'File 'MYSQL_test_invalid/dir/' not found .*");
 call mtr.add_suppression("\\[ERROR\\] \\[[^]]*\\] \\[[^]]*\\] Plugin keyring_file reported: 'File '/' not found .*");
+call mtr.add_suppression("\\[ERROR\\] \\[[^]]*\\] \\[[^]]*\\] Plugin keyring_file reported: 'Cannot seek in file '/'");
 call mtr.add_suppression("\\[ERROR\\] \\[[^]]*\\] \\[[^]]*\\] Plugin keyring_file reported: 'Incorrect Keyring file");
 
 # Installing keyring plugin.


### PR DESCRIPTION
Running this test in docker gives an additional error in the log:
`2022-08-23T11:31:00.065464Z 17 [ERROR] [MY-011370] [Server] Plugin keyring_file reported: 'Cannot seek in file '/' (OS errno 22 - Invalid argument)'
`

To reproduce:
`./mtr auth_sec.keyring_file_data_qa`
or
```
docker run -it -d --name mybug -e MYSQL_ROOT_PASSWORD=my-secret-pw mysql/mysql-server:latest
docker exec -it mybug mysql -p'my-secret-pw' -e'INSTALL PLUGIN keyring_file SONAME "keyring_file.so"';
docker exec -it mybug mysql -p"my-secret-pw" -e"SET @@global.keyring_file_data='/'";
docker logs mybug
```

Fix is to suppress the additional log message.