### PR TITLE
Add `goto func_exit` to ibd2sdi.cc

### DIFF
--- a/utilities/ibd2sdi.cc
+++ b/utilities/ibd2sdi.cc
@@ -1711,6 +1711,7 @@ uint64_t ibd2sdi::copy_compressed_blob(ib_tablespace *ts,
         page_id_t page_id(space_id, page_num);
         ib::error() << "Inflate() of compressed BLOB page " << page_id
                     << " returned " << err << " (" << d_stream.msg << ")";
+        goto func_exit;
       }
       case Z_BUF_ERROR:
         goto func_exit;


### PR DESCRIPTION
By adding this we eliminate an implicit fallthrough, opening the door to using `-Wimplicit-fallthrough` to make the code safer.