### PR TITLE
fix stale comment in my_command.h

### DIFF
--- a/include/my_command.h
+++ b/include/my_command.h
@@ -94,7 +94,7 @@ enum enum_server_command {
   COM_RESET_CONNECTION, /**< See @ref page_protocol_com_reset_connection */
   COM_CLONE,
   COM_SUBSCRIBE_GROUP_REPLICATION_STREAM,
-  /* don't forget to update const char *command_name[] in sql_parse.cc */
+  /* don't forget to update std::string Command_names::m_names[] in sql_parse.cc */
 
   /* Must be last */
   COM_END /**< Not a real command. Refused. */


### PR DESCRIPTION
A tinyfix of a comment to point [correct location](https://github.com/mysql/mysql-server/blob/trunk/sql/sql_parse.cc#L223-L259).