### PR TITLE
Fix sloppy home directory substitution in SSL tests

### DIFF
--- a/mysql-test/t/ssl_ca.test
+++ b/mysql-test/t/ssl_ca.test
@@ -16,7 +16,7 @@
 --echo #               PATH SUBSTITUTION
 --echo #
 
---let $mysql_test_dir_path= `SELECT REPLACE('$MYSQL_TEST_DIR', '$HOME', '~')`
+--let $mysql_test_dir_path= `SELECT CASE WHEN SUBSTR('$MYSQL_TEST_DIR', LENGTH('$HOME/'))='$HOME/' THEN CONCAT('~/', SUBSTR('$MYSQL_TEST_DIR', LENGTH('$HOME/')+1)) ELSE '$MYSQL_TEST_DIR' END`
 
 --echo # try to connect with '--ssl-ca' option using tilde home directoy
 --echo # path substitution : should connect

--- a/mysql-test/t/ssl_crl.test
+++ b/mysql-test/t/ssl_crl.test
@@ -19,7 +19,7 @@
 --echo #               PATH SUBSTITUTION
 --echo #
 
---let $mysql_test_dir_path= `SELECT REPLACE('$MYSQL_TEST_DIR', '$HOME', '~')`
+--let $mysql_test_dir_path= `SELECT CASE WHEN SUBSTR('$MYSQL_TEST_DIR', LENGTH('$HOME/'))='$HOME/' THEN CONCAT('~/', SUBSTR('$MYSQL_TEST_DIR', LENGTH('$HOME/')+1)) ELSE '$MYSQL_TEST_DIR' END`
 
 --echo # try to connect with '--ssl-crl' option using tilde home directoy
 --echo # path substitution : should connect


### PR DESCRIPTION
The MTR test files `ssl_ca.test` and `ssl_crl.test` both attempt to verify the absence of a bug relating to Unix home directory substitution, which involves replacing `~` as the leftmost pathname component with the value of the `HOME` environment variable.

However, the tests do so by replacing *all* occurrences of the value of `HOME` with '~' in the absolute path `MYSQL_TEST_DIR`.

This causes problems on systems where the value of `HOME` is a symlink.  For example, if `HOME=/home/myusername` (a symlink to `/local/home/myusername`) and `PWD=/local/home/myusername/MySQL`, the test will end up attempting to use nonsensical broken paths such as `/local~/MySQL/*`.

The solution is to ensure that the substitution occurs *only* at the beginning of the path, and when immediately followed by '/'.