### PR TITLE
Update log0files_governor.cc

### DIFF
--- a/storage/innobase/log/log0files_governor.cc
+++ b/storage/innobase/log/log0files_governor.cc
@@ -974,6 +974,7 @@ static bool log_files_recycle_file(log_t &log, Log_file_id file_id,
 
   log.m_unused_files_count++;
   log.m_files.erase(file_id);
+  os_event_set(log.m_file_removed_event);
   return true;
 }
 


### PR DESCRIPTION
In addition to remove log files, the recycle log file can also meets the condition of 'next available file'.