### PR TITLE
Unified behaviour when calling "plugin->deinit" for all plugin's types

### DIFF
--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -747,7 +747,7 @@ int ha_finalize_handlerton(st_plugin_int *plugin) {
       engine plugins.
     */
     DBUG_PRINT("info", ("Deinitializing plugin: '%s'", plugin->name.str));
-    if (plugin->plugin->deinit(nullptr)) {
+    if (plugin->plugin->deinit(plugin)) {
       DBUG_PRINT("warning", ("Plugin '%s' deinit function returned error.",
                              plugin->name.str));
     }

--- a/sql/sql_audit.cc
+++ b/sql/sql_audit.cc
@@ -766,7 +766,7 @@ static bool calc_class_mask(THD *, plugin_ref plugin, void *arg) {
 int finalize_audit_plugin(st_plugin_int *plugin) {
   unsigned long event_class_mask[MYSQL_AUDIT_CLASS_MASK_SIZE];
 
-  if (plugin->plugin->deinit && plugin->plugin->deinit(nullptr)) {
+  if (plugin->plugin->deinit && plugin->plugin->deinit(plugin)) {
     DBUG_PRINT("warning", ("Plugin '%s' deinit function returned error.",
                            plugin->name.str));
     DBUG_EXECUTE("finalize_audit_plugin", return 1;);

--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -5139,7 +5139,7 @@ int finalize_schema_table(st_plugin_int *plugin) {
   if (schema_table) {
     if (plugin->plugin->deinit) {
       DBUG_PRINT("info", ("Deinitializing plugin: '%s'", plugin->name.str));
-      if (plugin->plugin->deinit(nullptr)) {
+      if (plugin->plugin->deinit(plugin)) {
         DBUG_PRINT("warning", ("Plugin '%s' deinit function returned error.",
                                plugin->name.str));
       }


### PR DESCRIPTION
# Changes
This patch ensures that MySQL calls `plugin->deinit` with a valid plugin struct as argument no matter the plugin's type.

There is no reasons not to pass the `plugin struct` for all the extensible plugin's types.

# Rationale
Plugins usually implement `"deinit"` and `"deinit"` functions.
Those functions are called only once during the plugin lifecycle, **"init"** when installing a plugin and **"deinit"** when uninstalling a plugin (or something went wrong during the init phase).

## The following code shows how MySQL decides to call `deinit`
From [sql/sql_plugin.cc](https://github.com/mysql/mysql-server/blob/trunk/sql/sql_plugin.cc#L1129-L1140)
```cpp
  if (plugin_type_deinitialize[plugin->plugin->type]) {
    if ((*plugin_type_deinitialize[plugin->plugin->type])(plugin)) {
      LogErr(ERROR_LEVEL, ER_PLUGIN_FAILED_DEINITIALIZATION, plugin->name.str,
             plugin_type_names[plugin->plugin->type].str);
    }
  } else if (plugin->plugin->deinit) {
    DBUG_PRINT("info", ("Deinitializing plugin: '%s'", plugin->name.str));
    if (plugin->plugin->deinit(plugin)) {
      DBUG_PRINT("warning", ("Plugin '%s' deinit function returned error.",
                             plugin->name.str));
    }
  }
```

## Code explanation
Before calling `plugin->deinit`, MySQL verifies if for the given plugin's type there is a special function that handles the deinit phase. This is achieved by searching (using the plugin's type as index) in the array `plugin_type_deinitialize` in `sql/sql_plugin.cc`.

Currently, there are 3 special functions: `"ha_finalize_handlerton"` (MYSQL_STORAGE_PLUGIN), `"finalize_schema_table"` (MYSQL_INFORMATION_SCHEMA_PLUGIN) and `"finalize_audit_plugin"` (MYSQL_AUDIT_PLUGIN).

If there is not a special function then MySQL check if the plugin exposes a "deinit" function and executes it passing the "plugin struct" as argument. Otherwise, MySQL calls the "special function" passing the plugin as argument. Then the special function check if the plugin exposes a "deinit" function and then calls it but it always passes `nullptr` as argument rather than the "plugin struct".

Note: In case of `"init"` the code is similar but looks for special functions in the array `"plugin_type_initialize"`


The [documentation](https://dev.mysql.com/doc/extending-mysql/8.3/en/server-plugin-descriptors.html) says:
```
deinit: A once-only deinitialization function, or NULL if there is no such function.
The server executes this function when it unloads the plugin, which happens for UNINSTALL PLUGIN or,
for plugins listed in the mysql.plugin table, at server shutdown.
The function takes one argument that points to the internal structure used to identify the plugin It returns zero for success and nonzero for failure.
```

Doc does not explain that MySQL will always pass `nullptr` instead of the "plugin struct" for those plugin's types. Also it does not mention that it is plugin responsibility to check that pointer, using that pointer trusting it is not nullptr could crash MySQL.

Because of that, plugins of type "MYSQL_STORAGE_PLUGIN", "MYSQL_INFORMATION_SCHEMA_PLUGIN" and "MYSQL_AUDIT_PLUGIN" need to do something similar to the code below:
```cpp
static int xxx_deinit(MYSQL_PLUGIN p [[maybe_unused]])
static int xxx_deinit(MYSQL_PLUGIN p __attribute__((unused)))
```