### PR TITLE
Remove unnecessary whitespace in mysqldump

### DIFF
--- a/client/mysqldump.cc
+++ b/client/mysqldump.cc
@@ -2851,7 +2851,7 @@ static uint get_table_structure(const char *table, char *db, char *table_type,
       dynstr_set_checked(&insert_pat, "");
   }
 
-  insert_option = ((opt_ignore || skip_ddl) ? " IGNORE " : "");
+  insert_option = ((opt_ignore || skip_ddl) ? "IGNORE " : "");
 
   verbose_msg("-- Retrieving table structure for table %s...\n", table);
 


### PR DESCRIPTION
before this PR when mysqldump was used to create `INSERT` or `REPLACE` statements with additional table-options, one unnecessary space was written to the dump for each `INSERT` or `REPLACE`

before this PR:
```
INSERT  IGNORE INTO `test033` VALUES (1,'test test test');
```
_note the 2 spaces between `INSERT` and `IGNORE`_

after this PR:
```
INSERT IGNORE INTO `test033` VALUES (1,'test test test');
```

motivation: when dumping databases without additional compression, this results in one unnecessary byte per row in dump-files which wastes disc space or creates unnecessay network traffic. my thesis is, because compressing dumps requires an additional manual step (as its not used per default), there will be a lot of db dumps beeing exported without compression - and these will benefit.

at the scale mysql is used, this can easily add up. lets make sure we don't waste our planets resources :).