### PR TITLE
Replace MySQL Internals Manual links

### DIFF
--- a/man/mysqlbinlog.1
+++ b/man/mysqlbinlog.1
@@ -3226,7 +3226,7 @@ You should have received a copy of the GNU General Public License along with the
 .IP " 1." 4
 MySQL Internals: The Binary Log
 .RS 4
-\%https://dev.mysql.com/doc/internals/en/binary-log.html
+\%https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_replication.html#sect_protocol_replication_binlog_file
 .RE
 .SH "SEE ALSO"
 For more information, please refer to the MySQL Reference Manual,

--- a/mysql-test/mysql-test-run.dox
+++ b/mysql-test/mysql-test-run.dox
@@ -1194,9 +1194,9 @@
   PAGE_CODING_GUIDELINES.
 
   Other guidelines may be found in this page, which discusses general
-  principles of test-case writing: MySQL Internals:
-  [How to Create Good Test Cases]
-  (https://dev.mysql.com/doc/internals/en/good-tests.html)
+  principles of test-case writing: MySQL Source Code Documentation:
+  [Writing Test Cases]
+  (https://dev.mysql.com/doc/dev/mysql-server/latest/PAGE_WRITING_TESTCASES.html)
 
   The following guidelines are particularly applicable to writing test
   cases:
@@ -2645,8 +2645,8 @@
 
   For a description of the Debug Sync facility and how to use
   synchronization points,
-  see [MySQL Internals: Test Synchronization]
-  (https://dev.mysql.com/doc/internals/en/test-synchronization.html).
+  see [MySQL Source Code Documentation: Thread Synchronization]
+  (https://dev.mysql.com/doc/dev/mysql-server/latest/PAGE_THREAD_SYNCHRONIZATION.html).
 */
 
 ###############################################################################

--- a/plugin/x/protocol/doc/mysqlx-protocol-comparison.dox
+++ b/plugin/x/protocol/doc/mysqlx-protocol-comparison.dox
@@ -32,8 +32,8 @@
 | TLS extension                        | ✓                                                                                       | ✓                                                |
 | max message size >= 1Gb              | ✓                                                                                       | ✓                                                |
 | compression extension                | ✓                                                                                       | ✓ zlib, lz4, zstd                                |
-| resettable sessions                  | [COM_RESET_CONNECTION](http://dev.mysql.com/doc/internals/en/com-reset-connection.html) | @ref Mysqlx::Session::Reset                      |
-| multiple, sequential sessions        | [COM_CHANGE_USER](http://dev.mysql.com/doc/internals/en/com-change-user.html)           | @ref Mysqlx::Session::AuthenticateStart          |
+| resettable sessions                  | [COM_RESET_CONNECTION](https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com-reset-connection.html) | @ref Mysqlx::Session::Reset                      |
+| multiple, sequential sessions        | [COM_CHANGE_USER](https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com-change-user.html)           | @ref Mysqlx::Session::AuthenticateStart          |
 | out-of-band notifications            | ✕                                                                                       | @ref Mysqlx::Notice::Frame                       |
 | extensible messages                  | ✕                                                                                       | via protobuf                                     |
 | extensible protocol                  | via capability flags                                                                    | @ref Mysqlx::Connection::CapabilitiesGet         |
@@ -47,28 +47,28 @@
 
 | Command                                                                                       | X %Protocol                                       |
 |-----------------------------------------------------------------------------------------------|---------------------------------------------------|
-| [COM_QUIT](http://dev.mysql.com/doc/internals/en/com-quit.html)                               | @ref Mysqlx::Connection::Close                    |
-| [COM_INIT_DB](http://dev.mysql.com/doc/internals/en/com-init-db.html)                         | ✕                                                 |
-| [COM_QUERY](http://dev.mysql.com/doc/internals/en/com-query.html)                             | @ref Mysqlx::Sql::StmtExecute namespace="sql"     |
-| [COM_FIELD_LIST](http://dev.mysql.com/doc/internals/en/com-field-list.html)                   | ✕, deprecated                                     |
-| [COM_CREATE_DB](http://dev.mysql.com/doc/internals/en/com-create-db.html)                     | ✕, deprecated                                     |
-| [COM_DROP_DB](http://dev.mysql.com/doc/internals/en/com-drop-db.html)                         | ✕, deprecated                                     |
-| [COM_REFRESH](http://dev.mysql.com/doc/internals/en/com-refresh.html)                         | ✕, deprecated                                     |
-| [COM_SHUTDOWN](http://dev.mysql.com/doc/internals/en/com-shutdown.html)                       | ✕, use SQL ``SHUTDOWN``                           |
-| [COM_STATISTICS](http://dev.mysql.com/doc/internals/en/com-statistics.html)                   | ✕, deprecated                                     |
-| [COM_PROCESS_INFO](http://dev.mysql.com/doc/internals/en/com-process-info.html)               | ✕, deprecated                                     |
-| [COM_PROCESS_KILL](http://dev.mysql.com/doc/internals/en/com-process-kill.html)               | ✕, deprecated                                     |
-| [COM_DEBUG](http://dev.mysql.com/doc/internals/en/com-debug.html)                             | ✕, deprecated                                     |
-| [COM_PING](http://dev.mysql.com/doc/internals/en/com-ping.html)                               | @ref Mysqlx::Sql::StmtExecute namespace="mysqlx"  |
-| [COM_CHANGE_USER](http://dev.mysql.com/doc/internals/en/com-change-user.html)                 | @ref Mysqlx::Session::AuthenticateStart           |
-| [COM_RESET_CONNECTION](http://dev.mysql.com/doc/internals/en/com-reset-connection.html)       | @ref Mysqlx::Session::Reset                       |
-| [COM_STMT_PREPARE](http://dev.mysql.com/doc/internals/en/com-stmt-prepare.html)               | @ref Mysqlx::Prepare::Prepare                     |
-| [COM_STMT_SEND_LONG_DATA](http://dev.mysql.com/doc/internals/en/com-stmt-send-long-data.html) | ✕                                                 |
-| [COM_STMT_EXECUTE](http://dev.mysql.com/doc/internals/en/com-stmt-execute.html)               | @ref Mysqlx::Prepare::Execute                     |
-| [COM_STMT_CLOSE](http://dev.mysql.com/doc/internals/en/com-stmt-close.html)                   | @ref Mysqlx::Prepare::Deallocate                  |
-| [COM_STMT_RESET](http://dev.mysql.com/doc/internals/en/com-stmt-reset.html)                   | ✕                                                 |
-| [COM_SET_OPTION](http://dev.mysql.com/doc/internals/en/com-set-option.html)                   | ✕                                                 |
-| [COM_STMT_FETCH](http://dev.mysql.com/doc/internals/en/com-stmt-fetch.html)                   | @ref Mysqlx::Cursor::Fetch                        |
+| [COM_QUIT](https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_quit.html)                               | @ref Mysqlx::Connection::Close                    |
+| [COM_INIT_DB](https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_init_db.html)                         | ✕                                                 |
+| [COM_QUERY](https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_query.html)                             | @ref Mysqlx::Sql::StmtExecute namespace="sql"     |
+| [COM_FIELD_LIST](https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_field_list.html)                   | ✕, deprecated                                     |
+| [COM_CREATE_DB](https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_create_db.html)                     | ✕, deprecated                                     |
+| [COM_DROP_DB](https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_drop_db.html)                         | ✕, deprecated                                     |
+| [COM_REFRESH](https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_refresh.html)                         | ✕, deprecated                                     |
+| [COM_SHUTDOWN](https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_shutdown.html)                       | ✕, use SQL ``SHUTDOWN``                           |
+| [COM_STATISTICS](https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_statistics.html)                   | ✕, deprecated                                     |
+| [COM_PROCESS_INFO](https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_process_info.html)               | ✕, deprecated                                     |
+| [COM_PROCESS_KILL](https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_process_kill.html)               | ✕, deprecated                                     |
+| [COM_DEBUG](https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_debug.html)                             | ✕, deprecated                                     |
+| [COM_PING](https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_ping.html)                               | @ref Mysqlx::Sql::StmtExecute namespace="mysqlx"  |
+| [COM_CHANGE_USER](https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_change_user.html)                 | @ref Mysqlx::Session::AuthenticateStart           |
+| [COM_RESET_CONNECTION](https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_reset_connection.html)       | @ref Mysqlx::Session::Reset                       |
+| [COM_STMT_PREPARE](https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_stmt_prepare.html)               | @ref Mysqlx::Prepare::Prepare                     |
+| [COM_STMT_SEND_LONG_DATA](https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_stmt_send_long_data.html) | ✕                                                 |
+| [COM_STMT_EXECUTE](https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_stmt_execute.html)               | @ref Mysqlx::Prepare::Execute                     |
+| [COM_STMT_CLOSE](https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_stmt_close.html)                   | @ref Mysqlx::Prepare::Deallocate                  |
+| [COM_STMT_RESET](https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_stmt_reset.html)                   | ✕                                                 |
+| [COM_SET_OPTION](https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_set_option.html)                   | ✕                                                 |
+| [COM_STMT_FETCH](https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_stmt_fetch.html)                   | @ref Mysqlx::Cursor::Fetch                        |
 
 
 */

--- a/sql/auth/sha2_password.cc
+++ b/sql/auth/sha2_password.cc
@@ -940,7 +940,7 @@ static int caching_sha2_password_authenticate(MYSQL_PLUGIN_VIO *vio,
 
   /*
     Note: The nonce is split into 8 + 12 bytes according to
-    http://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::HandshakeV10
+    https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_connection_phase_packets_protocol_handshake_v10.html
     Native authentication sent 20 bytes + '\0' character = 21 bytes.
     This plugin must do the same to stay consistent with historical behavior
     if it is set to operate as a default plugin.

--- a/sql/auth/sql_authentication.cc
+++ b/sql/auth/sql_authentication.cc
@@ -4804,7 +4804,7 @@ static int sha256_password_authenticate(MYSQL_PLUGIN_VIO *vio,
 
   /*
     Note: The nonce is split into 8 + 12 bytes according to
-http://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::HandshakeV10
+    https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_connection_phase_packets_protocol_handshake_v10.html
     Native authentication sent 20 bytes + '\0' character = 21 bytes.
     This plugin must do the same to stay consistent with historical behavior
     if it is set to operate as a default plugin.

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -46,8 +46,6 @@
 
   For the user manual, see http://dev.mysql.com/doc/refman/8.0/en/
 
-  For the internals manual, see https://dev.mysql.com/doc/internals/en/index.html
-
   This documentation is published for each release, starting with MySQL 8.0.
 
   The present document corresponds to:


### PR DESCRIPTION
The MySQL Internals Manual links now also use the same generic redirect instead of redirecting to the specific information that it was pointing to before. This tries to update the majority of the links that were still in the source code.