### PR TITLE
Fix build failure with WITH_INNODB_EXTRA_DEBUG set

### DIFF
--- a/storage/innobase/buf/buf0lru.cc
+++ b/storage/innobase/buf/buf0lru.cc
@@ -2135,7 +2135,7 @@ static bool buf_LRU_block_remove_hashed(buf_page_t *bpage, bool zip,
           case FIL_PAGE_RTREE:
 #ifdef UNIV_ZIP_DEBUG
             ut_a(page_zip_validate(&bpage->zip, page,
-                                   ((buf_block_t *)bpage)->index));
+                                   ((buf_block_t *)bpage)->ahi.index));
 #endif /* UNIV_ZIP_DEBUG */
             break;
           default:

--- a/storage/innobase/page/page0page.cc
+++ b/storage/innobase/page/page0page.cc
@@ -2580,15 +2580,7 @@ bool page_delete_rec(const dict_index_t *index, page_cur_t *pcur,
   }
 
   if (no_compress_needed) {
-#ifdef UNIV_ZIP_DEBUG
-    ut_a(!page_zip || page_zip_validate(page_zip, page, index));
-#endif /* UNIV_ZIP_DEBUG */
-
     page_cur_delete_rec(pcur, index, offsets, nullptr);
-
-#ifdef UNIV_ZIP_DEBUG
-    ut_a(!page_zip || page_zip_validate(page_zip, page, index));
-#endif /* UNIV_ZIP_DEBUG */
   }
 
   return (no_compress_needed);


### PR DESCRIPTION
Fixes two compile-time errors thrown with the WITH_INNODB_EXTRA_DEBUG flag set during compilation:
- in buf0lru.cc, a buf_block_t object incorrectly references `index` rather than through its member `ahi`
- in page0page.cc, zip debug checks are run despite the fact that the reference to the zipped page is no longer passed to the method