### PR TITLE
libmysql: workaround missing res_n* functions on e.g. musl

### DIFF
--- a/libmysql/CMakeLists.txt
+++ b/libmysql/CMakeLists.txt
@@ -441,6 +441,19 @@ IF(HAS_WARN_FLAG)
     )
 ENDIF()
 
+check_symbol_exists(res_ninit "resolv.h" HAVE_RES_NINIT_FUNCTION)
+check_symbol_exists(res_nsearch "resolv.h" HAVE_RES_NSEARCH_FUNCTION)
+check_symbol_exists(res_nclose "resolv.h" HAVE_RES_NCLOSE_FUNCTION)
+IF (HAVE_RES_NINIT_FUNCTION)
+	add_compile_definitions(HAVE_RES_NINIT)
+ENDIF(HAVE_RES_NINIT_FUNCTION)
+IF (HAVE_RES_NSEARCH_FUNCTION)
+	add_compile_definitions(HAVE_RES_NSEARCH)
+ENDIF(HAVE_RES_NSEARCH_FUNCTION)
+IF (HAVE_RES_NCLOSE_FUNCTION)
+	add_compile_definitions(HAVE_RES_NCLOSE)
+ENDIF(HAVE_RES_NCLOSE_FUNCTION)
+
 # Verify that libmysql_api_test runs OK
 ADD_CUSTOM_COMMAND(
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/libmysql_api_test.out

--- a/libmysql/dns_srv.cc
+++ b/libmysql/dns_srv.cc
@@ -37,6 +37,17 @@
 #include <netdb.h>
 #include <resolv.h>
 
+/* we don't have anything else but the non-thread-safe variants */
+#if !defined(HAVE_RES_NINIT)
+#define res_ninit(X)              (void)X
+#endif
+#if !defined(HAVE_RES_NSEARCH)
+#define res_nsearch(X,D,I,S,B,L)  res_search(D,I,S,B,L)
+#endif
+#if !defined(HAVE_RES_NCLOSE)
+#define res_nclose(X)             (void)X
+#endif
+
 // POSIX version
 
 static bool get_dns_srv(Dns_srv_data &data, const char *dnsname, int &error) {


### PR DESCRIPTION
musl doesn't have res_n* functions so we are falling back to the not thread safe ones.

Note that another approach was submitted at https://bugs.mysql.com/bug.php?id=106034 (https://github.com/mysql/mysql-server/pull/385) but that is arguably less portable given it takes the new path for everything non-glibc where things may already work fine (e.g. Solaris).

This patch is less invasive.

Bug: https://bugs.gentoo.org/761352
See also: https://github.com/mysql/mysql-server/pull/385
See also: https://bugs.mysql.com/bug.php?id=106034