### PR TITLE
Fix usage of BIO_get_mem_data

### DIFF
--- a/sql-common/oci/ssl.cc
+++ b/sql-common/oci/ssl.cc
@@ -51,7 +51,7 @@ std::string base64_encode(const void *binary, size_t length) {
   BIO_push(b64.get(), sink);
   BIO_write(b64.get(), binary, static_cast<int>(length));
   if (BIO_flush(b64.get()) != 1) return {};
-  const char *encoded;
+  char *encoded;
   const size_t result_length = BIO_get_mem_data(sink, &encoded);
   return {encoded, result_length};
 }


### PR DESCRIPTION
According to the function signature in OpenSSL's documentation, the `BIO_get_mem_data` function should take a `char **` argument instead of a `const char **`. `const char**` and `char **` aren't directly interchangeable, and using `const char**` is considered a misusage.

Reference: https://www.openssl.org/docs/man1.1.1/man3/BIO_get_mem_data.html

I am contributing on behalf of my employer Amazon Web Services.