### PR TITLE
docs: multibyte collation for HandshakeResponse41

### DIFF
--- a/sql-common/client.cc
+++ b/sql-common/client.cc
@@ -4186,10 +4186,10 @@ error:
   <tr><td>@ref a_protocol_type_int4 "int&lt;4&gt;"</td>
     <td>max_packet_size</td>
     <td>maximum packet size</td></tr>
-  <tr><td>@ref a_protocol_type_int1 "int&lt;1&gt;"</td>
+  <tr><td>@ref a_protocol_type_int2 "int&lt;2&gt;"</td>
     <td>character_set</td>
-    <td>client charset \ref a_protocol_character_set, only the lower 8-bits</td></tr>
-  <tr><td>@ref sect_protocol_basic_dt_string_fix "string[23]"</td>
+    <td>client charset \ref a_protocol_character_set</td></tr>
+  <tr><td>@ref sect_protocol_basic_dt_string_fix "string[22]"</td>
     <td>filler</td>
     <td>filler to the size of the handhshake response packet. All 0s.</td></tr>
   <tr><td colspan="3">} else {</td></tr>
@@ -4858,10 +4858,10 @@ connect_stage STDCALL mysql_get_connect_nonblocking_stage(MYSQL *mysql) {
   <tr><td>@ref a_protocol_type_int4 "int&lt;4&gt;"</td>
     <td>max_packet_size</td>
     <td>maximum packet size</td></tr>
-  <tr><td>@ref a_protocol_type_int1 "int&lt;1&gt;"</td>
+  <tr><td>@ref a_protocol_type_int2 "int&lt;2&gt;"</td>
     <td>character_set</td>
-    <td>client charset \ref a_protocol_character_set, only the lower 8-bits</td></tr>
-  <tr><td>@ref sect_protocol_basic_dt_string_fix "string[23]"</td>
+    <td>client charset \ref a_protocol_character_set</td></tr>
+  <tr><td>@ref sect_protocol_basic_dt_string_fix "string[22]"</td>
     <td>filler</td>
     <td>filler to the size of the handhshake response packet. All 0s.</td></tr>
   <tr><td>@ref sect_protocol_basic_dt_string_null "string&lt;NUL&gt;"</td>


### PR DESCRIPTION
```python
import mysql.connector
c = mysql.connector.connect(
    host='127.0.0.1',
    port=3306,
    user="test",
    password="test",
    collation="utf8mb4_ja_0900_as_cs",
    ssl_disabled=True
)
cur = c.cursor()
cur.execute("SHOW SESSION VARIABLES LIKE '%collation%'");
for col in cur:
    print(col)
cur.close()
c.close()
```

Output:
```
('collation_connection', 'utf8mb4_ja_0900_as_cs')
('collation_database', 'utf8mb4_0900_ai_ci')
('collation_server', 'utf8mb4_ja_0900_as_cs')
('default_collation_for_utf8mb4', 'utf8mb4_0900_ai_ci')
```

This uses the `utf8mb4_ja_0900_as_cs` collation, which has ID=303. And 303 in hex is 0x012f. If only the lower 8 bits are sent this would be 0x2f (47 decimal). However the `0x01` is actually sent in the next byte.

![image](https://github.com/mysql/mysql-server/assets/1272980/492a4a58-8009-437b-88a8-87b6b3253e7b)
