### PR TITLE
Fixing typo in docstring

### DIFF
--- a/router/src/mysql_protocol/include/mysqlrouter/classic_protocol_message.h
+++ b/router/src/mysql_protocol/include/mysqlrouter/classic_protocol_message.h
@@ -232,8 +232,8 @@ inline bool operator==(const AuthMethodSwitch<Borrowed> &a,
  * like caching_sha2_password does:
  *
  * - 0x01 0x02 (send public key)
- * - 0x01 0x03 (send full handshake)
- * - 0x01 0x04 (fast path done)
+ * - 0x01 0x03 (fast path done)
+ * - 0x01 0x04 (send full handshake)
  */
 template <bool Borrowed>
 class AuthMethodData {


### PR DESCRIPTION
This docstring references the `caching_sha2_password` auth method. However, the meanings of two of the packets are swapped.

In `caching_sha2_password`, `0x03` refers to a successful fast authentication and `0x04` refers to a prompt for full authentication.

References:
* https://dev.mysql.com/doc/dev/mysql-server/latest/sha2__password_8cc.html#a32725d60d8b4cf18f2e933b4b80f87bf
* https://github.com/mysql/mysql-server/commit/1eab171d9fb12d5b012456c8e6f90c313991c124
* https://github.com/mysql/mysql-server/blob/87307d4ddd88405117e3f1e51323836d57ab1f57/router/src/routing/src/classic_auth_caching_sha2.h#L44