### PR TITLE
On s390x, use the stckf instruction to get the cycles timer value.

### DIFF
--- a/mysys/my_rdtsc.cc
+++ b/mysys/my_rdtsc.cc
@@ -173,7 +173,7 @@ ulonglong my_timer_cycles(void) {
 #elif defined(__GNUC__) && defined(__s390x__)
   {
     uint64_t result;
-    __asm __volatile__("stck %0" : "=Q"(result) : : "cc");
+    __asm __volatile__("stckf %0" : "=Q"(result) : : "cc");
     return result;
   }
 #elif defined(HAVE_SYS_TIMES_H) && defined(HAVE_GETHRTIME)


### PR DESCRIPTION
The test ut0rnd.random_from_interval_fast from test suite merge_innodb_tests-t is failing on s390x on 8.0.34 because the stck (Store Clock) instruction in the my_timer_cycles() function is not very good when used as a source of randomness in random_64_fast().

The stckf (Store Clock Fast) instruction works much better as a source of randomness and is less expensive to call as well. Compared to stck, stckf may store the same clock value twice but according to the Additional Comments comment in mysys/my_rdtsc.cc that should be fine. All 'make test' tests pass with this change.

The stckf instruction was added to the Z Architecture in z9 and all of the s390x versions of distros MySQL supports are compiled for z9 or newer so we don't need to check if it is available.