### PR TITLE
New 'RENAME TABLE ... NO LOCK CHECK' optional clause. 

### DIFF
--- a/sql/sql_lex.h
+++ b/sql/sql_lex.h
@@ -3981,6 +3981,11 @@ struct LEX : public Query_tables_list {
   uint8 context_analysis_only;
   bool drop_if_exists;
   /**
+  refers to optional NO LOCK CHECK clause in RENAME TABLE sql. This flag when
+  set to true skips the table lock validation that precedes the actual rename operation.
+  */
+  bool no_lock_check;
+  /**
     refers to optional IF EXISTS clause in REVOKE sql. This flag when set to
     true will report warnings in case privilege being granted is not granted to
     given user/role. When set to false error is reported.

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -3619,7 +3619,7 @@ int mysql_execute_command(THD *thd, bool first_level) {
           goto error;
       }
 
-      if (mysql_rename_tables(thd, first_table)) goto error;
+      if (mysql_rename_tables(thd, first_table, lex->no_lock_check)) goto error;
       break;
     }
     case SQLCOM_CHECKSUM: {

--- a/sql/sql_rename.h
+++ b/sql/sql_rename.h
@@ -26,6 +26,6 @@
 class THD;
 struct TABLE_LIST;
 
-bool mysql_rename_tables(THD *thd, TABLE_LIST *table_list);
+bool mysql_rename_tables(THD *thd, TABLE_LIST *table_list, bool no_lock_check);
 
 #endif /* SQL_RENAME_INCLUDED */

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -1479,6 +1479,7 @@ void warn_about_deprecated_binary(THD *thd)
         lock_option
         udf_type if_exists
         opt_no_write_to_binlog
+        opt_no_lock_check
         all_or_any opt_distinct
         fulltext_options union_option
         transaction_access_mode_types
@@ -9654,13 +9655,17 @@ opt_no_write_to_binlog:
         | LOCAL_SYM { $$= 1; }
         ;
 
+opt_no_lock_check:
+          /* empty */ { $$= 0; }
+        | NO_SYM LOCK_SYM CHECK_SYM { $$= 1; }
+        ;
+
 rename:
-          RENAME table_or_tables
+          RENAME table_or_tables table_to_table_list opt_no_lock_check
           {
             Lex->sql_command= SQLCOM_RENAME_TABLE;
+            Lex->no_lock_check = $4;
           }
-          table_to_table_list
-          {}
         | RENAME USER rename_list
           {
             Lex->sql_command = SQLCOM_RENAME_USER;


### PR DESCRIPTION
This PR proposes an optional `NO LOCK CHECK` clause to the `RENAME TABLE` statement, like so:

```sql
rename table t1 to t0, t2 to t1, t0 to t2 no lock check;
```

This clause disables (skips) the existing pre-RENAME validation that all relevant tables are either all locked or none is locked.

A bit of context. From the docs:

> Prior to MySQL 8.0.13, to execute RENAME TABLE, there must be no tables locked with LOCK TABLES.

So pre `8.0.13` any attempt to `LOCK TABLES any_table_whatsoever WRITE; RENAME TABLE ...` would result with error.

In `8.0.13` a check is added: either no table is locked, or all affected tables must be locked. This was developed to assist 3rd party online schema change tools, specifically `gh-ost` (much appreciated!), to manage the final cut-over phase. However, as it turned out, this implementation created a different kind of complexity to `gh-ost` (for reasons we can elaborate on if so desired). Today, as I'm looking into both `gh-ost` and `vitess` online schema changes, I'm again facing the cut-over issue.

For even more context, the following should be considered:

- The fact the tables are not locked up-front is not really an issue. As evidence, pre `8.0.13` locks were impossible.
- The `RENAME` operation grabs all necessary locks, whether locks were present beforehand or not.
- The current code comments mention: 
  https://github.com/mysql/mysql-server/blob/a246bad76b9271cb4333634e954040a970222e0a/sql/sql_rename.cc#L248-L250
  However, I think the risk of deadlock is very low, and easily mitigated by `SET LOCK_WAIT_TIMEOUT` to any reasonable value, which then works well to resolve a table-lock deadlock scenario.
- The ideal logic for all asynchronous online-schema-change tools, `fb-osc`, `gh-ost` and `vitess` is to `LOCK WRITE` the original table only, then keep digesting what remains of the changelog, applying it to the "shadow table", then flipping both.

With this new optional clause, an OSC like `gh-ost` or `vitess` would therefore run:

1. Connection `#1`: `LOCK TABLES original_table WRITE`
2. Connection `#2`: apply any remaining `INSERT/DELETE/UPDATE` on the shadow table
3. Connection `#1`: `RENAME TABLE original_table TO _old, _shadow_table TO original_table` or `RENAME TABLE original_table TO _swap, _shadow_table TO original_table, _swap TO _shadow_table`
  The `RENAME` operation escalates connection `#1` locks to hold both `original_table` and `_shadow_table`
5. Connection `#1`: `UNLOCK TABLES` 
6. Done

That's a much shorter, less error prone, and overall less locking, flow than the one described in http://code.openark.org/blog/mysql/solving-the-non-atomic-table-swap-take-iii-making-it-atomic (see additional writeup here: https://github.com/vitessio/vitess/pull/11460#issuecomment-1275826833). But the flow is currently impossible because it grabs a lock on a single table out of the two/more tables used in the `RENAME` statement, which fails the `RENAME`.

And so this contribution offers:

- An optional clause `NO LOCK CHECK`
- Which changes locking check behavior of a `RENAME` statement
- Backwards compatible if clause is not provided
- To be used, I guess, exclusively by OSC tools
- Will benefit `gh-ost`, `vitess` and `fb-osc`

Thank you for your consideration!