### PR TITLE
Use commonly supported TLSv1.3 ciphersuites in MTR

### DIFF
--- a/mysql-test/suite/group_replication/r/gr_recovery_tlsv13_incompatible_ciphersuites.result
+++ b/mysql-test/suite/group_replication/r/gr_recovery_tlsv13_incompatible_ciphersuites.result
@@ -14,7 +14,7 @@ SET SESSION sql_log_bin=1;
 SET @tls_version_saved= @@GLOBAL.tls_version;
 SET GLOBAL tls_version='TLSv1.3';
 SET @tls_ciphersuites_saved= @@GLOBAL.tls_ciphersuites;
-SET GLOBAL tls_ciphersuites='TLS_AES_128_CCM_8_SHA256';
+SET GLOBAL tls_ciphersuites='TLS_AES_256_GCM_SHA384';
 ALTER INSTANCE RELOAD TLS;
 #
 # Add some data and start the member
@@ -38,13 +38,13 @@ SET SESSION sql_log_bin= 1;
 SET @tls_version_saved= @@GLOBAL.tls_version;
 SET GLOBAL tls_version='TLSv1.3';
 SET @tls_ciphersuites_saved= @@GLOBAL.tls_ciphersuites;
-SET GLOBAL tls_ciphersuites='TLS_AES_128_CCM_8_SHA256';
+SET GLOBAL tls_ciphersuites='TLS_AES_256_GCM_SHA384';
 ALTER INSTANCE RELOAD TLS;
 CHANGE REPLICATION SOURCE TO SOURCE_USER="rec_ssl_user" FOR CHANNEL "group_replication_recovery";
 SET @group_replication_recovery_use_ssl_saved= @@GLOBAL.group_replication_recovery_use_ssl;
 SET GLOBAL group_replication_recovery_use_ssl=1;
 SET @group_replication_recovery_tls_ciphersuites_saved= @@GLOBAL.group_replication_recovery_tls_ciphersuites;
-SET GLOBAL group_replication_recovery_tls_ciphersuites='TLS_AES_128_CCM_SHA256';
+SET GLOBAL group_replication_recovery_tls_ciphersuites='TLS_CHACHA20_POLY1305_SHA256';
 SET @group_replication_recovery_retry_count_saved= @@GLOBAL.group_replication_recovery_retry_count;
 SET GLOBAL group_replication_recovery_retry_count= 1;
 include/start_group_replication.inc

--- a/mysql-test/suite/group_replication/t/gr_recovery_tlsv13_incompatible_ciphersuites.test
+++ b/mysql-test/suite/group_replication/t/gr_recovery_tlsv13_incompatible_ciphersuites.test
@@ -4,7 +4,7 @@
 # Test:
 # 0. The test requires two servers: M1 and M2.
 # 1. Setup the first member (M1) with a recovery user that requires TLS 1.3 with
-#    a non-default ciphersuite.
+#    one specific ciphersuite.
 # 2. Add some data and bootstrap start a group on M1.
 # 3. Configure a joining member (M2) to use SSL options and a different TLS
 #    ciphersuite on recovery. Member will not be able to join.
@@ -33,7 +33,7 @@ SET SESSION sql_log_bin=1;
 SET @tls_version_saved= @@GLOBAL.tls_version;
 SET GLOBAL tls_version='TLSv1.3';
 SET @tls_ciphersuites_saved= @@GLOBAL.tls_ciphersuites;
-SET GLOBAL tls_ciphersuites='TLS_AES_128_CCM_8_SHA256';
+SET GLOBAL tls_ciphersuites='TLS_AES_256_GCM_SHA384';
 ALTER INSTANCE RELOAD TLS;
 
 --echo #
@@ -66,7 +66,7 @@ SET SESSION sql_log_bin= 1;
 SET @tls_version_saved= @@GLOBAL.tls_version;
 SET GLOBAL tls_version='TLSv1.3';
 SET @tls_ciphersuites_saved= @@GLOBAL.tls_ciphersuites;
-SET GLOBAL tls_ciphersuites='TLS_AES_128_CCM_8_SHA256';
+SET GLOBAL tls_ciphersuites='TLS_AES_256_GCM_SHA384';
 ALTER INSTANCE RELOAD TLS;
 
 --disable_warnings
@@ -76,7 +76,7 @@ CHANGE REPLICATION SOURCE TO SOURCE_USER="rec_ssl_user" FOR CHANNEL "group_repli
 SET @group_replication_recovery_use_ssl_saved= @@GLOBAL.group_replication_recovery_use_ssl;
 SET GLOBAL group_replication_recovery_use_ssl=1;
 SET @group_replication_recovery_tls_ciphersuites_saved= @@GLOBAL.group_replication_recovery_tls_ciphersuites;
-SET GLOBAL group_replication_recovery_tls_ciphersuites='TLS_AES_128_CCM_SHA256';
+SET GLOBAL group_replication_recovery_tls_ciphersuites='TLS_CHACHA20_POLY1305_SHA256';
 
 SET @group_replication_recovery_retry_count_saved= @@GLOBAL.group_replication_recovery_retry_count;
 SET GLOBAL group_replication_recovery_retry_count= 1;


### PR DESCRIPTION
The `group_replication.gr_recovery_tlsv13_incompatible_ciphersuites` MTR uses non-default ciphersuites 'TLS_AES_128_CCM_8_SHA256' and 'TLS_AES_128_CCM_SHA256' that some TLS libraries such as BoringSSL don't support.

Since the `group_replication.gr_recovery_tlsv13_nondefault_ciphersuite` MTR already covers the use of non-default ciphersuites, using default ciphersuites in this MTR will allow the test to pass when building against forks of OpenSSL like BoringSSL.

This test now uses cipher suites: 'TLS_AES_256_GCM_SHA384' and 'TLS_CHACHA20_POLY1305_SHA256'.

This contribution is under the OCA signed by Amazon and covering submissions to the MySQL project.