### PR TITLE
Fix build if UNIV_ZIP_DEBUG is enabled

### DIFF
--- a/storage/innobase/buf/buf0lru.cc
+++ b/storage/innobase/buf/buf0lru.cc
@@ -2135,7 +2135,7 @@ static bool buf_LRU_block_remove_hashed(buf_page_t *bpage, bool zip,
           case FIL_PAGE_RTREE:
 #ifdef UNIV_ZIP_DEBUG
             ut_a(page_zip_validate(&bpage->zip, page,
-                                   ((buf_block_t *)bpage)->index));
+                                   ((buf_block_t *)bpage)->ahi.index));
 #endif /* UNIV_ZIP_DEBUG */
             break;
           default:

--- a/storage/innobase/page/page0page.cc
+++ b/storage/innobase/page/page0page.cc
@@ -2580,15 +2580,7 @@ bool page_delete_rec(const dict_index_t *index, page_cur_t *pcur,
   }
 
   if (no_compress_needed) {
-#ifdef UNIV_ZIP_DEBUG
-    ut_a(!page_zip || page_zip_validate(page_zip, page, index));
-#endif /* UNIV_ZIP_DEBUG */
-
     page_cur_delete_rec(pcur, index, offsets, nullptr);
-
-#ifdef UNIV_ZIP_DEBUG
-    ut_a(!page_zip || page_zip_validate(page_zip, page, index));
-#endif /* UNIV_ZIP_DEBUG */
   }
 
   return (no_compress_needed);


### PR DESCRIPTION
If the `UNIV_ZIP_DEBUG` flag is enabled during build, the build process may fail with the error:

```
In function ‘bool buf_LRU_block_remove_hashed(buf_page_t*, bool, bool)’: error: ‘struct buf_block_t’ has no member named ‘index’
                                    ((buf_block_t *)bpage)->index));
                                                            ^~~~~
```

Because the 'index' field was moved from the buf_block_t structure to the buf_block_t.ahi_t in the d7114b14050 commit.

The second error appears in the `page_delete_rec()`. Since the `page_zip` parameter was removed from the function in the 85f9abf990750, the assert checks that are enabled in a case of `UNIV_ZIP_DEBUG` are failed. As there is no such parameter in the `page_delete_rec()` function anymore the both assertions are removed.

The commit fixes the both compilation errors.