### PR TITLE
Fix hard-coded timestamps in main.derived_condition_pushdown MTR test

### DIFF
--- a/mysql-test/r/derived_condition_pushdown.result
+++ b/mysql-test/r/derived_condition_pushdown.result
@@ -2098,7 +2098,7 @@ UNION
 SELECT NOW() AS time FROM t1 WHERE f1 = 0) AS dt
 WHERE time <= ?";
 SET @a = 1;
-SET @b = '2022-05-06 16:49:45';
+SET @b = DATE_FORMAT(DATE_ADD(NOW(), INTERVAL -1 DAY), '%Y-%m-%d %H:%i:%s');
 EXECUTE stmt USING @a, @b;
 time
 PREPARE stmt FROM "EXPLAIN FORMAT=tree SELECT *
@@ -2111,7 +2111,7 @@ EXPLAIN
 -> Zero rows (no matching row in const table)  (rows=0)
 
 SET @a = 2;
-SET @b = '2023-05-06 16:49:45';
+SET @b = DATE_FORMAT(DATE_ADD(NOW(), INTERVAL +1 DAY), '%Y-%m-%d %H:%i:%s');
 EXECUTE stmt USING @a, @b;
 EXPLAIN
 -> Table scan on dt  (rows=2)

--- a/mysql-test/t/derived_condition_pushdown.test
+++ b/mysql-test/t/derived_condition_pushdown.test
@@ -1305,14 +1305,14 @@ let $query = SELECT *
              WHERE time <= ?;
 eval PREPARE stmt FROM "$query";
 SET @a = 1;
-SET @b = '2022-05-06 16:49:45';
+SET @b = DATE_FORMAT(DATE_ADD(NOW(), INTERVAL -1 DAY), '%Y-%m-%d %H:%i:%s');  # Date in the past
 eval EXECUTE stmt USING @a, @b;
 eval PREPARE stmt FROM "EXPLAIN FORMAT=tree $query";
 --replace_regex $elide_costs
 --skip_if_hypergraph  # Depends on the query plan.
 eval EXECUTE stmt USING @a, @b;
 SET @a = 2;
-SET @b = '2023-05-06 16:49:45';
+SET @b = DATE_FORMAT(DATE_ADD(NOW(), INTERVAL +1 DAY), '%Y-%m-%d %H:%i:%s');  # Date in the future
 --replace_regex $elide_costs
 --skip_if_hypergraph  # Depends on the query plan.
 eval EXECUTE stmt USING @a, @b;


### PR DESCRIPTION
Two hard-coded timestamps were added to this test in https://github.com/mysql/mysql-server/commit/22f6ef90cae8#diff-d7e1b8c7138b94f92fbd555c44e7facc027cb50217f59f51729444ee7c3b37a4R1950

1. '2022-05-06 16:49:45' (assumed by the test's result file to be `< NOW()`)
2. '2023-05-06 16:49:45' (assumed by the test's result file to be `>= NOW()`)

Because the second of these timestamps is now in the past, the test is now failing due to result mismatch.

Tests should not be written to include hard-coded assumptions about the local time in their execution environment; these are essentially guaranteed to get out-of-date and cause failures.

This test can very easily be rewritten to choose past/future timestamps relative to the time at which it is run,
`DATE_ADD(NOW(), INTERVAL [+-] 1 DAY)`.

Note that Ubuntu's build environment had to disable this test on 2022-05-09, likely due to encountering this problem:
    https://bugs.launchpad.net/ubuntu/+source/mysql-8.0/8.0.33-0ubuntu2