### PR TITLE
fix: typo in sql_auth_cache.h

### DIFF
--- a/sql/auth/sql_auth_cache.h
+++ b/sql/auth/sql_auth_cache.h
@@ -232,7 +232,7 @@ class Acl_credential {
   LEX_CSTRING m_auth_string;
   /**
     The salt variable is used as the password hash for
-    native_password_authetication.
+    native_password_authentication.
   */
   uint8 m_salt[SCRAMBLE_LENGTH + 1];  // scrambled password in binary form
   /**


### PR DESCRIPTION
This PR fixes typos in **sql/auth/sql_auth_cache.h** file.

Following typos have been fixed:

`native_password_authetication` -> `native_password_authentication`

No other changes.