### PR TITLE
fix plugin semisync find minAck bug

### DIFF
--- a/plugin/semisync/semisync_source.h
+++ b/plugin/semisync/semisync_source.h
@@ -552,8 +552,11 @@ class AckContainer : public Trace {
     AckInfo *ackinfo = nullptr;
 
     for (i = 0; i < m_size; i++) {
-      if (m_ack_array[i].less_than(log_file_name, log_file_pos))
+      if (m_ack_array[i].less_than(log_file_name, log_file_pos)) { 
         ackinfo = m_ack_array + i;
+        log_file_name = ackinfo->binlog_name;
+        log_file_pos = ackinfo->binlog_pos;
+      }
     }
 
     return ackinfo;


### PR DESCRIPTION
As [explanatory note](https://github.com/jiyfhust/mysql-server/blob/87307d4ddd88405117e3f1e51323836d57ab1f57/plugin/semisync/semisync_source.h#L540-L549) shows: 
>   Find the minimum ack which is smaller than given position. When more than
     one slots are minimum acks, it returns the one has smallest index.

the return ack is " the minimum ack which is smaller than given position", but the [minAck](https://github.com/jiyfhust/mysql-server/blob/87307d4ddd88405117e3f1e51323836d57ab1f57/plugin/semisync/semisync_source.h#L555C4-L556) return a value which is the last index who is smaller than given position.