### PR TITLE
Bug #109633: Display DB (Schema) name the thread is using in the logs during a crash

### DIFF
--- a/sql/signal_handler.cc
+++ b/sql/signal_handler.cc
@@ -183,6 +183,9 @@ void print_fatal_signal(int sig) {
     my_safe_printf_stderr("Query (%p): ", thd->query().str);
     my_safe_puts_stderr(thd->query().str,
                         std::min(size_t{1024}, thd->query().length));
+    my_safe_printf_stderr("DB (%p): ", thd->db().str);
+    my_safe_puts_stderr(thd->db().str,
+                        std::min(size_t{64}, thd->db().length));
     my_safe_printf_stderr("Connection ID (thread ID): %u\n", thd->thread_id());
     my_safe_printf_stderr("Status: %s\n\n", kreason);
   }


### PR DESCRIPTION
Bug Reference: https://bugs.mysql.com/bug.php?id=109633

If a thread in MySQL causes a segfault, the signal handler will output information about that thread including the query it was executing but not the DB it is using. Below is an example of this message:

```
Trying to get some variables.
Some pointers may be invalid and cause the dump to abort.
Query (7fd94c421e50): select city,state,sleep(10) from offices
Connection ID (thread ID): 13
Status: NOT_KILLED
```
This information does not contain the DB name the thread was using. If the MySQL instance has many DBs with identical table names it can be difficult to determine on which DB the query was executing. As a result identifying a corrupted table or index can not be done easily.

Testing:

Ran a slow query with a sleep in it:
`select city,state,sleep(10) from offices;`

Found the OS thread ID in `performance_schema.threads`

Next sent a SIGSEGV to the thread with `kill` 

Then captured the output in the error log.
```
/lib/x86_64-linux-gnu/libpthread.so.0(+0x7fa3) [0x7fd9c619bfa3]
/lib/x86_64-linux-gnu/libc.so.6(clone+0x3f) [0x7fd9c596d06f]

Trying to get some variables.
Some pointers may be invalid and cause the dump to abort.
Query (7fd94c421e50): select city,state,sleep(10) from offices
DB (7fd94c324ce0): classicmodels
Connection ID (thread ID): 13
Status: NOT_KILLED
```


