### PR TITLE
Fix linkage of 'gen_keyword_list' executable

### DIFF
--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -89,7 +89,7 @@ ADD_CUSTOM_COMMAND(
 MYSQL_ADD_EXECUTABLE(gen_keyword_list
   gen_keyword_list.cc
   DEPENDENCIES GenServerSource
-  LINK_LIBRARIES ext::icu
+  LINK_LIBRARIES ext::icu ${CMAKE_DL_LIBS}
   SKIP_INSTALL
   )
 


### PR DESCRIPTION
In https://github.com/mysql/mysql-server/commit/dcef29c297fa9593752a6ea85324fcc0d79298e3,
first tagged in mysql-8.0.33, the CMake build infrastructure for the libicu
dependency was modified to declare a new 'ext::icu' alias (see
'cmake/icu.cmake').

The CMake LINK_LIBRARIES for the 'gen_keyword_list' executable were changed
to use the new 'ext::icu' alias, but at the same time '${CMAKE_DL_LIBS}' was
*removed* from its LINK_LIBRARIES.  This built-in variable names the library
that includes the dlopen/dlclose/dlsym functions, normally '-ldl' on POSIX
systems (see https://cmake.org/cmake/help/latest/variable/CMAKE_DL_LIBS.html).

As a result, 'gen_keyword_list' doesn't link correctly in a clean build,
because those functions cannot be found.

The exact introduction of the problem was at
https://github.com/mysql/mysql-server/commit/dcef29c297fa9593752a6ea85324fcc0d79298e3#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR2229