### PR TITLE
Bug#113442 Fix innodb corruption that is caused when a column order alter is allowed to proceed with ALGORITHM=INSTANT

### DIFF
--- a/mysql-test/suite/innodb/r/bug113442.result
+++ b/mysql-test/suite/innodb/r/bug113442.result
@@ -1,0 +1,31 @@
+SET GLOBAL innodb_fast_shutdown=2;
+CREATE TABLE `t1` (
+c1 int,
+c2 int,
+c3 int,
+c4 datetime
+);
+ALTER TABLE `t1` DROP COLUMN c3, MODIFY COLUMN c4 datetime after c1;
+INSERT INTO t1  (c1, c2)  VALUES (1, 10);
+INSERT INTO t1  (c1, c2)  VALUES (2, 20);
+INSERT INTO t1 select * from t1;
+INSERT INTO t1 select * from t1;
+INSERT INTO t1 select * from t1;
+INSERT INTO t1 select * from t1;
+INSERT INTO t1 select * from t1;
+INSERT INTO t1 select * from t1;
+INSERT INTO t1 select * from t1;
+INSERT INTO t1 select * from t1;
+INSERT INTO t1 select * from t1;
+INSERT INTO t1 select * from t1;
+INSERT INTO t1 select * from t1;
+INSERT INTO t1 select * from t1;
+INSERT INTO t1 select * from t1;
+INSERT INTO t1 select * from t1;
+INSERT INTO t1 select * from t1;
+INSERT INTO t1 select * from t1;
+# Kill and restart
+SELECT c1, c2 FROM t1 LIMIT 1;
+c1	c2
+1	10
+DROP TABLE t1;

--- a/mysql-test/suite/innodb/t/bug113442.test
+++ b/mysql-test/suite/innodb/t/bug113442.test
@@ -1,0 +1,46 @@
+##########################################################################
+# This test checks that if a drop column is done with a column order
+# change in the same ALTER statement and no ALTER ALGORITHM explicitly
+# provided, ALGORITHM=INSTANT is not used by default under-the-hood.
+# If ALGORITHM=INSTANT were used, the table would get corrupted.
+##########################################################################
+# Perform a fast shutdown so that the DB performs recovery on restart
+SET GLOBAL innodb_fast_shutdown=2;
+
+CREATE TABLE `t1` (
+  c1 int,
+  c2 int,
+  c3 int,
+  c4 datetime
+);
+
+ALTER TABLE `t1` DROP COLUMN c3, MODIFY COLUMN c4 datetime after c1;
+
+# Insert sufficiently large amounts of data that will have to be recovered
+# after a fast shutdown.
+INSERT INTO t1  (c1, c2)  VALUES (1, 10);
+INSERT INTO t1  (c1, c2)  VALUES (2, 20);
+INSERT INTO t1 select * from t1;
+INSERT INTO t1 select * from t1;
+INSERT INTO t1 select * from t1;
+INSERT INTO t1 select * from t1;
+INSERT INTO t1 select * from t1;
+INSERT INTO t1 select * from t1;
+INSERT INTO t1 select * from t1;
+INSERT INTO t1 select * from t1;
+INSERT INTO t1 select * from t1;
+INSERT INTO t1 select * from t1;
+INSERT INTO t1 select * from t1;
+INSERT INTO t1 select * from t1;
+INSERT INTO t1 select * from t1;
+INSERT INTO t1 select * from t1;
+INSERT INTO t1 select * from t1;
+INSERT INTO t1 select * from t1;
+
+--source include/kill_and_restart_mysqld.inc
+
+# After the restart, without the bugfix, the database will crash
+# and never successfully start up. Run a select to confirm that 
+# the database started up successfully
+SELECT c1, c2 FROM t1 LIMIT 1;
+DROP TABLE t1;

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -150,7 +150,6 @@ static const Alter_inplace_info::HA_ALTER_FLAGS INNOBASE_INSTANT_ALLOWED =
     Alter_inplace_info::DROP_VIRTUAL_COLUMN |
     Alter_inplace_info::ALTER_VIRTUAL_COLUMN_ORDER |
     Alter_inplace_info::ADD_STORED_BASE_COLUMN |
-    Alter_inplace_info::ALTER_STORED_COLUMN_ORDER |
     Alter_inplace_info::DROP_STORED_COLUMN;
 
 /** Operations on foreign key definitions (changing the schema only) */


### PR DESCRIPTION
Description
============

ALTER commands that change column order are not allowed to use ALGORITHM=INSTANT:

    mysql> ALTER TABLE test.`t` MODIFY COLUMN c4 datetime after c1, ALGORITHM=INSTANT;
    ERROR 1845 (0A000): ALGORITHM=INSTANT is not supported for this operation. Try ALGORITHM=COPY/INPLACE.

ALGORITHM=INSTANT is the default ALTER algorithm since MySQL 8.0.28 for operations such as add or drop column if no ALGORITHM is explicitly defined by the user. If a column order ALTER is run in the same query with an add or drop, the expectation is that InnoDB should use either COPY or INPLACE which are the lowest common denominator algorithms that are supported for the aforementioned operations. However, this is not the case currently as a drop done together with a column order leads to using ALGORITHM=INSTANT by default under-the-hood:


    mysql> ALTER TABLE test.`t` DROP COLUMN c3, MODIFY COLUMN c4 datetime after c1;
    Query OK, 0 rows affected (0.08 sec)
    Records: 0  Duplicates: 0  Warnings: 0

This causes a silent corruption of the table involved, that leads to a database crash when a database restart is performed. The cause of the corruption is a mismatch between the physical ordering and ordinal ordering of the columns. E.g. for the case tested
in which the position of column c4 was changed in the ALTER above, when we query the system tables we find that the
ordinal position of c4 puts it in the second position, in between columns c1 and c2, but its physical position places it
after c2 instead of before. See below:

    mysql> select table_id,ordinal_position,name,se_private_data from mysql.columns where table_id IN (select table_id  from mysql.columns where name='c1') order by table_id,ordinal_position;
    +----------+------------------+---------------------------+-----------------------------------+
    | table_id | ordinal_position | name                      | se_private_data                   |
    +----------+------------------+---------------------------+-----------------------------------+
    |      371 |                1 | c1                        | physical_pos=3;table_id=1067;     |
    |      371 |                2 | c4                        | physical_pos=6;table_id=1067;     |
    |      371 |                3 | c2                        | physical_pos=4;table_id=1067;     |
    |      371 |                4 | DB_ROW_ID                 | physical_pos=0;table_id=1067;     |
    |      371 |                5 | DB_TRX_ID                 | physical_pos=1;table_id=1067;     |
    |      371 |                6 | DB_ROLL_PTR               | physical_pos=2;table_id=1067;     |
    |      371 |                7 | !hidden!_dropped_v1_p5_c3 | physical_pos=5;version_dropped=1; |
    +----------+------------------+---------------------------+-----------------------------------+
    7 rows in set (0.03 sec)

The fix for this issue is to remove the flags for position ordering of columns from the constant that defines the flags of operations for which ALGORITHM=INSTANT is allowed. The fix solves the bug reported in https://bugs.mysql.com/bug.php?id=113442 . This bug was introduced by the commit 1cb4e7ffd70d and affects MySQL versions 8.0.28+.

Testing
=======
An MTR test has been added that performs both a column drop and column order change to confirm that no innodb corruption occurs.

A debug binary was also used to confirm that after the query `ALTER TABLE test.t DROP COLUMN c3, MODIFY COLUMN c4 datetime after c1;` has been run, the physical position of column `c4` comes before column `c2` as expected:

    +----------+------+-----+-------+--------+-----+-------------+------------------------------+---------------+-----------------+--------------+
    | TABLE_ID | NAME | POS | MTYPE | PRTYPE | LEN | HAS_DEFAULT | DEFAULT_VALUE                | VERSION_ADDED | VERSION_DROPPED | PHYSICAL_POS |
    +----------+------+-----+-------+--------+-----+-------------+------------------------------+---------------+-----------------+--------------+
    |     1066 | c1   |   0 |     6 |   1027 |   4 |           0 | NULL                         |             0 |               0 |            3 |
    |     1066 | c4   |   1 |     3 | 525324 |   5 |           0 | NULL                         |             0 |               0 |            6 |
    |     1066 | c2   |   2 |     6 |   1027 |   4 |           0 | NULL                         |             0 |               0 |            4 |
    +----------+------+-----+-------+--------+-----+-------------+------------------------------+---------------+-----------------+--------------+



This contribution is under the OCA signed by Amazon and covering submissions to the MySQL project.