### PR TITLE
Fix: typo in comment about SQL statement rewriting

### DIFF
--- a/sql/sql_rewrite.cc
+++ b/sql/sql_rewrite.cc
@@ -319,7 +319,7 @@ bool rewrite_query(THD *thd, Consumer_type type, const Rewrite_params *params,
 }  // anonymous namespace
 
 /**
-  Provides the default interface to rewrite the SQL statements to
+  Provides the default interface to rewrite the SQL statements
   to obfuscate passwords.
 
   The query aimed to be rewritten in the usual log files


### PR DESCRIPTION
Removed an extra 'to' in the comment describing the default interface for SQL statement rewriting to obfuscate passwords. This correction improves the readability and accuracy of the documentation.