### PR TITLE
sql/memory: Fix the musl build

### DIFF
--- a/sql/memory/aligned_atomic.h
+++ b/sql/memory/aligned_atomic.h
@@ -76,7 +76,7 @@ static inline size_t _cache_line_size() {
   return line_size;
 }
 
-#elif defined(__linux__)
+#elif defined(__GLIBC__)
 static inline size_t _cache_line_size() {
   long size = sysconf(_SC_LEVEL1_DCACHE_LINESIZE);
   if (size == -1) return 64;


### PR DESCRIPTION
`_SC_LEVEL1_DCACHE_LINESIZE` is not specific to linux, but to glibc.