### PR TITLE
client/mysql: enable comments by default

### DIFF
--- a/client/mysql.cc
+++ b/client/mysql.cc
@@ -167,7 +167,7 @@ static bool ignore_errors = false, wait_flag = false, quick = false,
 static bool opt_binary_as_hex_set_explicitly = false;
 static bool debug_info_flag, debug_check_flag;
 static bool column_types_flag;
-static bool preserve_comments = false;
+static bool preserve_comments = true;
 static ulong opt_max_allowed_packet, opt_net_buffer_length;
 static uint verbose = 0, opt_silent = 0, opt_mysql_port = 0,
             opt_local_infile = 0;
@@ -1687,9 +1687,9 @@ static struct my_option my_long_options[] = {
      nullptr, 0, nullptr},
     {"comments", 'c',
      "Preserve comments. Send comments to the server."
-     " The default is --skip-comments (discard comments), enable with "
-     "--comments.",
-     &preserve_comments, &preserve_comments, nullptr, GET_BOOL, NO_ARG, 0, 0, 0,
+     " The default is --comments (keep comments), disable with "
+     "--skip-comments.",
+     &preserve_comments, &preserve_comments, nullptr, GET_BOOL, NO_ARG, 1, 0, 0,
      nullptr, 0, nullptr},
     {"compress", 'C', "Use compression in server/client protocol.",
      &opt_compress, &opt_compress, nullptr, GET_BOOL, NO_ARG, 0, 0, 0, nullptr,


### PR DESCRIPTION
Make `--comments` the default for MySQL Client.

Stripping comments was very useful to make the MySQL Query Cache get a higher hitrate. However with the query cache having been deprecated in 5.7.20 and removed in 8.0 this isn't needed anymore.

Having the comments sent to the server make them appear in the processlist which can make them more easy to identify. Making them available to routers and proxies allows those to make use of them for query routing and diagnostic purposes as well.