### PR TITLE
sql/binlog/group_commit: include header for std::uint64_t

### DIFF
--- a/sql/binlog/group_commit/bgc_ticket.h
+++ b/sql/binlog/group_commit/bgc_ticket.h
@@ -23,6 +23,7 @@
 #ifndef BINLOG_BCG_TICKET_H
 #define BINLOG_BCG_TICKET_H
 
+#include <cstdint>
 #include <functional>
 #include <limits>
 #include <memory>


### PR DESCRIPTION
GCC 13 changed default header dependencies for C++ necessitating including cstdint explicitly.