### PR TITLE
mysqldump: add line break before each database row

### DIFF
--- a/client/mysqldump.cc
+++ b/client/mysqldump.cc
@@ -3946,7 +3946,7 @@ static void dump_table(char *table, char *db) {
                 : 0;
         if (extended_insert && !opt_xml) {
           if (first_column) {
-            dynstr_set_checked(&extended_row, "(");
+            dynstr_set_checked(&extended_row, "\n(");
             first_column = false;
           } else
             dynstr_append_checked(&extended_row, ",");
@@ -4084,7 +4084,7 @@ static void dump_table(char *table, char *db) {
         row_length = 2 + extended_row.length;
         if (total_length + row_length < opt_net_buffer_length) {
           total_length += row_length;
-          fputc(',', md_result_file); /* Always row break */
+          fputc(',', md_result_file);
           fputs(extended_row.str, md_result_file);
         } else {
           if (row_break) fputs(";\n", md_result_file);


### PR DESCRIPTION
I found the data format created by mysqldump slightly annoying. By default the INSERT INTO values are all on one very long line. This fix solves the issue. 

What I found very interesting is that the comment read 'Always row break' but there was _never_ a row break, so the code was not doing what it said.  That is the 'naive' place to put the line break, so all rows terminate with a newline. I opted to put the newline at the beginning of the line instead, so also the first row goes on its own line.

https://github.com/mysql/mysql-server/blob/ea1efa9822d81044b726aab20c857d5e1b7e046a/client/mysqldump.cc#L4081-L4087

This is the output without the patch:

```
--
-- Dumping data for table `category`
--

LOCK TABLES `category` WRITE;
/*!40000 ALTER TABLE `category` DISABLE KEYS */;
INSERT INTO `category` VALUES (1,'Action','2006-02-15 04:46:27'),(2,'Animation','2006-02-15 04:46:27'),(3,'Children','2006-02-15 04:46:27'),(4,'Classics','2006-02-15 04:46:27'),(5,'Comedy','2006-02-15 04:46:27'),(6,'Documentary','2006-02-15 04:46:27'),(7,'Drama','2006-02-15 04:46:27'),(8,'Family','2006-02-15 04:46:27'),(9,'Foreign','2006-02-15 04:46:27'),(10,'Games','2006-02-15 04:46:27'),(11,'Horror','2006-02-15 04:46:27'),(12,'Music','2006-02-15 04:46:27'),(13,'New','2006-02-15 04:46:27'),(14,'Sci-Fi','2006-02-15 04:46:27'),(15,'Sports','2006-02-15 04:46:27'),(16,'Travel','2006-02-15 04:46:27');
```

and this is with the patch:

```
--
-- Dumping data for table `category`
--

LOCK TABLES `category` WRITE;
/*!40000 ALTER TABLE `category` DISABLE KEYS */;
INSERT INTO `category` VALUES
(1,'Action','2006-02-15 04:46:27'),
(2,'Animation','2006-02-15 04:46:27'),
(3,'Children','2006-02-15 04:46:27'),
(4,'Classics','2006-02-15 04:46:27'),
(5,'Comedy','2006-02-15 04:46:27'),
...
```
much easier to handle.


After I created the patch, I found this enhancement request concerning this issue:
https://bugs.mysql.com/bug.php?id=65465