### PR TITLE
BUG-109433 mysqld crash when IF more than 64

### DIFF
--- a/rapid/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/sock_probe_ix.c
+++ b/rapid/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/sock_probe_ix.c
@@ -155,7 +155,7 @@ static int init_sock_probe(sock_probe *s)
      We are just starting or have filled up all pre-allocated entries.
      Need to allocate some more.
      */
-    if (i==ifrpsize || i==0)
+    if (i==ifrpsize / (int)sizeof(struct ifreq *) || i==0)
     {
 		ifrpsize+= IFRP_INIT_ARR_SIZE * (int)sizeof(struct ifreq *);
       /* allocate one more block */


### PR DESCRIPTION
To fix [BUG-109433](https://bugs.mysql.com/bug.php?id=109433)

Problem:
Crash when network interface is more than 64 (when deploy with k8s, who create many virtual network interface)

Analysis:
`ifrp` is overflowed when network interface is more than IFRP_INIT_ARR_SIZE(64). It is not reallocated because wrong condition `i==ifrpsize`.

Fix:
fix wrong reallocate condition.