### PR TITLE
mysql client: more details about compression settings

### DIFF
--- a/client/mysql.cc
+++ b/client/mysql.cc
@@ -4909,7 +4909,9 @@ static int com_status(String *buffer [[maybe_unused]],
     tee_fprintf(stdout, "TCP port:\t\t%d\n", mysql.port);
   else
     tee_fprintf(stdout, "UNIX socket:\t\t%s\n", mysql.unix_socket);
-  if (mysql.net.compress) tee_fprintf(stdout, "Protocol:\t\tCompressed\n");
+  if (mysql.net.compress) tee_fprintf(stdout,
+		  "Protocol:\t\tCompressed, algorithms: %s, zstd level: %d\n",
+		  opt_compress_algorithm, opt_zstd_compress_level);
   if (opt_binhex) tee_fprintf(stdout, "Binary data as:\t\tHexadecimal\n");
   if (mysql_get_ssl_session_reused(&mysql))
     tee_fprintf(stdout, "SSL session reused:\ttrue\n");


### PR DESCRIPTION
Have the client print out more details about the compression algorithm and compression level:

```
mysql> \s
--------------
./runtime_output_directory/mysql  Ver 8.0.33 for Linux on x86_64 (Source distribution)

Connection id:		235
Current database:	
Current user:		root@localhost
SSL:			Cipher in use is TLS_AES_256_GCM_SHA384
Current pager:		stdout
Using outfile:		''
Using delimiter:	;
Server version:		8.0.33 MySQL Community Server - GPL
Protocol version:	10
Connection:		127.0.0.1 via TCP/IP
Server characterset:	utf8mb4
Db     characterset:	utf8mb4
Client characterset:	utf8mb4
Conn.  characterset:	utf8mb4
TCP port:		3306
Protocol:		Compressed, algorithms: zstd, zstd level: 9                               ←------------------------------
Binary data as:		Hexadecimal
Uptime:			9 hours 48 min 31 sec

Threads: 2  Questions: 1899280  Slow queries: 0  Opens: 584  Flush tables: 3  Open tables: 476  Queries per second avg: 53.787
--------------

mysql>
```

The `NET` structure as defined in `mysql_com.h`  only has a `bool` for `compress`. Extending this and using that instead of the `opt_...` variables would be a good alternative.