### PR TITLE
fix typo change ENUM to SET

### DIFF
--- a/sql/dd/impl/types/column_impl.cc
+++ b/sql/dd/impl/types/column_impl.cc
@@ -147,7 +147,7 @@ bool Column_impl::validate() const {
   }
 
   if ((type() == enum_column_types::ENUM ||
-       type() == enum_column_types::ENUM) &&
+       type() == enum_column_types::SET) &&
       m_elements.empty()) {
     my_error(ER_INVALID_DD_OBJECT, MYF(0), DD_table::instance().name().c_str(),
              "There are no elements supplied.");


### PR DESCRIPTION
There seems to a typo when to check `m_elements.empty()`, because `m_elements` is related to `ENUM` and `SET`, the duplicate should be a typo problem.