### PR TITLE
Fix operator name keywords causing obscure errors on -fno-operator-names

### DIFF
--- a/sql/iterators/ref_row_iterators.cc
+++ b/sql/iterators/ref_row_iterators.cc
@@ -297,7 +297,7 @@ int PushedJoinRefIterator::Read() {
     if (error) {
       return HandleError(error);
     }
-  } else if (not m_is_unique) {
+  } else if (!m_is_unique) {
     int error = table()->file->ha_index_next_pushed(table()->record[0]);
     if (error) {
       return HandleError(error);

--- a/storage/temptable/include/temptable/lock_free_type.h
+++ b/storage/temptable/include/temptable/lock_free_type.h
@@ -121,7 +121,7 @@ struct Lock_free_type_selector {
  * */
 template <typename T>
 struct Lock_free_type_selector<
-    T, typename std::enable_if<std::is_class<T>::value and
+    T, typename std::enable_if<std::is_class<T>::value &&
                                std::is_trivially_copyable<T>::value>::type> {
   static_assert(!std::is_same<T, T>::value,
                 "Querying always-lock-free property of trivially-copyable "
@@ -145,7 +145,7 @@ struct Lock_free_type_selector<
 template <typename T>
 struct Lock_free_type_selector<
     T,
-    typename std::enable_if<std::is_same<T, long long>::value or
+    typename std::enable_if<std::is_same<T, long long>::value ||
                             std::is_same<T, unsigned long long>::value>::type> {
 #if (ATOMIC_LLONG_LOCK_FREE == 2) || (WORKAROUND_PR31864_CLANG_BUG == 1)
   using Type = T;
@@ -159,7 +159,7 @@ struct Lock_free_type_selector<
 /** Template-specialization for long types. */
 template <typename T>
 struct Lock_free_type_selector<
-    T, typename std::enable_if<std::is_same<T, long>::value or
+    T, typename std::enable_if<std::is_same<T, long>::value ||
                                std::is_same<T, unsigned long>::value>::type> {
 #if (ATOMIC_LONG_LOCK_FREE == 2)
   using Type = T;
@@ -173,7 +173,7 @@ struct Lock_free_type_selector<
 /** Template-specialization for int types. */
 template <typename T>
 struct Lock_free_type_selector<
-    T, typename std::enable_if<std::is_same<T, int>::value or
+    T, typename std::enable_if<std::is_same<T, int>::value ||
                                std::is_same<T, unsigned int>::value>::type> {
 #if (ATOMIC_INT_LOCK_FREE == 2)
   using Type = T;
@@ -187,7 +187,7 @@ struct Lock_free_type_selector<
 /** Template-specialization for short types. */
 template <typename T>
 struct Lock_free_type_selector<
-    T, typename std::enable_if<std::is_same<T, short>::value or
+    T, typename std::enable_if<std::is_same<T, short>::value ||
                                std::is_same<T, unsigned short>::value>::type> {
 #if (ATOMIC_SHORT_LOCK_FREE == 2)
   using Type = T;
@@ -201,7 +201,7 @@ struct Lock_free_type_selector<
 /** Template-specialization for char types. */
 template <typename T>
 struct Lock_free_type_selector<
-    T, typename std::enable_if<std::is_same<T, char>::value or
+    T, typename std::enable_if<std::is_same<T, char>::value ||
                                std::is_same<T, unsigned char>::value>::type> {
 #if (ATOMIC_CHAR_LOCK_FREE == 2)
   using Type = T;


### PR DESCRIPTION
[Alternative operator name keywords](https://en.cppreference.com/w/cpp/language/operator_alternative) like `and`, `or`, `xor`, etc., are rarely used in MySQL and can cause obscure errors when the GCC flag `-fno-operator-names` is applied, for example:

```
/MySQL/storage/temptable/include/temptable/lock_free_type.h:125:75: error: template argument 2 is invalid
  125 |                                std::is_trivially_copyable<T>::value>::type> {
      |                                                                           ^
/MySQL/storage/temptable/include/temptable/lock_free_type.h:148:19: error: parse error in template argument list
  148 |     typename std::enable_if<std::is_same<T, long long>::value or
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  149 |                             std::is_same<T, unsigned long long>::value>::type> {
      |                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Replace the few occurrences of operator name keywords to use their primary counter parts, like `&&`, `||`, and `!`.