### PR TITLE
Improved the way my_plugin_log_message() handles plugin_ptr argument

### DIFF
--- a/sql/log.cc
+++ b/sql/log.cc
@@ -2355,8 +2355,15 @@ int my_plugin_log_message(MYSQL_PLUGIN *plugin_ptr, plugin_log_level level,
       return 1;
   }
 
+  std::string plugin_name;
+  if (plugin) {
+    plugin_name = plugin->name.str;
+  } else {
+    plugin_name = "'Unknown' (plugin_ptr parameter has unexpected nullptr)";
+  }
+
   snprintf(format2, sizeof(format2) - 1, "Plugin %.*s reported: '%s'",
-           (int)plugin->name.length, plugin->name.str, format);
+           (int)plugin_name.length(), plugin_name.c_str(), format);
 
   va_start(args, format);
   vsnprintf(msg, sizeof(msg) - 1, format2, args);
@@ -2373,7 +2380,7 @@ int my_plugin_log_message(MYSQL_PLUGIN *plugin_ptr, plugin_log_level level,
         richer (service) interface can use that to add such
         information.
       */
-      .component(plugin->name.str)
+      .component(plugin_name.c_str())
       .verbatim(msg);
 
   return 0;


### PR DESCRIPTION
# Context
I have seen MySQL crashes in production when a plugin tries to log to mysqld's logfile.
This PR aims to make MySQL more resilient to this case.

This PR proposes to log a special message indicating the unexpected situation. This approach gives some extra information to admins to understand what is going on and the most important aspect it avoids MySQL from crashing.

# Explanation

If a plugin calls `"my_plugin_log_message"` passing the first argument as `nullptr` then MySQL crashes.
This happens because the function `"my_plugin_log_message"` does not validate the pointer but uses it directly. This situation could happen, for example, because of a bug in a plugin.

MySQL should be more resilient and not to crash and handle cases like this one, even if the bug comes from plugin.

Summary, the following call crashed MySQL
```c
my_plugin_log_message(nullptr, MY_ERROR_LEVEL, "hello")
```

I found this when trying to install a plugin and I got a stack-trace that looks like the one below:

```
2024-01-22T08:26:11.960906Z 2272391 [Note] [MY-010733] [Server] Shutting down plugin 'someplugin'
2024-01-22T08:26:11Z UTC - mysqld got signal 11 ;
Most likely, you have hit a bug, but this error can also be caused by malfunctioning hardware.
BuildID[sha1]=0b168807aaca44fa650560191d175e4fd878ff78
Thread pointer: 0x7f506c0896f0
Attempting backtrace. You can use the following information to find out
where mysqld died. If you see no messages after this, something went
terribly wrong...
stack_bottom = 7f61757d3c10 thread_stack 0x100000
/usr/sbin/mysqld(my_print_stacktrace(unsigned char const*, unsigned long)+0x41) [0x2131091]
/usr/sbin/mysqld(print_fatal_signal(int)+0x2a2) [0xfee7e2]
/usr/sbin/mysqld(handle_fatal_signal+0xa5) [0xfee995]
/lib64/libpthread.so.0(+0x12cf0) [0x7f6c8a14ccf0]
/usr/sbin/mysqld(my_plugin_log_message(void**, plugin_log_level, char const*, ...)+0xb0) [0x12bbf50]
/usr/lib64/mysql/plugin/someplugin.so(+0xed4) [0x7f5770eb8ed4]
/usr/sbin/mysqld(finalize_audit_plugin(st_plugin_int*)+0x35) [0xff1885]
/usr/sbin/mysqld() [0xe9b1a4]
/usr/sbin/mysqld() [0xe9f74b]
/usr/sbin/mysqld() [0xea67a2]
/usr/sbin/mysqld(Sql_cmd_install_plugin::execute(THD*)+0x22) [0xea7002]
/usr/sbin/mysqld(mysql_execute_command(THD*, bool)+0xae7) [0xe7f677]
/usr/sbin/mysqld(dispatch_sql_command(THD*, Parser_state*)+0x51b) [0xe82e6b]
/usr/sbin/mysqld(dispatch_command(THD*, COM_DATA const*, enum_server_command)+0x2341) [0xe857a1]
/usr/sbin/mysqld(do_command(THD*)+0x15b) [0xe8631b]
/usr/sbin/mysqld() [0xfde9f8]
/usr/sbin/mysqld() [0x2844714]
/lib64/libpthread.so.0(+0x81ca) [0x7f6c8a1421ca]
/lib64/libc.so.6(clone+0x43) [0x7f6c884e6e73]

Trying to get some variables.
Some pointers may be invalid and cause the dump to abort.
Query (7f506c134140): INSTALL PLUGIN someplugin SONAME 'someplugin.so'
Connection ID (thread ID): 2272391
Status: NOT_KILLED
```

As you can see in the stack-trace, something went wrong during the plugin's initialization phase (or plugin's init returned a non-zero value) then MySQL called the plugin's `deinit` function, then the plugin called `my_plugin_log_message` with a `nullptr` and MySQL crashed.

The client received the following message
```
mysql> install plugin someplugin soname 'someplugin.so';
ERROR 2013 (HY000): Lost connection to MySQL server during query
No connection. Trying to reconnect...
ERROR 2002 (HY000): Can't connect to local MySQL server through socket '/tmp/mysql.sock' (111)
ERROR:
Can't connect to the server
```

The changes in this PR, improved the situation and generates the following entry in MySQL's log
```
2024-01-24T16:30:33.408895Z 8 [ERROR] [MY-000000] [Server] Plugin 'Unknown' (plugin_ptr parameter has unexpected nullptr, verify the plugin) reported: 'this is a message from a plugin'
```

The client gets the error below rather than a crash
```
mysql> install plugin someplugin soname 'someplugin.so';
ERROR 1123 (HY000): Can't initialize function 'someplugin'; Plugin initialization function failed.
mysql>
```


## How to reproduce the crash?

The plugin below shows how to reproduce the crash in `trunk` branch.
This plugins follow some of the most common practices found in multiple plugins such as: keep an internal reference to the `MYSQL_PLUGIN` struct during its lifecycle.

```c
#include <mysql/plugin.h>
#include <mysql/plugin_audit.h>
#include <mysql/service_my_plugin_log.h>


static MYSQL_PLUGIN g_plugin = nullptr;

static int crash_notify(__attribute__((unused)) MYSQL_THD thd,
                        __attribute__((unused)) mysql_event_class_t event_class,
                        __attribute__((unused)) const void *event) {
  return 0;
}

static struct st_mysql_audit crash_descriptor = {
    MYSQL_AUDIT_INTERFACE_VERSION, /* interface version    */
    NULL,                          /* release_thd function */
    crash_notify,                  /* notify function      */
    {
        0,                          /* general */
        MYSQL_AUDIT_CONNECTION_ALL, /* connection */
        0,                          /* parse */
        0,                          /* authorization */
        0,                          /* table access */
        0,                          /* global variables */
        0,                          /* server startup */
        0,                          /* server shutdown */
        0,                          /* command */
        0,                          /* query */
        0                           /* stored program */
    }};


static int crash_init(MYSQL_PLUGIN p) {
    my_plugin_log_message(&p, MY_ERROR_LEVEL, "This message is correct");

    /* Avoid setting g_plugin to force the crash
    Tell MySQL something went wrong and deinit()
    should be called.
    */
    return 1;
}

static int crash_deinit(__attribute__((unused)) MYSQL_PLUGIN p) {
  // g_plugin is nullptr
  my_plugin_log_message(&g_plugin, MY_ERROR_LEVEL, "this nullptr will crash MySQL");

  return 0;
}

mysql_declare_plugin(fastaudit){
    MYSQL_AUDIT_PLUGIN, /* type                            */
    &crash_descriptor,  /* descriptor                      */
    "crash",            /* name                            */
    "Martin",           /* author                          */
    "Crash plugin",     /* description                     */
    PLUGIN_LICENSE_GPL,
    crash_init, /* init function (when loaded)     */
    NULL,
    crash_deinit,  /* deinit function (when unloaded) */
    0x001, /* version                         */
    NULL,          /* status variables                */
    NULL,          /* system variables                */
    NULL,
    0,
} mysql_declare_plugin_end;
```