### PR TITLE
CONTRIB_371: Efficient zeroing of UNDO, REDO and tablespace files

### DIFF
--- a/config.h.cmake
+++ b/config.h.cmake
@@ -1,4 +1,5 @@
 /* Copyright (c) 2009, 2023, Oracle and/or its affiliates.
+   Copyright (c) 2023, 2023, Hopsworks and/or its affiliates.
  
  This program is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License, version 2.0,
@@ -73,6 +74,7 @@
 #cmakedefine HAVE_CHOWN 1
 #cmakedefine HAVE_CUSERID 1
 #cmakedefine HAVE_DIRECTIO 1
+#cmakedefine HAVE_FALLOCATE 1
 #cmakedefine HAVE_FTRUNCATE 1
 #cmakedefine HAVE_FCHMOD 1
 #cmakedefine HAVE_FCNTL 1

--- a/configure.cmake
+++ b/configure.cmake
@@ -1,4 +1,5 @@
 # Copyright (c) 2009, 2023, Oracle and/or its affiliates.
+# Copyright (c) 2023, 2023, Hopsworks and/or its affiliates.
 # 
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License, version 2.0,
@@ -231,6 +232,7 @@ CHECK_FUNCTION_EXISTS (index HAVE_INDEX)
 CHECK_FUNCTION_EXISTS (chown HAVE_CHOWN)
 CHECK_FUNCTION_EXISTS (cuserid HAVE_CUSERID)
 CHECK_FUNCTION_EXISTS (directio HAVE_DIRECTIO)
+CHECK_FUNCTION_EXISTS (fallocate HAVE_FALLOCATE)
 CHECK_FUNCTION_EXISTS (ftruncate HAVE_FTRUNCATE)
 CHECK_FUNCTION_EXISTS (fchmod HAVE_FCHMOD)
 CHECK_FUNCTION_EXISTS (fcntl HAVE_FCNTL)

--- a/storage/ndb/include/kernel/signaldata/FsReadWriteReq.hpp
+++ b/storage/ndb/include/kernel/signaldata/FsReadWriteReq.hpp
@@ -1,5 +1,6 @@
 /*
    Copyright (c) 2003, 2023, Oracle and/or its affiliates.
+   Copyright (c) 2023, 2023, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -128,6 +129,9 @@ private:
     struct {
       Uint32 pageNumber;
     } sharedPage;
+    struct {
+      Uint32 initZero;
+    } zeroPageIndicator;
   } data;
 
   static Uint8 getSyncFlag(const UintR & opFlag);

--- a/storage/ndb/include/portlib/ndb_file.h
+++ b/storage/ndb/include/portlib/ndb_file.h
@@ -178,6 +178,10 @@ public:
    * Reserve disk blocks for entire file.
    */
   int allocate() const;
+  /*
+   * Zero all disk pages allocated by allocate (avoid headers)
+   */
+  int init_zero(ndb_off_t data_size, ndb_off_t offset) const;
 
   int set_block_size_and_alignment(size_t size, size_t alignment);
   bool have_direct_io_support() const;

--- a/storage/ndb/include/util/ndbxfrm_file.h
+++ b/storage/ndb/include/util/ndbxfrm_file.h
@@ -343,6 +343,7 @@ class ndbxfrm_file
   int read_forward(ndbxfrm_output_iterator* out);
   int read_backward(ndbxfrm_output_reverse_iterator* out);
   ndb_off_t move_to_end();
+  ndb_off_t get_payload_start() const;
 
  private:
   // file fixed properties
@@ -480,4 +481,8 @@ inline bool ndbxfrm_file::is_definite_offset(ndb_off_t offset)
   return (offset != INDEFINITE_OFFSET);
 }
 
+inline ndb_off_t ndbxfrm_file::get_payload_start() const
+{
+  return m_payload_start;
+}
 #endif

--- a/storage/ndb/src/common/portlib/ndb_file_posix.cpp
+++ b/storage/ndb/src/common/portlib/ndb_file_posix.cpp
@@ -225,7 +225,6 @@ int ndb_file::truncate(ndb_off_t end) const
   }
   return 0;
 }
-
 int ndb_file::allocate() const
 {
   ndb_off_t size = get_size();
@@ -236,20 +235,23 @@ int ndb_file::allocate() const
 #ifdef HAVE_XFS_XFS_H
   if (::platform_test_xfs_fd(m_handle))
   {
-    std::printf("Using xfsctl(XFS_IOC_RESVSP64) to allocate disk space");
+    std::printf("Using xfsctl(XFS_IOC_RESVSP64) to allocate disk space"
+                ", size: %lu\n", size);
     xfs_flock64_t fl;
     fl.l_whence= 0;
     fl.l_start= 0;
     fl.l_len= (ndb_off_t)size;
     if (::xfsctl(NULL, m_handle, XFS_IOC_RESVSP64, &fl) < 0)
     {
-      std::printf("failed to optimally allocate disk space");
+      std::printf("failed to optimally allocate disk space\n");
       return -1;
     }
     return 0;
   }
 #endif
 #ifdef HAVE_POSIX_FALLOCATE
+  std::printf("Using posix_fallocate to allocate disk space"
+              ", size: %llu\n", size);
   return ::posix_fallocate(m_handle, 0, size);
 #else
   errno = ENOSPC;
@@ -535,3 +537,30 @@ int ndb_file::reopen_with_sync(const char name[])
 
   return 0;
 }
+
+int ndb_file::init_zero(ndb_off_t data_size, ndb_off_t offset) const
+{
+#ifdef HAVE_XFS_XFS_H
+  if (::platform_test_xfs_fd(m_handle))
+  {
+    std::printf("Using xfsctl(XFS_IOC_ZERO_RANGE) to zero disk space,"
+                " data_size: %lu, offset: %lu\n", data_size, offset);
+    xfs_flock64_t fl;
+    fl.l_whence= 0;
+    fl.l_start= (off64_t)start_offset;
+    fl.l_len= (off64_t)data_size;
+    if (::xfsctl(NULL, m_handle, XFS_IOC_ZERO_RANGE, &fl) < 0)
+    {
+      std::printf("failed to optimally zero disk space\n");
+      return -1;
+    }
+  }
+#endif
+#ifdef HAVE_FALLOCATE
+  std::printf("Using fallocate to zero disk space, data_size: %llu,"
+              " offset: %llu\n", data_size, offset);
+  return fallocate(m_handle, FALLOC_FL_ZERO_RANGE, offset, data_size);
+#endif
+  return -1;
+}
+

--- a/storage/ndb/src/kernel/blocks/dblqh/Dblqh.hpp
+++ b/storage/ndb/src/kernel/blocks/dblqh/Dblqh.hpp
@@ -2982,7 +2982,8 @@ private:
   }
 
 public:
-  void execFSWRITEREQ(const FsReadWriteReq*) const /* called direct cross threads from Ndbfs */;
+  /* called direct cross threads from Ndbfs */
+  Uint32 execFSWRITEREQ(const FsReadWriteReq*) const;
   void execLQH_WRITELOG_REQ(Signal* signal);
   void execTUP_ATTRINFO(Signal* signal);
   void execREAD_PSEUDO_REQ(Uint32 opPtrI, Uint32 attrId, Uint32* out, Uint32 out_words);

--- a/storage/ndb/src/kernel/blocks/lgman.hpp
+++ b/storage/ndb/src/kernel/blocks/lgman.hpp
@@ -1,4 +1,5 @@
 /*
+<<<<<<< HEAD
    Copyright (c) 2005, 2023, Oracle and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
@@ -49,7 +50,8 @@ public:
   BLOCK_DEFINES(Lgman);
   
 public:
-  void execFSWRITEREQ(const FsReadWriteReq* req) const /* called direct cross threads from Ndbfs */;
+  /* called direct cross threads from Ndbfs */
+  Uint32 execFSWRITEREQ(const FsReadWriteReq* req) const;
 protected:
   void execSTTOR(Signal* signal);
   void sendSTTORRY(Signal*);

--- a/storage/ndb/src/kernel/blocks/ndbfs/Ndbfs.cpp
+++ b/storage/ndb/src/kernel/blocks/ndbfs/Ndbfs.cpp
@@ -2002,7 +2002,7 @@ Ndbfs::get_filename(Uint32 fd) const
   return "";
 }
 
-void Ndbfs::callFSWRITEREQ(BlockReference ref, FsReadWriteReq* req) const
+Uint32 Ndbfs::callFSWRITEREQ(BlockReference ref, FsReadWriteReq* req) const
 {
   Uint32 block = refToMain(ref);
   Uint32 instance = refToInstance(ref);
@@ -2017,17 +2017,18 @@ void Ndbfs::callFSWRITEREQ(BlockReference ref, FsReadWriteReq* req) const
   switch (block)
   {
   case DBLQH:
-    static_cast<Dblqh*>(rec_block)->execFSWRITEREQ(req);
+    return static_cast<Dblqh*>(rec_block)->execFSWRITEREQ(req);
     break;
   case TSMAN:
-    static_cast<Tsman*>(rec_block)->execFSWRITEREQ(req);
+    return static_cast<Tsman*>(rec_block)->execFSWRITEREQ(req);
     break;
   case LGMAN:
-    static_cast<Lgman*>(rec_block)->execFSWRITEREQ(req);
+    return static_cast<Lgman*>(rec_block)->execFSWRITEREQ(req);
     break;
   default:
     ndbabort();
   }
+  return 0;
 }
 
 #if defined(VM_TRACE) || defined(ERROR_INSERT) || !defined(NDEBUG)

--- a/storage/ndb/src/kernel/blocks/ndbfs/Ndbfs.hpp
+++ b/storage/ndb/src/kernel/blocks/ndbfs/Ndbfs.hpp
@@ -1,5 +1,6 @@
 /*
    Copyright (c) 2003, 2023, Oracle and/or its affiliates.
+   Copyright (c) 2023, 2023, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -53,7 +54,7 @@ public:
 
   static Uint32 translateErrno(int aErrno);
 
-  void callFSWRITEREQ(BlockReference ref, FsReadWriteReq* req) const;
+  Uint32 callFSWRITEREQ(BlockReference ref, FsReadWriteReq* req) const;
 protected:
   BLOCK_DEFINES(Ndbfs);
 

--- a/storage/ndb/src/kernel/blocks/tsman.hpp
+++ b/storage/ndb/src/kernel/blocks/tsman.hpp
@@ -1,5 +1,6 @@
 /*
    Copyright (c) 2005, 2023, Oracle and/or its affiliates.
+   Copyright (c) 2023, 2023, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -48,7 +49,8 @@ public:
   BLOCK_DEFINES(Tsman);
   
 public:
-  void execFSWRITEREQ(const FsReadWriteReq* req) const /* called direct cross threads from Ndbfs */;
+  /* called direct cross threads from Ndbfs */
+  Uint32 execFSWRITEREQ(const FsReadWriteReq* req) const;
 
 protected:
   void execSTTOR(Signal* signal);


### PR DESCRIPTION
When initialising REDO log files at startup we want to ensure that the entire file size is preallocated and that the file is properly initialised.

The same is true for UNDO log files in LGMAN and tablespace files.

To speed up this we use special XFS methods and POSIX methods that apply to the file systems we recommend users to use. This means that we can preallocate file space without actually writing it and we can even ensure that reads of this area returns pages filled with zeroes.

We can also use fallocate which works for XFS and ext4 at least in Linux.

We still need to write the initial parts of the file and for the REDO log we have to write each start page of each MByte.

Encrypted and compressed files have a file header that should not be zeroed. More debug info.