### PR TITLE
Bug #103275: Fix startup hang when memcached enabled and DB has many tables

### DIFF
--- a/include/my_thread.h
+++ b/include/my_thread.h
@@ -177,5 +177,7 @@ extern void my_thread_global_end();
 // Need to be extern "C" for the time being, due to memcached.
 extern "C" bool my_thread_init();
 extern "C" void my_thread_end();
+extern void my_dd_reset_tables_and_tablespaces_set_done();
+extern "C" bool my_is_dd_reset_tables_and_tablespaces_done();
 
 #endif /* MY_THREAD_INCLUDED */

--- a/mysys/my_init.cc
+++ b/mysys/my_init.cc
@@ -457,7 +457,8 @@ PSI_mutex_key key_IO_CACHE_append_buffer_lock, key_IO_CACHE_SHARE_mutex,
     key_KEY_CACHE_cache_lock, key_THR_LOCK_charset, key_THR_LOCK_heap,
     key_THR_LOCK_lock, key_THR_LOCK_malloc, key_THR_LOCK_mutex,
     key_THR_LOCK_myisam, key_THR_LOCK_net, key_THR_LOCK_open,
-    key_THR_LOCK_threads, key_TMPDIR_mutex, key_THR_LOCK_myisam_mmap;
+    key_THR_LOCK_threads, key_TMPDIR_mutex, key_THR_LOCK_myisam_mmap,
+    key_THR_LOCK_dd_cache;
 
 #ifdef HAVE_PSI_MUTEX_INTERFACE
 
@@ -484,6 +485,8 @@ static PSI_mutex_info all_mysys_mutexes[] = {
      PSI_DOCUMENT_ME},
     {&key_TMPDIR_mutex, "TMPDIR_mutex", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
     {&key_THR_LOCK_myisam_mmap, "THR_LOCK_myisam_mmap", PSI_FLAG_SINGLETON, 0,
+     PSI_DOCUMENT_ME},
+    {&key_THR_LOCK_dd_cache, "THR_LOCK_dd_cache", PSI_FLAG_SINGLETON, 0,
      PSI_DOCUMENT_ME}};
 #endif /* HAVE_PSI_MUTEX_INTERFACE */
 

--- a/mysys/mysys_priv.h
+++ b/mysys/mysys_priv.h
@@ -47,7 +47,8 @@ extern PSI_mutex_key key_IO_CACHE_append_buffer_lock, key_IO_CACHE_SHARE_mutex,
     key_KEY_CACHE_cache_lock, key_THR_LOCK_charset, key_THR_LOCK_heap,
     key_THR_LOCK_lock, key_THR_LOCK_malloc, key_THR_LOCK_mutex,
     key_THR_LOCK_myisam, key_THR_LOCK_net, key_THR_LOCK_open,
-    key_THR_LOCK_threads, key_TMPDIR_mutex, key_THR_LOCK_myisam_mmap;
+    key_THR_LOCK_threads, key_TMPDIR_mutex, key_THR_LOCK_myisam_mmap, 
+    key_THR_LOCK_dd_cache;
 
 extern PSI_rwlock_key key_SAFE_HASH_lock;
 

--- a/plugin/innodb_memcached/daemon_memcached/daemon/memcached.c
+++ b/plugin/innodb_memcached/daemon_memcached/daemon/memcached.c
@@ -44,6 +44,7 @@
 #define INNODB_MEMCACHED
 void my_thread_init();
 void my_thread_end();
+bool my_is_dd_reset_tables_and_tablespaces_done();
 
 static inline void item_set_cas(const void *cookie, item *it, uint64_t cas) {
     settings.engine.v1->item_set_cas(settings.engine.v0, cookie, it, cas);
@@ -7864,6 +7865,10 @@ int main (int argc, char **argv) {
 
     /* initialize main thread libevent instance */
     main_base = event_init();
+
+#ifdef INNODB_MEMCACHED
+    my_is_dd_reset_tables_and_tablespaces_done();
+#endif
 
     /* Load the storage engine */
     ENGINE_HANDLE *engine_handle = NULL;

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -6865,6 +6865,7 @@ static int init_server_components() {
   if (dd::reset_tables_and_tablespaces()) {
     unireg_abort(MYSQLD_ABORT_EXIT);
   }
+  my_dd_reset_tables_and_tablespaces_set_done();
   ha_post_recover();
 
   /*


### PR DESCRIPTION
Description
============
As reported in https://bugs.mysql.com/bug.php?id=103275 ,when memcached is enabled and a MySQL DB has many tables,
the database hangs on startup due to a deadlock between the memcached plugin and the mysqld main thread.
This deadlock is because memcached is waiting for a lock that is held by the main thread whereas the main
thread is waiting on a condition variable whose notifier is unknown.

The cause of this deadlock is a race condition created at startup when the mysqld main thread is resetting
the shared dictionary cache while at the same time memcached is populating this same cache as it accesses underlying
objects during its own initialization.

To solve the problem, we ensure strict ordering between shared dictionary cache resetting and memcached
initialization. We use a single flag protected in a critical region to communicate completion of shared
dictionary cache resetting between the mysqld main thread and the memcached thread. The memcached polls this flag
with a back-off period of 1 second in case it is not set. It is expected that the back-off period never to be hit more than
once as the resetting of the shared dictionary cache is a quick process, and so if the memcached thread polls the flag
once and finds it unset, it is likely to find it set on the next try.

## Rationale for implementation
The mutex lock has got 2 reasons for its usage in the implementation:

- To ensure that access to flag are atomic: We do not want a scenario in which the writer thread partially
updates the flag and then gets evicted from execution by the OS, and then the reader thread reads the flag while it is in
an inconsitent state. This scenario in modern C++ is normally handled by std::atomic_bool (std::atomic<bool>), but is not
available in C for use in memcached.
- We want to ensure that there is no compiler or CPU reordering of instructions on either side of the pthread_mutex. Normally
with C++ one would use std::atomic_thread_fence, but it is not usable for this case because memcached is a C library rather
than a C++ one. When we attempted to use it, we got linker errors, so we decided to create a "poor man's" fence.
pthread_mutex has fencing capabilities, see https://stackoverflow.com/a/24138417 , and so using it allows
us to make sure that the dd cache clearing instructions fully run and set the flag, before the memcached
initialization happens hence ensuring strict ordering.

Reason for implementing a polling with back-off period in the memcached plugin thread:

We want to avoid any additional synchronization mechanisms as our main goal is ordering and not multithreaded
synchronization, so we opt not to use pthread_cond_timedwait but instead do the following:

- If we successfully lock the mutex, we check the flag, and if it is set, we just move on to initialization of the
memcached plugin.
- If we successfully lock the mutex, but find that the flag is not set, then we want to signal to the OS that we want the
memcached thread to be suspended so that other threads can take its execution slot. Even though whichever thread that is
chosen to take the memcached thread's slot is random, we are at least giving a chance for the main thread to to proceed
and hopefully complete dd shared dictionary cache resetting.
- If we do not get the lock, we want to signal to the OS that the memached thread's execution slot can be ceded to
another thread while we wait for 1 second. During this time we are expecting the resetting of the dd shared
dictionary cache will have completed. I.e. we expect this back-off to only happen once.

This contribution is under the OCA signed by Amazon and covering submissions to the MySQL project.

Testing
=======

### Test scenario 1: memcached is installed and conditions that cause the startup hang exist

1. Log into the mysql server

    ```
    cd /<path to mysql>/mysql-8.0.34
    bin/mysql -u root --skip-password
    ```

2. Run the memcached setup script:

    ```
    mysql> source /<path to mysql>/mysql-8.0.34/share/innodb_memcached_config.sql
    ```

3. Activate the daemon_memcached plugin by running the INSTALL PLUGIN statement:

    ```
    mysql> INSTALL PLUGIN daemon_memcached soname "libmemcached.so";
    ```

4. Create a test database that will hold the many tables to be created:

    ```
    mysql> create database testdb1;
    ```

5. Use sysbench to create the 10K tables in the `testdb1` database:

    ```
   sysbench /usr/share/sysbench/tests/include/oltp_legacy/insert.lua   --mysql-port=3306 --db-driver=mysql --mysql-table-engine=innodb --oltp-tables-count=10000 --oltp-table-size=1 --threads=100 --mysql-user=sbtest   --mysql-db=testdb1  --mysql-host=127.0.0.1 prepare
    ```

6.  Populate `innodb_memcache`.`containers` with the details of the 10K tables previously created:

    ```
    INSERT INTO `innodb_memcache`.`containers` select concat(table_name,table_schema), table_schema, table_name,'id','k','flags','cas','expiry','PRIMARY' from information_schema.tables where table_schema like 'testdb1' ;
    ```

7. Shutdown the MySQL server:

    ```
    mysql> shutdown;
    ```

8. Start up the MySQL server again. The server should not hang on startup.


### Test scenario 2: memcached is compiled and available but not installed

1. Log into the already running mysqld server:

    ```
    bin/mysql -u root --skip-password
    ```

2. Uninistall the previously installed memcached plugin:


    ```
    mysql> UNINSTALL PLUGIN daemon_memcached;
    ```

3. Confirm that the memcached plugin is not listed in `mysql.plugin`

    ```
    mysql> select * from mysql.plugin;
    ```

3. Shutdown the mysqld server:

    ```
    mysql> shutdown;
    ```

4. Startup the server and confirm that it does not hang on startup:

    ```
    $ bin/mysqld --user=msqluser
    2023-10-23T16:10:43.856349Z 0 [System] [MY-010116] [Server] /<path to sever>/mysql-8.0.34/bin/mysqld (mysqld 8.0.34) starting as process 120670
    2023-10-23T16:10:43.866809Z 1 [System] [MY-013576] [InnoDB] InnoDB initialization has started.
    2023-10-23T16:10:45.929823Z 1 [System] [MY-013577] [InnoDB] InnoDB initialization has ended.
    2023-10-23T16:10:46.955941Z 0 [Warning] [MY-010068] [Server] CA certificate ca.pem is self signed.
    2023-10-23T16:10:46.955971Z 0 [System] [MY-013602] [Server] Channel mysql_main configured to support TLS. Encrypted connections are now supported for this channel.
    2023-10-23T16:10:46.974434Z 0 [System] [MY-011323] [Server] X Plugin ready for connections. Socket: /tmp/mysqlx.sock
    2023-10-23T16:10:46.974473Z 0 [System] [MY-010931] [Server] /<path to sever>/mysql-8.0.34/bin/mysqld: ready for connections. Version: '8.0.34'  socket: '/tmp/mysql.sock'  port: 0  Source distribution.
    ```