### PR TITLE
protocol_classic: Document column default in Protocol::ColumnDefiniti…

### DIFF
--- a/sql/protocol_classic.cc
+++ b/sql/protocol_classic.cc
@@ -3194,6 +3194,9 @@ bool Protocol_classic::end_result_metadata() {
         <li>0x1f for dynamic strings, double, float</li>
         <li>0x00 to 0x51 for decimals</li>
         </ul></td></tr>
+  <tr><td>@ref sect_protocol_basic_dt_string_le "string&lt;lenenc&gt;"</td>
+      <td>default</td>
+      <td>Column default</td></tr>
   </table>
 
   @note `decimals` and `column_length` can be used for text output formatting


### PR DESCRIPTION
In the response to `COM_FIELD_LIST` the column defaults are sent, but this seems to be missing from the documentation.

Example program to trigger creation these kinds of packets:
```c
#include <mysql/mysql.h>
#include <stdio.h>

int main() {
  MYSQL mysql;
  mysql_init(&mysql);

  if (!mysql_real_connect(&mysql, "127.0.0.1", "root", NULL, "test", 3306, NULL,
                          0)) {
    fprintf(stderr, "Failed to connect: %s\n", mysql_error(&mysql));
  }

  MYSQL_RES *fields = mysql_list_fields(&mysql, "t1", "%");

  if (fields) {
    int field_cnt = mysql_num_fields(fields);

    for (int i = 0; i < field_cnt; ++i) {
      MYSQL_FIELD *col = mysql_fetch_field_direct(fields, i);
      printf("Column %d: name=%s, default=%s\n", i, col->name,
             col->flags & NO_DEFAULT_VALUE_FLAG ? "<no default>" : col->def);
    }
  } else {
    if (mysql_errno(&mysql)) {
      fprintf(stderr, "Failed to get field info: %s\n", mysql_error(&mysql));
    }
  }
  mysql_free_result(fields);
}
```