### PR TITLE
Fix for errors: Plugin sha256_password reported

### DIFF
--- a/sql/auth/sql_authentication.cc
+++ b/sql/auth/sql_authentication.cc
@@ -2060,7 +2060,7 @@ ACL_USER *decoy_user(const LEX_CSTRING &username, const LEX_CSTRING &hostname,
     } else {
       const int DECIMAL_SHIFT = 1000;
       const int random_number = static_cast<int>(my_rnd(rand) * DECIMAL_SHIFT);
-      uint plugin_num = (uint)(random_number % ((uint)PLUGIN_LAST));
+      uint plugin_num = (uint)(random_number % ((uint)PLUGIN_LAST-1));
       user->plugin =
           Cached_authentication_plugins::cached_plugins_names[plugin_num];
       unknown_accounts->clear_if_greater(MAX_UNKNOWN_ACCOUNTS);

--- a/sql/auth/sql_authentication.cc
+++ b/sql/auth/sql_authentication.cc
@@ -2060,6 +2060,7 @@ ACL_USER *decoy_user(const LEX_CSTRING &username, const LEX_CSTRING &hostname,
     } else {
       const int DECIMAL_SHIFT = 1000;
       const int random_number = static_cast<int>(my_rnd(rand) * DECIMAL_SHIFT);
+      /* SHA256_PASSWORD plugin is excluded. */
       uint plugin_num = (uint)(random_number % ((uint)PLUGIN_LAST-1));
       user->plugin =
           Cached_authentication_plugins::cached_plugins_names[plugin_num];


### PR DESCRIPTION
In the absence of --skip-grant-table, the database creates an acl_user object through the function decoy_user() when a non-existent user is logged into the database. When this object is created, its plugin property is randomly selected from cached_plugins_enum. This makes it possible to select the PLUGIN_SHA256_PASSWORD plug-in. But at the entrance to sha256_password_authenticate(), a Warning message is generated indicating that PLUGIN_SHA256_PASSWORD is deprecated: 2023-01-10T01:07:23.035479Z 13 [Warning] [MY-013360] [Server] Plugin sha256_password reported: ''sha256_password' is deprecated and will be removed in a future release. Please use caching_sha2_password instead'

When invalid database access occurs due to objective reasons, a large number of Warning logs are generated in the database error log. As a result, alarms and log files are too large.

Therefore, the decoy_user() function removes PLUGIN_SHA256_PASSWORD to fix the problem without affecting other functions.