### PR TITLE
mysql_tzinfo_to_sql: suppress expected warnings

### DIFF
--- a/sql/mysql_tzinfo_to_sql.cc
+++ b/sql/mysql_tzinfo_to_sql.cc
@@ -310,12 +310,12 @@ static bool scan_tz_dir(char *name_end) {
         }
       } else if (MY_S_ISREG(cur_dir->dir_entry[i].mystat->st_mode)) {
         bname = basename(fullname);
-        if ((strcmp(bname,"iso3166.tab") == 0) ||
-	  (strcmp(bname,"leap-seconds.list") == 0) ||
-	  (strcmp(bname,"leapseconds") == 0) ||
-	  (strcmp(bname,"tzdata.zi") == 0) ||
-	  (strcmp(bname,"zone.tab") == 0) ||
-	  (strcmp(bname,"zone1970.tab") == 0)) {
+        if ((strcmp(bname, "iso3166.tab") == 0) ||
+            (strcmp(bname, "leap-seconds.list") == 0) ||
+            (strcmp(bname, "leapseconds") == 0) ||
+            (strcmp(bname, "tzdata.zi") == 0) ||
+            (strcmp(bname, "zone.tab") == 0) ||
+            (strcmp(bname, "zone1970.tab") == 0)) {
           continue;
         }
 

--- a/sql/mysql_tzinfo_to_sql.cc
+++ b/sql/mysql_tzinfo_to_sql.cc
@@ -291,7 +291,7 @@ char *root_name_end;
 */
 static bool scan_tz_dir(char *name_end) {
   MY_DIR *cur_dir;
-  char *name_end_tmp;
+  char *name_end_tmp, *bname;
   uint i;
 
   if (!(cur_dir = my_dir(fullname, MYF(MY_WANT_STAT)))) return true;
@@ -309,6 +309,16 @@ static bool scan_tz_dir(char *name_end) {
           return true;
         }
       } else if (MY_S_ISREG(cur_dir->dir_entry[i].mystat->st_mode)) {
+        bname = basename(fullname);
+        if ((strcmp(bname,"iso3166.tab") == 0) ||
+	  (strcmp(bname,"leap-seconds.list") == 0) ||
+	  (strcmp(bname,"leapseconds") == 0) ||
+	  (strcmp(bname,"tzdata.zi") == 0) ||
+	  (strcmp(bname,"zone.tab") == 0) ||
+	  (strcmp(bname,"zone1970.tab") == 0)) {
+          continue;
+        }
+
         ::new ((void *)&tz_storage) MEM_ROOT(PSI_NOT_INSTRUMENTED, 32768);
         if (!tz_load(fullname, &tz_info, &tz_storage))
           print_tz_as_sql(root_name_end + 1, &tz_info);


### PR DESCRIPTION
See also https://bugs.mysql.com/bug.php?id=115019

Before:
```
$ mysql_tzinfo_to_sql /usr/share/zoneinfo/ | wc -l
Warning: Unable to load '/usr/share/zoneinfo//iso3166.tab' as time zone. Skipping it.
Warning: Unable to load '/usr/share/zoneinfo//leap-seconds.list' as time zone. Skipping it.
Warning: Unable to load '/usr/share/zoneinfo//leapseconds' as time zone. Skipping it.
Warning: Unable to load '/usr/share/zoneinfo//tzdata.zi' as time zone. Skipping it.
Warning: Unable to load '/usr/share/zoneinfo//zone.tab' as time zone. Skipping it.
Warning: Unable to load '/usr/share/zoneinfo//zone1970.tab' as time zone. Skipping it.
138261
```

After:
```
$ mysql_tzinfo_to_sql /usr/share/zoneinfo/ | wc -l
138261
```

Another way would be to check the file magic, which should be `TZif` starting at byte 0 for timezone files according to `/usr/share/magic`.