### PR TITLE
Update README.build

### DIFF
--- a/Docs/README.build
+++ b/Docs/README.build
@@ -47,7 +47,7 @@ or
 cmake --build . --config RelWithDebInfo
 
 You can pass options to msbuild, see
-https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild-command-line-reference?view=vs-2019
+https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-command-line-reference?view=vs-2019
 
 To speed up compilation, building multiple projects in parallel:
 cmake --build . --config Debug -- -m


### PR DESCRIPTION
The subdomain docs has been redirected to learn. 

My PR corrects the subdomain to ensure it points to the final url rather than needing the redirection.