### PR TITLE
Bug#111594: add pading to solve false sharing problem

### DIFF
--- a/storage/innobase/include/buf0buf.h
+++ b/storage/innobase/include/buf0buf.h
@@ -1614,6 +1614,9 @@ class buf_page_t {
    the truncation number. */
   uint32_t m_version{};
 
+  /** Pading to solve false sharing problem */
+  char pading[ut::INNODB_CACHE_LINE_SIZE];
+
   /** Time of first access, or 0 if the block was never accessed in the
   buffer pool. Protected by block mutex */
   std::chrono::steady_clock::time_point access_time;


### PR DESCRIPTION
Signed-off-by: Teresaliu <changyan.liu@intel.com>
Signed-off-by: Lin Yang <lin.a.yang@intel.com>

## Description

When using sysbench to benchmark mysql's performance,  we found MySQL has some scalability issues as the the number of threads increase in select random ranges/points senarios; more details is there: https://bugs.mysql.com/bug.php?id=111594

After investigation, we located that this problem is a ``false sharing`` problem,  and this kind cacheline contention problem could be reduced by adding code ``pading`` to separate variables in the one cacheline.

## Conclusion
After adding pading, the benchmark results and the performance improvement ratio are as shown in the figure below：
<img width="852" alt="image" src="https://github.com/mysql/mysql-server/assets/55775529/7157485a-08d0-42c0-887d-79cc0d8b19d5">
<img width="1254" alt="image" src="https://github.com/mysql/mysql-server/assets/55775529/5abc62a4-3870-4e82-aece-3977546ddcd5">
