### PR TITLE
Fix incorrect number of seconds in a day (86400, not 84600)

### DIFF
--- a/sql/ssl_init_callback.cc
+++ b/sql/ssl_init_callback.cc
@@ -216,13 +216,13 @@ static Sys_var_bool Sys_var_opt_ssl_session_cache_mode(
     PERSIST_AS_READONLY GLOBAL_VAR(opt_ssl_session_cache_mode),
     CMD_LINE(OPT_ARG), DEFAULT(true), PFS_TRAILING_PROPERTIES);
 
-/* 84600 is 1 day in seconds */
+/* 86400 is 1 day in seconds */
 static Sys_var_long Sys_var_opt_ssl_session_cache_timeout(
     "ssl_session_cache_timeout",
     "The timeout to expire sessions in the TLS session cache",
     PERSIST_AS_READONLY GLOBAL_VAR(opt_ssl_session_cache_timeout),
     CMD_LINE(REQUIRED_ARG, OPT_SSL_SESSION_CACHE_TIMEOUT),
-    VALID_RANGE(0, 84600), DEFAULT(300), BLOCK_SIZE(1),
+    VALID_RANGE(0, 86400), DEFAULT(300), BLOCK_SIZE(1),
     PFS_TRAILING_PROPERTIES);
 
 /* Related to admin connection port */


### PR DESCRIPTION
Hi there, I used a code search and found an incorrect number of seconds in a day (84600 instead of 86400) listed in one of your files. I recommend fixing it to avoid incorrect timings that could potentially lead to unexpected behavior.

https://github.com/mysql/mysql-server/blob/824e2b4064053f7daf17d7f3f84b7a3ed92e5fb4/sql/ssl_init_callback.cc#L219

Fix incorrect number of seconds in a day (86400, not 84600)