### PR TITLE
Fix crashing mysql due to inadequate cleanup of cached queries that use TempTable

### DIFF
--- a/mysql-test/r/temptable_repeat_cached_query.result
+++ b/mysql-test/r/temptable_repeat_cached_query.result
@@ -1,0 +1,27 @@
+DROP DATABASE IF EXISTS db1;
+CREATE DATABASE `db1`;
+USE `db1`;
+CREATE TABLE db1.`tb1` (
+`col1` varchar(8) NOT NULL 
+);
+INSERT INTO db1.`tb1`(col1) VALUES ('20211114');
+CREATE PROCEDURE db1.`stored_proc1`()
+BEGIN
+WITH t_dataset_info as (
+SELECT col1 as yyyymmdd FROM tb1 WHERE col1 = (SELECT max(col1) FROM tb1 )
+)
+SELECT a.yyyymmdd as yyyymmdd
+FROM (
+SELECT a.yyyymmdd
+FROM t_dataset_info a
+WHERE a.yyyymmdd = (SELECT max(a.yyyymmdd) FROM t_dataset_info a WHERE a.yyyymmdd <= '20220131')
+) a;
+END|
+SET optimizer_switch="derived_merge=off";
+call db1.stored_proc1();
+yyyymmdd
+20211114
+call db1.stored_proc1();
+yyyymmdd
+20211114
+DROP DATABASE db1;

--- a/mysql-test/t/temptable_repeat_cached_query.test
+++ b/mysql-test/t/temptable_repeat_cached_query.test
@@ -1,0 +1,45 @@
+########################################################################################
+# Check that repeat queries that are cached do not cause MySQL to crash due to
+# usable keys not being reset after completion of processing for each query for
+# the TempTable storage engine.
+########################################################################################
+
+# Disable warnings as they add noise that is not relevant to verifying the
+# behavior that is being tested.
+--disable_warnings
+
+DROP DATABASE IF EXISTS db1;
+CREATE DATABASE `db1`;
+USE `db1`;
+
+CREATE TABLE db1.`tb1` (
+  `col1` varchar(8) NOT NULL 
+);
+
+INSERT INTO db1.`tb1`(col1) VALUES ('20211114');
+
+
+--delimiter |
+
+CREATE PROCEDURE db1.`stored_proc1`()
+BEGIN
+
+    WITH t_dataset_info as (
+        SELECT col1 as yyyymmdd FROM tb1 WHERE col1 = (SELECT max(col1) FROM tb1 )
+    )
+    SELECT a.yyyymmdd as yyyymmdd
+                      FROM (
+                            SELECT a.yyyymmdd
+                              FROM t_dataset_info a
+                            WHERE a.yyyymmdd = (SELECT max(a.yyyymmdd) FROM t_dataset_info a WHERE a.yyyymmdd <= '20220131')
+                            ) a;
+
+END|
+
+--delimiter ;
+SET optimizer_switch="derived_merge=off";
+
+call db1.stored_proc1();
+call db1.stored_proc1();
+DROP DATABASE db1;
+--enable_warnings

--- a/storage/temptable/include/temptable/handler.h
+++ b/storage/temptable/include/temptable/handler.h
@@ -523,6 +523,15 @@ class Handler : public ::handler {
   /** Currently opened table, or `nullptr` if none is opened. */
   Table *m_opened_table;
 
+  /* Determine if handler has cached the underlying 
+   * data of a temptable. This normally happens
+   * after the second usage  of the temptable handler.
+   * Before the second usage, we want to
+   * reset keys_in_use_for_query of the underlying
+   * temptable.
+   */
+  bool is_temptable_cached;
+
   /** Pointer to the non-owned shared-block of memory to be re-used by all
    * `Allocator` instances or copies made by `Table`. */
   Block *m_shared_block;


### PR DESCRIPTION
Description
============
The TempTable storage engine can cause the MySQL engine to crash
if the same query that created a temporary table is run more than
once. The reason for this crash is that the TempTable handler is
cleaned up after execution of the query, but the "keys in use" flag
for the underlying temporary table remains "on" in the cached results.
When the query is rerun, it uses the cached results from the
previous run, and since the "keys in use" flag is set, logic in the
execute stage of the query attempts to access a pointer to what it
expects is an opened temporary table. But since the TempTable
handler had been cleaned up after the first run, a new TempTable
handler is instantiated for the new run, which does not yet have
a pointer to an opened temporary table. When the query rerun
attempts to access the opened temporary table via a null pointer
the system crashes. The crashes only happen on the second
rerun of the query. Subsequent reruns after the second one do
not crash the engine.

This change fixes this issue by ensuring that the "keys in use" flag
is reset (0) during the TempTable handler clean up, after the first
run of a query. This is done because, if the underlying
temporary table has been cleaned up, then by definition there should
not be any "keys in use" on it.

Fixes bug https://bugs.mysql.com/bug.php?id=110152 reported to
Oracle MySQL.

Testing
========
An MTR test is provided with the PR that forces the creation of 
temporary tables and hence causes a crash without the change, but
works correctly with the change.
