### PR TITLE
Replace MOCK_METHODN and MOCK_CONST_METHODN with general MOCK_METHOD

### DIFF
--- a/router/src/routing/tests/test_connection.cc
+++ b/router/src/routing/tests/test_connection.cc
@@ -62,8 +62,8 @@ class MockProtocol : public BaseProtocol {
 
   /* Mocking copy_packet triggers compilation error in VS so let's just stub it,
      it is good enough for our needs here. */
-  /* MOCK_METHOD8(copy_packets, int(int, int, bool,
-     RoutingProtocolBuffer&, int* , bool&, size_t*, bool)); */
+  /* MOCK_METHOD(int, copy_packets, (int, int, bool,
+     RoutingProtocolBuffer&, int* , bool&, size_t*, bool),  (override)); */
   stdx::expected<size_t, std::error_code> copy_packets(int, int, bool,
                                                        std::vector<uint8_t> &,
                                                        int *, bool &, bool) {

--- a/unittest/gunit/base_mock_handler.h
+++ b/unittest/gunit/base_mock_handler.h
@@ -40,23 +40,28 @@ class Base_mock_HANDLER : public handler {
  public:
   // Declare all the pure-virtuals.
   // Note: Sun Studio needs a little help in resolving uchar.
-  MOCK_METHOD0(close, int());
-  MOCK_METHOD4(create, int(const char *name, TABLE *form, HA_CREATE_INFO *,
-                           dd::Table *table_def));
-  MOCK_METHOD1(info, int(unsigned ha_status_bitmap));
-  MOCK_METHOD4(open, int(const char *name, int mode, uint test_if_locked,
-                         const dd::Table *table_def));
-  MOCK_METHOD1(position, void(const ::uchar *record));
-  MOCK_METHOD1(rnd_init, int(bool scan));
-  MOCK_METHOD1(rnd_next, int(::uchar *buf));
-  MOCK_METHOD2(rnd_pos, int(::uchar *buf, ::uchar *pos));
-  MOCK_METHOD3(store_lock,
-               THR_LOCK_DATA **(THD *, THR_LOCK_DATA **, thr_lock_type));
+  MOCK_METHOD(int, close, (), (override));
+  MOCK_METHOD(int, create,
+              (const char *name, TABLE *form, HA_CREATE_INFO *,
+               dd::Table *table_def),
+              (override));
+  MOCK_METHOD(int, info, (unsigned ha_status_bitmap), (override));
+  MOCK_METHOD(int, open,
+              (const char *name, int mode, uint test_if_locked,
+               const dd::Table *table_def),
+              (override));
+  MOCK_METHOD(void, position, (const ::uchar *record), (override));
+  MOCK_METHOD(int, rnd_init, (bool scan), (override));
+  MOCK_METHOD(int, rnd_next, (::uchar * buf), (override));
+  MOCK_METHOD(int, rnd_pos, (::uchar * buf, ::uchar *pos), (override));
+  MOCK_METHOD(THR_LOCK_DATA **, store_lock,
+              (THD *, THR_LOCK_DATA **, thr_lock_type), (override));
 
-  MOCK_CONST_METHOD3(index_flags, ulong(::uint idx, ::uint part, bool));
-  MOCK_CONST_METHOD0(table_flags, Table_flags());
-  MOCK_CONST_METHOD0(table_type, const char *());
-  MOCK_METHOD2(print_error, void(int error, myf errflag));
+  MOCK_METHOD(ulong, index_flags, (::uint idx, ::uint part, bool),
+              (const, override));
+  MOCK_METHOD(Table_flags, table_flags, (), (const, override));
+  MOCK_METHOD(const char *, table_type, (), (const, override));
+  MOCK_METHOD(void, print_error, (int error, myf errflag), (override));
 
   Base_mock_HANDLER(handlerton *ht_arg, TABLE_SHARE *share_arg)
       : handler(ht_arg, share_arg) {}

--- a/unittest/gunit/copy_info-t.cc
+++ b/unittest/gunit/copy_info-t.cc
@@ -63,7 +63,7 @@ class Mock_field : public Field_long {
   explicit Mock_field(uchar auto_flags_arg)
       : Field_long(nullptr, 0, nullptr, 0, auto_flags_arg, "", false, false) {}
 
-  MOCK_METHOD1(store_timestamp, void(const my_timeval *));
+  MOCK_METHOD(void, store_timestamp, (const my_timeval *), (override));
 };
 
 /*

--- a/unittest/gunit/dd.h
+++ b/unittest/gunit/dd.h
@@ -73,14 +73,15 @@ using ::testing::StrictMock;
 class Mock_dd_HANDLER : public Base_mock_HANDLER {
  public:
   // Mock method used indirectly by find_record
-  MOCK_METHOD4(index_read_map, int(::uchar *, const ::uchar *, key_part_map,
-                                   enum ha_rkey_function));
+  MOCK_METHOD(int, index_read_map,
+              (::uchar *, const ::uchar *, key_part_map, enum ha_rkey_function),
+              (override));
 
   // Handler method used for inserts
-  MOCK_METHOD1(write_row, int(::uchar *));
+  MOCK_METHOD(int, write_row, (::uchar *), (override));
 
   // Handler method used for updates
-  MOCK_METHOD2(update_row, int(const ::uchar *, ::uchar *));
+  MOCK_METHOD(int, update_row, (const ::uchar *, ::uchar *), (override));
 
   Mock_dd_HANDLER(handlerton *hton, TABLE_SHARE *share)
       : Base_mock_HANDLER(hton, share) {}
@@ -104,9 +105,9 @@ class Mock_dd_field_longlong : public Base_mock_field_longlong {
     Mock the store and val_int methods.
     Note: Sun Studio needs a little help in resolving longlong.
   */
-  MOCK_METHOD2(store, type_conversion_status(::longlong, bool));
-  MOCK_CONST_METHOD0(val_int, ::longlong(void));
-  MOCK_METHOD0(val_uint, ::ulonglong(void));
+  MOCK_METHOD(type_conversion_status, store, (::longlong, bool), (override));
+  MOCK_METHOD(::longlong, val_int, (void), (const, override));
+  MOCK_METHOD(::ulonglong, val_uint, (void), (override));
 
   /*
     Add fake methods to set and get expected contents.
@@ -140,9 +141,9 @@ class Mock_dd_field_varstring : public Base_mock_field_varstring {
   /*
     Mock the store and var_str methods.
   */
-  MOCK_METHOD3(store, type_conversion_status(const char *, size_t length,
-                                             const CHARSET_INFO *));
-  MOCK_CONST_METHOD2(val_str, String *(String *, String *));
+  MOCK_METHOD(type_conversion_status, store,
+              (const char *, size_t length, const CHARSET_INFO *), (override));
+  MOCK_METHOD(String *, val_str, (String *, String *), (override));
 
   /*
     Add fake methods to set and get expected contents.

--- a/unittest/gunit/dphyp-t.cc
+++ b/unittest/gunit/dphyp-t.cc
@@ -47,9 +47,9 @@ using hypergraph::PrintSet;
 
 class MockReceiver {
  public:
-  MOCK_METHOD1(HasSeen, bool(NodeMap));
-  MOCK_METHOD1(FoundSingleNode, bool(int));
-  MOCK_METHOD3(FoundSubgraphPair, bool(NodeMap, NodeMap, int));
+  MOCK_METHOD(bool, HasSeen, (NodeMap));
+  MOCK_METHOD(bool, FoundSingleNode, (int));
+  MOCK_METHOD(bool, FoundSubgraphPair, (NodeMap, NodeMap, int));
 };
 
 TEST(DPhypTest, ExampleHypergraph) {

--- a/unittest/gunit/handler-t.h
+++ b/unittest/gunit/handler-t.h
@@ -64,9 +64,9 @@ class Mock_SAMPLING_HANDLER : public Base_mock_HANDLER {
     Declare the members we actually want to test. These are the members that
     should be called by the "default" sampling implementation.
   */
-  MOCK_METHOD1(rnd_init, int(bool scan));
-  MOCK_METHOD1(rnd_next, int(::uchar *buf));
-  MOCK_METHOD0(rnd_end, int());
+  MOCK_METHOD(int, rnd_init, (bool scan), (override));
+  MOCK_METHOD(int, rnd_next, (::uchar * buf), (override));
+  MOCK_METHOD(int, rnd_end, (), (override));
 
   Mock_SAMPLING_HANDLER(handlerton *ht_arg, TABLE *table_arg,
                         TABLE_SHARE *share)

--- a/unittest/gunit/item-t.cc
+++ b/unittest/gunit/item-t.cc
@@ -116,7 +116,8 @@ class Mock_field_long : public Field_long {
     This is the only member function we need to override.
     Note: Sun Studio needs a little help in resolving longlong.
   */
-  MOCK_METHOD2(store, type_conversion_status(::longlong nr, bool unsigned_val));
+  MOCK_METHOD(type_conversion_status, store, (::longlong nr, bool unsigned_val),
+              (override));
 };
 
 /**

--- a/unittest/gunit/libmysqlgcs/xcom/gcs_logging-t.cc
+++ b/unittest/gunit/libmysqlgcs/xcom/gcs_logging-t.cc
@@ -33,9 +33,10 @@ class Mock_Logger : public Logger_interface {
   }
 
   ~Mock_Logger() = default;
-  MOCK_METHOD0(initialize, enum_gcs_error());
-  MOCK_METHOD0(finalize, enum_gcs_error());
-  MOCK_METHOD2(log_event, void(const gcs_log_level_t, const std::string &));
+  MOCK_METHOD(enum_gcs_error, initialize, (), (override));
+  MOCK_METHOD(enum_gcs_error, finalize, (), (override));
+  MOCK_METHOD(void, log_event, (const gcs_log_level_t, const std::string &),
+              (override));
 };
 
 class LoggingInfrastructureTest : public GcsBaseTestNoLogging {

--- a/unittest/gunit/libmysqlgcs/xcom/gcs_logging_system-t.cc
+++ b/unittest/gunit/libmysqlgcs/xcom/gcs_logging_system-t.cc
@@ -30,12 +30,14 @@ namespace gcs_logging_unittest {
 
 class Mock_gcs_log_sink : public Sink_interface {
  public:
-  MOCK_METHOD1(log_event, void(const std::string &message));
-  MOCK_METHOD2(log_event, void(const char *message, size_t message_size));
-  MOCK_METHOD0(initialize, enum_gcs_error());
-  MOCK_METHOD0(finalize, enum_gcs_error());
+  MOCK_METHOD(void, log_event, (const std::string &message), (override));
+  MOCK_METHOD(void, log_event, (const char *message, size_t message_size),
+              (override));
+  MOCK_METHOD(enum_gcs_error, initialize, (), (override));
+  MOCK_METHOD(enum_gcs_error, finalize, (), (override));
   /* purecov: begin deadcode */
-  MOCK_CONST_METHOD0(get_information, const std::string());
+  MOCK_METHOD(const std::string, get_information, std::string(),
+              (const, override));
   /* purecov: end */
 };
 
@@ -178,12 +180,14 @@ class Wrapper_file_sink : public Sink_interface {
 
   ~Wrapper_file_sink() { delete m_sink; }
 
-  MOCK_METHOD1(log_event, void(const std::string &message));
-  MOCK_METHOD2(log_event, void(const char *message, size_t message_size));
-  MOCK_METHOD0(initialize, enum_gcs_error());
-  MOCK_METHOD0(finalize, enum_gcs_error());
-  MOCK_METHOD1(get_file_name, enum_gcs_error(char *file_name_buffer));
-  MOCK_CONST_METHOD0(get_information, const std::string());
+  MOCK_METHOD(void, log_event, (const std::string &message), (override));
+  MOCK_METHOD(void, log_event, (const char *message, size_t message_size),
+              (override));
+  MOCK_METHOD(enum_gcs_error, initialize, (), (override));
+  MOCK_METHOD(enum_gcs_error, finalize, (), (override));
+  MOCK_METHOD(enum_gcs_error, get_file_name, (char *file_name_buffer),
+              (override));
+  MOCK_METHOD(const std::string, get_information, (), (const, override));
 
  private:
   Gcs_file_sink *m_sink;

--- a/unittest/gunit/libmysqlgcs/xcom/gcs_message_stage_fragmentation-t.cc
+++ b/unittest/gunit/libmysqlgcs/xcom/gcs_message_stage_fragmentation-t.cc
@@ -46,84 +46,96 @@ class Mock_gcs_xcom_proxy : public Gcs_xcom_proxy_base {
         .WillByDefault(Invoke(&mock_xcom_client_send_data));
   }
 
-  MOCK_METHOD3(new_node_address_uuid,
-               node_address *(unsigned int n, char const *names[],
-                              blob uuids[]));
-  MOCK_METHOD2(delete_node_address, void(unsigned int n, node_address *na));
-  MOCK_METHOD3(xcom_client_add_node, bool(connection_descriptor *con,
-                                          node_list *nl, uint32_t group_id));
-  MOCK_METHOD2(xcom_client_remove_node, bool(node_list *nl, uint32_t group_id));
-  MOCK_METHOD3(xcom_client_remove_node, bool(connection_descriptor *con,
-                                             node_list *nl, uint32_t group_id));
-  MOCK_METHOD2(xcom_client_get_event_horizon,
-               bool(uint32_t group_id, xcom_event_horizon &event_horizon));
-  MOCK_METHOD2(xcom_client_set_event_horizon,
-               bool(uint32_t group_id, xcom_event_horizon event_horizon));
-  MOCK_METHOD2(xcom_client_set_max_leaders,
-               bool(uint32_t group_id, node_no max_leaders));
-  MOCK_METHOD4(xcom_client_set_leaders,
-               bool(uint32_t group_id, u_int n, char const *names[],
-                    node_no max_nr_leaders));
-  MOCK_METHOD2(xcom_client_get_leaders,
-               bool(uint32_t gid, leader_info_data &leaders));
-  MOCK_METHOD4(xcom_client_get_synode_app_data,
-               bool(connection_descriptor *con, uint32_t group_id_hash,
-                    synode_no_array &synodes, synode_app_data_array &reply));
-  MOCK_METHOD1(xcom_client_set_cache_size, bool(uint64_t));
-  MOCK_METHOD2(xcom_client_boot, bool(node_list *nl, uint32_t group_id));
-  MOCK_METHOD2(xcom_client_open_connection,
-               connection_descriptor *(std::string, xcom_port port));
-  MOCK_METHOD1(xcom_client_close_connection, bool(connection_descriptor *con));
-  MOCK_METHOD2(xcom_client_send_data,
-               bool(unsigned long long size, char *data));
-  MOCK_METHOD1(xcom_init, void(xcom_port listen_port));
-  MOCK_METHOD0(xcom_exit, void());
-  MOCK_METHOD0(xcom_set_cleanup, void());
-  MOCK_METHOD1(xcom_get_ssl_mode, int(const char *mode));
-  MOCK_METHOD1(xcom_set_ssl_mode, int(int mode));
-  MOCK_METHOD1(xcom_get_ssl_fips_mode, int(const char *mode));
-  MOCK_METHOD1(xcom_set_ssl_fips_mode, int(int mode));
-  MOCK_METHOD0(xcom_init_ssl, bool());
-  MOCK_METHOD0(xcom_destroy_ssl, void());
-  MOCK_METHOD0(xcom_use_ssl, bool());
-  MOCK_METHOD2(xcom_set_ssl_parameters,
-               void(ssl_parameters ssl, tls_parameters tls));
-  MOCK_METHOD1(find_site_def, site_def const *(synode_no synode));
-  MOCK_METHOD2(xcom_open_handlers, bool(std::string saddr, xcom_port port));
-  MOCK_METHOD0(xcom_close_handlers, bool());
-  MOCK_METHOD0(xcom_acquire_handler, int());
-  MOCK_METHOD1(xcom_release_handler, void(int index));
-  MOCK_METHOD0(xcom_wait_ready, enum_gcs_error());
-  MOCK_METHOD0(xcom_is_ready, bool());
-  MOCK_METHOD1(xcom_set_ready, void(bool value));
-  MOCK_METHOD0(xcom_signal_ready, void());
-  MOCK_METHOD1(xcom_wait_for_xcom_comms_status_change, void(int &status));
-  MOCK_METHOD0(xcom_has_comms_status_changed, bool());
-  MOCK_METHOD1(xcom_set_comms_status, void(int status));
-  MOCK_METHOD1(xcom_signal_comms_status_changed, void(int status));
-  MOCK_METHOD0(xcom_wait_exit, enum_gcs_error());
-  MOCK_METHOD0(xcom_is_exit, bool());
-  MOCK_METHOD1(xcom_set_exit, void(bool));
-  MOCK_METHOD0(xcom_signal_exit, void());
-  MOCK_METHOD3(xcom_client_force_config, int(connection_descriptor *fd,
-                                             node_list *nl, uint32_t group_id));
-  MOCK_METHOD2(xcom_client_force_config,
-               bool(node_list *nl, uint32_t group_id));
+  MOCK_METHOD(node_address *, new_node_address_uuid,
+              (unsigned int n, char const *names[], blob uuids[]), (override));
+  MOCK_METHOD(void, delete_node_address, (unsigned int n, node_address *na),
+              (override));
+  MOCK_METHOD(bool, xcom_client_add_node,
+              (connection_descriptor * con, node_list *nl, uint32_t group_id),
+              (override));
+  MOCK_METHOD(bool, xcom_client_remove_node,
+              (node_list * nl, uint32_t group_id), (override));
+  MOCK_METHOD(bool, xcom_client_remove_node,
+              (connection_descriptor * con, node_list *nl, uint32_t group_id),
+              (override));
+  MOCK_METHOD(bool, xcom_client_get_event_horizon,
+              (uint32_t group_id, xcom_event_horizon &event_horizon),
+              (override));
+  MOCK_METHOD(bool, xcom_client_set_event_horizon,
+              (uint32_t group_id, xcom_event_horizon event_horizon),
+              (override));
+  MOCK_METHOD(bool, xcom_client_set_max_leaders,
+              (uint32_t group_id, node_no max_leaders), (override));
+  MOCK_METHOD(bool, xcom_client_set_leaders,
+              (uint32_t group_id, u_int n, char const *names[],
+               node_no max_nr_leaders),
+              (override));
+  MOCK_METHOD(bool, xcom_client_get_leaders,
+              (uint32_t gid, leader_info_data &leaders), (override));
+  MOCK_METHOD(bool, xcom_client_get_synode_app_data,
+              (connection_descriptor * con, uint32_t group_id_hash,
+               synode_no_array &synodes, synode_app_data_array &reply),
+              (override));
+  MOCK_METHOD(bool, xcom_client_set_cache_size, (uint64_t), (override));
+  MOCK_METHOD(bool, xcom_client_boot, (node_list * nl, uint32_t group_id),
+              (override));
+  MOCK_METHOD(connection_descriptor *, xcom_client_open_connection,
+              (std::string, xcom_port port), (override));
+  MOCK_METHOD(bool, xcom_client_close_connection, (connection_descriptor * con),
+              (override));
+  MOCK_METHOD(bool, client_send_data, (unsigned long long size, char *data),
+              (override));
+  MOCK_METHOD(void, xcom_init, (xcom_port listen_port), (override));
+  MOCK_METHOD(void, xcom_exit, (), (override));
+  MOCK_METHOD(void, xcom_set_cleanup, (), (override));
+  MOCK_METHOD(int, xcom_get_ssl_mode, (const char *mode), (override));
+  MOCK_METHOD(int, xcom_set_ssl_mode, (int mode), (override));
+  MOCK_METHOD(int, xcom_get_ssl_fips_mode, (const char *mode), (override));
+  MOCK_METHOD(int, xcom_set_ssl_fips_mode, (int mode), (override));
+  MOCK_METHOD(bool, xcom_init_ssl, (), (override));
+  MOCK_METHOD(void, xcom_destroy_ssl, (), (override));
+  MOCK_METHOD(bool, xcom_use_ssl, (), (override));
+  MOCK_METHOD(void, xcom_set_ssl_parameters,
+              (ssl_parameters ssl, tls_parameters tls), (override));
+  MOCK_METHOD(site_def const *, find_site_def, (synode_no synode), (override));
+  MOCK_METHOD(bool, xcom_open_handlers, (std::string saddr, xcom_port port),
+              (override));
+  MOCK_METHOD(bool, xcom_close_handlers, (), (override));
+  MOCK_METHOD(int, xcom_acquire_handler, (), (override));
+  MOCK_METHOD(void, xcom_release_handler, (int index), (override));
+  MOCK_METHOD(enum_gcs_error, xcom_wait_ready, (), (override));
+  MOCK_METHOD(bool, xcom_is_ready, (), (override));
+  MOCK_METHOD(void, xcom_set_ready, (bool value), (override));
+  MOCK_METHOD(void, xcom_signal_ready, (), (override));
+  MOCK_METHOD(void, xcom_wait_for_xcom_comms_status_change, (int &status),
+              (override));
+  MOCK_METHOD(bool, xcom_has_comms_status_changed, (), (override));
+  MOCK_METHOD(void, xcom_set_comms_status, (int status), (override));
+  MOCK_METHOD(void, xcom_signal_comms_status_changed, (int status), (override));
+  MOCK_METHOD(enum_gcs_error, xcom_wait_exit, (), (override));
+  MOCK_METHOD(bool, xcom_is_exit, (), (override));
+  MOCK_METHOD(void, xcom_set_exit, (bool), (override));
+  MOCK_METHOD(void, xcom_signal_exit, (), (override));
+  MOCK_METHOD(int, xcom_client_force_config,
+              (connection_descriptor * fd, node_list *nl, uint32_t group_id),
+              (override));
+  MOCK_METHOD(bool, xcom_client_force_config,
+              (node_list * nl, uint32_t group_id), (override));
 
-  MOCK_METHOD0(get_should_exit, bool());
-  MOCK_METHOD1(set_should_exit, void(bool should_exit));
+  MOCK_METHOD(bool, get_should_exit, (), (override));
+  MOCK_METHOD(void, set_should_exit, (bool should_exit), (override));
 
-  MOCK_METHOD2(xcom_input_connect,
-               bool(std::string const &address, xcom_port port));
-  MOCK_METHOD0(xcom_input_disconnect, void());
-  MOCK_METHOD1(xcom_input_try_push, bool(app_data_ptr data));
+  MOCK_METHOD(bool, xcom_input_connect,
+              (std::string const &address, xcom_port port), (override));
+  MOCK_METHOD(void, xcom_input_disconnect, (), (override));
+  MOCK_METHOD(bool, xcom_input_try_push, (app_data_ptr data), (override));
   /* Mocking fails compilation on Windows. It attempts to copy the std::future
    * which is non-copyable. */
   Gcs_xcom_input_queue::future_reply xcom_input_try_push_and_get_reply(
       app_data_ptr) {
     return std::future<std::unique_ptr<Gcs_xcom_input_queue::Reply>>();
   }
-  MOCK_METHOD0(xcom_input_try_pop, xcom_input_request_ptr());
+  MOCK_METHOD(xcom_input_request_ptr, xcom_input_try_pop, (), (override));
 };
 
 class Mock_gcs_xcom_view_change_control_interface
@@ -132,57 +144,61 @@ class Mock_gcs_xcom_view_change_control_interface
   Mock_gcs_xcom_view_change_control_interface() {
     ON_CALL(*this, belongs_to_group()).WillByDefault(Return(true));
   }
-  MOCK_METHOD0(start_view_exchange, void());
-  MOCK_METHOD0(end_view_exchange, void());
-  MOCK_METHOD0(wait_for_view_change_end, void());
-  MOCK_METHOD0(is_view_changing, bool());
-  MOCK_METHOD0(start_leave, bool());
-  MOCK_METHOD0(end_leave, void());
-  MOCK_METHOD0(is_leaving, bool());
-  MOCK_METHOD0(start_join, bool());
-  MOCK_METHOD0(end_join, void());
-  MOCK_METHOD0(is_joining, bool());
+  MOCK_METHOD(void, start_view_exchange, (), (override));
+  MOCK_METHOD(void, end_view_exchange, (), (override));
+  MOCK_METHOD(void, wait_for_view_change_end, (), (override));
+  MOCK_METHOD(bool, is_view_changing, (), (override));
+  MOCK_METHOD(bool, start_leave, (), (override));
+  MOCK_METHOD(void, end_leave, (), (override));
+  MOCK_METHOD(bool, is_leaving, (), (override));
+  MOCK_METHOD(bool, start_join, (), (override));
+  MOCK_METHOD(void, end_join, (), (override));
+  MOCK_METHOD(bool, is_joining, (), (override));
 
-  MOCK_METHOD1(set_current_view, void(Gcs_view *));
-  MOCK_METHOD0(get_current_view, Gcs_view *());
-  MOCK_METHOD0(belongs_to_group, bool());
-  MOCK_METHOD1(set_belongs_to_group, void(bool));
-  MOCK_METHOD1(set_unsafe_current_view, void(Gcs_view *));
-  MOCK_METHOD0(get_unsafe_current_view, Gcs_view *());
+  MOCK_METHOD(void, set_current_view, (Gcs_view *), (override));
+  MOCK_METHOD(Gcs_view *, get_current_view, (), (override));
+  MOCK_METHOD(bool, belongs_to_group, (), (override));
+  MOCK_METHOD(void, set_belongs_to_group, (bool), (override));
+  MOCK_METHOD(void, set_unsafe_current_view, (Gcs_view *), (override));
+  MOCK_METHOD(Gcs_view *, get_unsafe_current_view, (), (override));
 
-  MOCK_METHOD0(finalize, void());
-  MOCK_METHOD0(is_finalized, bool());
+  MOCK_METHOD(void, finalize, (), (override));
+  MOCK_METHOD(bool, is_finalized, (), (override));
 };
 
 class Mock_gcs_communication_event_listener
     : public Gcs_communication_event_listener {
  public:
-  MOCK_CONST_METHOD1(on_message_received, void(const Gcs_message &message));
+  MOCK_METHOD(void, on_message_received, (const Gcs_message &message),
+              (const, override));
 };
 
 class Mock_gcs_network_provider_management_interface
     : public Network_provider_management_interface {
  public:
-  MOCK_METHOD0(initialize, bool());
-  MOCK_METHOD0(finalize, bool());
-  MOCK_METHOD1(set_running_protocol, void(enum_transport_protocol new_value));
-  MOCK_METHOD1(add_network_provider,
-               void(std::shared_ptr<Network_provider> provider));
-  MOCK_CONST_METHOD0(get_running_protocol, enum_transport_protocol());
-  MOCK_CONST_METHOD0(get_incoming_connections_protocol,
-                     enum_transport_protocol());
-  MOCK_CONST_METHOD0(is_xcom_using_ssl, int());
-  MOCK_METHOD1(xcom_set_ssl_mode, int(int mode));
-  MOCK_METHOD1(xcom_get_ssl_mode, int(const char *mode));
-  MOCK_METHOD0(xcom_get_ssl_mode, int());
-  MOCK_METHOD1(xcom_set_ssl_fips_mode, int(int mode));
-  MOCK_METHOD1(xcom_get_ssl_fips_mode, int(const char *mode));
-  MOCK_METHOD0(xcom_get_ssl_fips_mode, int());
-  MOCK_METHOD0(cleanup_secure_connections_context, void());
-  MOCK_METHOD0(delayed_cleanup_secure_connections_context, void());
-  MOCK_METHOD0(finalize_secure_connections_context, void());
-  MOCK_METHOD0(remove_all_network_provider, void());
-  MOCK_METHOD1(remove_network_provider, void(enum_transport_protocol));
+  MOCK_METHOD(bool, initialize, (), (override));
+  MOCK_METHOD(bool, finalize, (), (override));
+  MOCK_METHOD(void, set_running_protocol, (enum_transport_protocol new_value),
+              (override));
+  MOCK_METHOD(void, add_network_provider,
+              (std::shared_ptr<Network_provider> provider), (override));
+  MOCK_METHOD(enum_transport_protocol, get_running_protocol, (),
+              (const, override));
+  MOCK_METHOD(enum_transport_protocol, get_incoming_connections_protocol, (),
+              (const, override));
+  MOCK_METHOD(int, is_xcom_using_ssl, (), (const, override));
+  MOCK_METHOD(int, xcom_set_ssl_mode, (int mode), (override));
+  MOCK_METHOD(int, xcom_get_ssl_mode, (const char *mode), (override));
+  MOCK_METHOD(int, xcom_get_ssl_mode, (), (override));
+  MOCK_METHOD(int, xcom_set_ssl_fips_mode, (int mode), (override));
+  MOCK_METHOD(int, xcom_get_ssl_fips_mode, (const char *mode), (override));
+  MOCK_METHOD(int, xcom_get_ssl_fips_mode, (), (override));
+  MOCK_METHOD(void, cleanup_secure_connections_context, (), (override));
+  MOCK_METHOD(void, delayed_cleanup_secure_connections_context, (), (override));
+  MOCK_METHOD(void, finalize_secure_connections_context, (), (override));
+  MOCK_METHOD(void, remove_all_network_provider, (), (override));
+  MOCK_METHOD(void, remove_network_provider, (enum_transport_protocol),
+              (override));
 };
 
 class Mock_gcs_xcom_statistics_manager

--- a/unittest/gunit/libmysqlgcs/xcom/gcs_xcom_communication_interface-t.cc
+++ b/unittest/gunit/libmysqlgcs/xcom/gcs_xcom_communication_interface-t.cc
@@ -38,32 +38,32 @@ namespace gcs_xcom_communication_unittest {
 class mock_gcs_xcom_view_change_control_interface
     : public Gcs_xcom_view_change_control_interface {
  public:
-  MOCK_METHOD0(start_view_exchange, void());
-  MOCK_METHOD0(end_view_exchange, void());
-  MOCK_METHOD0(wait_for_view_change_end, void());
-  MOCK_METHOD0(is_view_changing, bool());
-  MOCK_METHOD0(start_leave, bool());
-  MOCK_METHOD0(end_leave, void());
-  MOCK_METHOD0(is_leaving, bool());
-  MOCK_METHOD0(start_join, bool());
-  MOCK_METHOD0(end_join, void());
-  MOCK_METHOD0(is_joining, bool());
+  MOCK_METHOD(void, start_view_exchange, (), (override));
+  MOCK_METHOD(void, end_view_exchange, (), (override));
+  MOCK_METHOD(void, wait_for_view_change_end, (), (override));
+  MOCK_METHOD(bool, is_view_changing, (), (override));
+  MOCK_METHOD(bool, start_leave, (), (override));
+  MOCK_METHOD(void, end_leave, (), (override));
+  MOCK_METHOD(bool, is_leaving, (), (override));
+  MOCK_METHOD(bool, start_join, (), (override));
+  MOCK_METHOD(void, end_join, (), (override));
+  MOCK_METHOD(bool, is_joining, (), (override));
 
-  MOCK_METHOD1(set_current_view, void(Gcs_view *));
-  MOCK_METHOD0(get_current_view, Gcs_view *());
-  MOCK_METHOD0(belongs_to_group, bool());
-  MOCK_METHOD1(set_belongs_to_group, void(bool));
-  MOCK_METHOD1(set_unsafe_current_view, void(Gcs_view *));
-  MOCK_METHOD0(get_unsafe_current_view, Gcs_view *());
+  MOCK_METHOD(void, set_current_view, (Gcs_view *), (override));
+  MOCK_METHOD(Gcs_view *, get_current_view, (), (override));
+  MOCK_METHOD(bool, belongs_to_group, (), (override));
+  MOCK_METHOD(void, set_belongs_to_group, (bool), (override));
+  MOCK_METHOD(void, set_unsafe_current_view, (Gcs_view *), (override));
+  MOCK_METHOD(Gcs_view *, get_unsafe_current_view, (), (override));
 
-  MOCK_METHOD0(finalize, void());
-  MOCK_METHOD0(is_finalized, bool());
+  MOCK_METHOD(void, finalize, (), (override));
+  MOCK_METHOD(bool, is_finalized, (), (override));
 };
 
 class mock_gcs_communication_event_listener
     : public Gcs_communication_event_listener {
  public:
-  MOCK_CONST_METHOD1(on_message_received, void(const Gcs_message &message));
+  MOCK_METHOD(void, on_message_received, (const Gcs_message &message), (const,override));
 };
 
 class mock_gcs_xcom_proxy : public Gcs_xcom_proxy_base {
@@ -75,109 +75,124 @@ class mock_gcs_xcom_proxy : public Gcs_xcom_proxy_base {
     ON_CALL(*this, xcom_client_send_data(_, _)).WillByDefault(Return(false));
   }
 
-  MOCK_METHOD3(new_node_address_uuid,
-               node_address *(unsigned int n, char const *names[],
-                              blob uuids[]));
-  MOCK_METHOD2(delete_node_address, void(unsigned int n, node_address *na));
-  MOCK_METHOD3(xcom_client_add_node, bool(connection_descriptor *con,
-                                          node_list *nl, uint32_t group_id));
-  MOCK_METHOD2(xcom_client_remove_node, bool(node_list *nl, uint32_t group_id));
-  MOCK_METHOD3(xcom_client_remove_node, bool(connection_descriptor *con,
-                                             node_list *nl, uint32_t group_id));
-  MOCK_METHOD2(xcom_client_get_event_horizon,
-               bool(uint32_t group_id, xcom_event_horizon &event_horizon));
-  MOCK_METHOD2(xcom_client_set_event_horizon,
-               bool(uint32_t group_id, xcom_event_horizon event_horizon));
-  MOCK_METHOD2(xcom_client_set_max_leaders,
-               bool(uint32_t group_id, node_no max_leaders));
-  MOCK_METHOD4(xcom_client_set_leaders,
-               bool(uint32_t group_id, u_int n, char const *names[],
-                    node_no max_nr_leaders));
-  MOCK_METHOD2(xcom_client_get_leaders,
-               bool(uint32_t gid, leader_info_data &leaders));
-  MOCK_METHOD4(xcom_client_get_synode_app_data,
-               bool(connection_descriptor *con, uint32_t group_id_hash,
-                    synode_no_array &synodes, synode_app_data_array &reply));
-  MOCK_METHOD1(xcom_client_set_cache_size, bool(uint64_t));
-  MOCK_METHOD2(xcom_client_boot, bool(node_list *nl, uint32_t group_id));
-  MOCK_METHOD2(xcom_client_open_connection,
-               connection_descriptor *(std::string, xcom_port port));
-  MOCK_METHOD1(xcom_client_close_connection, bool(connection_descriptor *con));
-  MOCK_METHOD2(xcom_client_send_data,
-               bool(unsigned long long size, char *data));
-  MOCK_METHOD1(xcom_init, void(xcom_port listen_port));
-  MOCK_METHOD0(xcom_exit, void());
-  MOCK_METHOD0(xcom_set_cleanup, void());
-  MOCK_METHOD1(xcom_get_ssl_mode, int(const char *mode));
-  MOCK_METHOD1(xcom_set_ssl_mode, int(int mode));
-  MOCK_METHOD1(xcom_get_ssl_fips_mode, int(const char *mode));
-  MOCK_METHOD1(xcom_set_ssl_fips_mode, int(int mode));
-  MOCK_METHOD0(xcom_init_ssl, bool());
-  MOCK_METHOD0(xcom_destroy_ssl, void());
-  MOCK_METHOD0(xcom_use_ssl, bool());
-  MOCK_METHOD2(xcom_set_ssl_parameters,
-               void(ssl_parameters ssl, tls_parameters tls));
-  MOCK_METHOD1(find_site_def, site_def const *(synode_no synode));
-  MOCK_METHOD2(xcom_open_handlers, bool(std::string saddr, xcom_port port));
-  MOCK_METHOD0(xcom_close_handlers, bool());
-  MOCK_METHOD0(xcom_acquire_handler, int());
-  MOCK_METHOD1(xcom_release_handler, void(int index));
-  MOCK_METHOD0(xcom_wait_ready, enum_gcs_error());
-  MOCK_METHOD0(xcom_is_ready, bool());
-  MOCK_METHOD1(xcom_set_ready, void(bool value));
-  MOCK_METHOD0(xcom_signal_ready, void());
-  MOCK_METHOD1(xcom_wait_for_xcom_comms_status_change, void(int &status));
-  MOCK_METHOD0(xcom_has_comms_status_changed, bool());
-  MOCK_METHOD1(xcom_set_comms_status, void(int status));
-  MOCK_METHOD1(xcom_signal_comms_status_changed, void(int status));
-  MOCK_METHOD0(xcom_wait_exit, enum_gcs_error());
-  MOCK_METHOD0(xcom_is_exit, bool());
-  MOCK_METHOD1(xcom_set_exit, void(bool));
-  MOCK_METHOD0(xcom_signal_exit, void());
-  MOCK_METHOD3(xcom_client_force_config, int(connection_descriptor *fd,
-                                             node_list *nl, uint32_t group_id));
-  MOCK_METHOD2(xcom_client_force_config,
-               bool(node_list *nl, uint32_t group_id));
+  MOCK_METHOD(node_address *, new_node_address_uuid,
+              (unsigned int n, char const *names[], blob uuids[]), (override));
+  MOCK_METHOD(void, delete_node_address, (unsigned int n, node_address *na),
+              (override));
+  MOCK_METHOD(bool, xcom_client_add_node,
+              (connection_descriptor * con, node_list *nl, uint32_t group_id),
+              (override));
+  MOCK_METHOD(bool, xcom_client_remove_node,
+              (node_list * nl, uint32_t group_id), (override));
+  MOCK_METHOD(bool, xcom_client_remove_node,
+              (connection_descriptor * con, node_list *nl, uint32_t group_id),
+              (override));
+  MOCK_METHOD(bool, xcom_client_get_event_horizon,
+              (uint32_t group_id, xcom_event_horizon &event_horizon),
+              (override));
+  MOCK_METHOD(bool, xcom_client_set_event_horizon,
+              (uint32_t group_id, xcom_event_horizon event_horizon),
+              (override));
+  MOCK_METHOD(bool, xcom_client_set_max_leaders,
+              (uint32_t group_id, node_no max_leaders), (override));
+  MOCK_METHOD(bool, xcom_client_set_leaders,
+              (uint32_t group_id, u_int n, char const *names[],
+               node_no max_nr_leaders),
+              (override));
+  MOCK_METHOD(bool, xcom_client_get_leaders,
+              (uint32_t gid, leader_info_data &leaders), (override));
+  MOCK_METHOD(bool, xcom_client_get_synode_app_data,
+              (connection_descriptor * con, uint32_t group_id_hash,
+               synode_no_array &synodes, synode_app_data_array &reply),
+              (override));
+  MOCK_METHOD(bool, xcom_client_set_cache_size, (uint64_t), (override));
+  MOCK_METHOD(bool, xcom_client_boot, (node_list * nl, uint32_t group_id),
+              (override));
+  MOCK_METHOD(connection_descriptor *, xcom_client_open_connection,
+              (std::string, xcom_port port), (override));
+  MOCK_METHOD(bool, xcom_client_close_connection, (connection_descriptor * con),
+              (override));
+  MOCK_METHOD(bool, xcom_client_send_data,
+              (unsigned long long size, char *data), (override));
+  MOCK_METHOD(void, xcom_init, (xcom_port listen_port), (override));
+  MOCK_METHOD(void, xcom_exit, (), (override));
+  MOCK_METHOD(void, xcom_set_cleanup, (), (override));
+  MOCK_METHOD(int, xcom_get_ssl_mode, (const char *mode), (override));
+  MOCK_METHOD(int, xcom_set_ssl_mode, (int mode), (override));
+  MOCK_METHOD(int, xcom_get_ssl_fips_mode, (const char *mode), (override));
+  MOCK_METHOD(int, xcom_set_ssl_fips_mode, (int mode), (override));
+  MOCK_METHOD(bool, xcom_init_ssl, (), (override));
+  MOCK_METHOD(void, xcom_destroy_ssl, (), (override));
+  MOCK_METHOD(bool, xcom_use_ssl, (), (override));
+  MOCK_METHOD(void, xcom_set_ssl_parameters,
+              (ssl_parameters ssl, tls_parameters tls), (override));
+  MOCK_METHOD(site_def const *, find_site_def, (synode_no synode), (override));
+  MOCK_METHOD(bool, xcom_open_handlers, (std::string saddr, xcom_port port),
+              (override));
+  MOCK_METHOD(bool, xcom_close_handlers, (), (override));
+  MOCK_METHOD(int, xcom_acquire_handler, (), (override));
+  MOCK_METHOD(void, xcom_release_handler, (int index), (override));
+  MOCK_METHOD(enum_gcs_error, xcom_wait_ready, (), (override));
+  MOCK_METHOD(bool, xcom_is_ready, (), (override));
+  MOCK_METHOD(void, xcom_set_ready, (bool value), (override));
+  MOCK_METHOD(void, xcom_signal_ready, (), (override));
+  MOCK_METHOD(void, xcom_wait_for_xcom_comms_status_change, (int &status),
+              (override));
+  MOCK_METHOD(bool, xcom_has_comms_status_changed, (), (override));
+  MOCK_METHOD(void, xcom_set_comms_status, (int status), (override));
+  MOCK_METHOD(void, xcom_signal_comms_status_changed, (int status), (override));
+  MOCK_METHOD(enum_gcs_error, xcom_wait_exit, (), (override));
+  MOCK_METHOD(bool, xcom_is_exit, (), (override));
+  MOCK_METHOD(void, xcom_set_exit, (bool), (override));
+  MOCK_METHOD(void, xcom_signal_exit, (), (override));
+  MOCK_METHOD(int, xcom_client_force_config,
+              (connection_descriptor * fd, node_list *nl, uint32_t group_id),
+              (override));
+  MOCK_METHOD(bool, xcom_client_force_config,
+              (node_list * nl, uint32_t group_id), (override));
 
-  MOCK_METHOD0(get_should_exit, bool());
-  MOCK_METHOD1(set_should_exit, void(bool should_exit));
+  MOCK_METHOD(bool, get_should_exit, (), (override));
+  MOCK_METHOD(void, set_should_exit, (bool should_exit), (override));
 
-  MOCK_METHOD2(xcom_input_connect,
-               bool(std::string const &address, xcom_port port));
-  MOCK_METHOD0(xcom_input_disconnect, void());
-  MOCK_METHOD1(xcom_input_try_push, bool(app_data_ptr data));
+  MOCK_METHOD(bool, xcom_input_connect,
+              (std::string const &address, xcom_port port), (override));
+  MOCK_METHOD(void, xcom_input_disconnect, (), (override));
+  MOCK_METHOD(bool, xcom_input_try_push, (app_data_ptr data), (override));
   /* Mocking fails compilation on Windows. It attempts to copy the std::future
    * which is non-copyable. */
   Gcs_xcom_input_queue::future_reply xcom_input_try_push_and_get_reply(
       app_data_ptr) {
     return std::future<std::unique_ptr<Gcs_xcom_input_queue::Reply>>();
   }
-  MOCK_METHOD0(xcom_input_try_pop, xcom_input_request_ptr());
+  MOCK_METHOD(xcom_input_request_ptr, xcom_input_try_pop, (), (override));
 };
 
 class mock_gcs_network_provider_management_interface
     : public Network_provider_management_interface {
  public:
-  MOCK_METHOD0(initialize, bool());
-  MOCK_METHOD0(finalize, bool());
-  MOCK_METHOD1(set_running_protocol, void(enum_transport_protocol new_value));
-  MOCK_METHOD1(add_network_provider,
-               void(std::shared_ptr<Network_provider> provider));
-  MOCK_CONST_METHOD0(get_running_protocol, enum_transport_protocol());
-  MOCK_CONST_METHOD0(get_incoming_connections_protocol,
-                     enum_transport_protocol());
-  MOCK_CONST_METHOD0(is_xcom_using_ssl, int());
-  MOCK_METHOD1(xcom_set_ssl_mode, int(int mode));
-  MOCK_METHOD1(xcom_get_ssl_mode, int(const char *mode));
-  MOCK_METHOD0(xcom_get_ssl_mode, int());
-  MOCK_METHOD1(xcom_set_ssl_fips_mode, int(int mode));
-  MOCK_METHOD1(xcom_get_ssl_fips_mode, int(const char *mode));
-  MOCK_METHOD0(xcom_get_ssl_fips_mode, int());
-  MOCK_METHOD0(cleanup_secure_connections_context, void());
-  MOCK_METHOD0(delayed_cleanup_secure_connections_context, void());
-  MOCK_METHOD0(finalize_secure_connections_context, void());
-  MOCK_METHOD0(remove_all_network_provider, void());
-  MOCK_METHOD1(remove_network_provider, void(enum_transport_protocol));
+  MOCK_METHOD(bool, initialize, (), (override));
+  MOCK_METHOD(bool, finalize, (), (override));
+  MOCK_METHOD(void, set_running_protocol, (enum_transport_protocol new_value),
+              (override));
+  MOCK_METHOD(void, add_network_provider,
+              (std::shared_ptr<Network_provider> provider), (override));
+  MOCK_METHOD(enum_transport_protocol, get_running_protocol, (),
+              (const, override));
+  MOCK_METHOD(enum_transport_protocol, get_incoming_connections_protocol, (),
+              (const, override));
+  MOCK_METHOD(int, is_xcom_using_ssl, (), (const, override));
+  MOCK_METHOD(int, xcom_set_ssl_mode, (int mode), (override));
+  MOCK_METHOD(int, xcom_get_ssl_mode, (const char *mode), (override));
+  MOCK_METHOD(int, xcom_get_ssl_mode, (), (override));
+  MOCK_METHOD(int, xcom_set_ssl_fips_mode, (int mode), (override));
+  MOCK_METHOD(int, xcom_get_ssl_fips_mode, (const char *mode), (override));
+  MOCK_METHOD(int, xcom_get_ssl_fips_mode, (), (override));
+  MOCK_METHOD(void, cleanup_secure_connections_context, (), (override));
+  MOCK_METHOD(void, delayed_cleanup_secure_connections_context, (), (override));
+  MOCK_METHOD(void, finalize_secure_connections_context, (), (override));
+  MOCK_METHOD(void, remove_all_network_provider, (), (override));
+  MOCK_METHOD(void, remove_network_provider, (enum_transport_protocol),
+              (override));
 };
 
 class Mock_gcs_xcom_statistics_manager

--- a/unittest/gunit/libmysqlgcs/xcom/gcs_xcom_control_interface-t.cc
+++ b/unittest/gunit/libmysqlgcs/xcom/gcs_xcom_control_interface-t.cc
@@ -148,13 +148,13 @@ class mock_gcs_xcom_view_change_control_interface
     m_joining_leaving_mutex.destroy();
   }
 
-  MOCK_METHOD0(start_view_exchange, void());
-  MOCK_METHOD0(end_view_exchange, void());
-  MOCK_METHOD0(wait_for_view_change_end, void());
-  MOCK_METHOD0(is_view_changing, bool());
+  MOCK_METHOD(void, start_view_exchange, (), (override));
+  MOCK_METHOD(void, end_view_exchange, (), (override));
+  MOCK_METHOD(void, wait_for_view_change_end, (), (override));
+  MOCK_METHOD(bool, is_view_changing, (), (override));
 
-  MOCK_METHOD0(finalize, void());
-  MOCK_METHOD0(is_finalized, bool());
+  MOCK_METHOD(void, finalize, (), (override));
+  MOCK_METHOD(bool, is_finalized, (), (override));
 
   bool start_leave() override {
     bool retval = false;
@@ -295,36 +295,36 @@ class mock_gcs_xcom_state_exchange_interface
     ON_CALL(*this, process_recovery_state()).WillByDefault(Return(true));
   }
 
-  MOCK_METHOD0(init, void());
-  MOCK_METHOD0(reset, void());
-  MOCK_METHOD0(reset_with_flush, void());
-  MOCK_METHOD0(end, void());
+  MOCK_METHOD(void, init, (), (override));
+  MOCK_METHOD(void, reset, (), (override));
+  MOCK_METHOD(void, reset_with_flush, (), (override));
+  MOCK_METHOD(void, end, (), (override));
 
-  MOCK_METHOD0(compute_incompatible_members,
-               std::vector<Gcs_xcom_node_information>());
-  MOCK_METHOD0(process_recovery_state, bool());
+  MOCK_METHOD(std::vector<Gcs_xcom_node_information>,
+              compute_incompatible_members(), (override));
+  MOCK_METHOD(bool, process_recovery_state, (), (override));
 
-  MOCK_METHOD9(
-      state_exchange,
-      bool(synode_no configuration_id,
-           std::vector<Gcs_member_identifier *> &total,
-           std::vector<Gcs_member_identifier *> &left,
-           std::vector<Gcs_member_identifier *> &joined,
-           std::vector<std::unique_ptr<Gcs_message_data>> &exchangeable_data,
-           Gcs_view *current_view, std::string *group,
-           const Gcs_member_identifier &local_info, const Gcs_xcom_nodes &));
-  MOCK_METHOD4(process_member_state,
-               bool(Xcom_member_state *ms_info,
-                    const Gcs_member_identifier &p_id,
-                    Gcs_protocol_version max_protocol_version,
-                    Gcs_protocol_version used_protocol_version));
-  MOCK_METHOD0(get_new_view_id, Gcs_xcom_view_identifier *());
-  MOCK_METHOD0(get_joined, std::set<Gcs_member_identifier *> *());
-  MOCK_METHOD0(get_left, std::set<Gcs_member_identifier *> *());
-  MOCK_METHOD0(get_total, std::set<Gcs_member_identifier *> *());
-  MOCK_METHOD0(get_group, string *());
-  MOCK_METHOD0(get_member_states, Stored_States *());
-  MOCK_METHOD0(compute_maximum_supported_protocol_version, void());
+  MOCK_METHOD(
+      bool, state_exchange,
+      (synode_no configuration_id, std::vector<Gcs_member_identifier *> &total,
+       std::vector<Gcs_member_identifier *> &left,
+       std::vector<Gcs_member_identifier *> &joined,
+       std::vector<std::unique_ptr<Gcs_message_data>> &exchangeable_data,
+       Gcs_view *current_view, std::string *group,
+       const Gcs_member_identifier &local_info, const Gcs_xcom_nodes &),
+      (override));
+  MOCK_METHOD(bool, process_member_state,
+              (Xcom_member_state * ms_info, const Gcs_member_identifier &p_id,
+               Gcs_protocol_version max_protocol_version,
+               Gcs_protocol_version used_protocol_version),
+              (override));
+  MOCK_METHOD(Gcs_xcom_view_identifier *, get_new_view_id, (), (override));
+  MOCK_METHOD(std::set<Gcs_member_identifier *> *, get_joined, (), (override));
+  MOCK_METHOD(std::set<Gcs_member_identifier *> *, get_left(), (override));
+  MOCK_METHOD(std::set<Gcs_member_identifier *> *, get_total, (), (override));
+  MOCK_METHOD(string *, get_group, (), (override));
+  MOCK_METHOD(Stored_States *, get_member_states, (), (override));
+  MOCK_METHOD(void, compute_maximum_supported_protocol_version, (), (override));
 };
 
 class mock_gcs_xcom_proxy : public Gcs_xcom_proxy_base {
@@ -351,100 +351,113 @@ class mock_gcs_xcom_proxy : public Gcs_xcom_proxy_base {
     ON_CALL(*this, xcom_is_exit()).WillByDefault(Return(true));
   }
 
-  MOCK_METHOD3(new_node_address_uuid,
-               node_address *(unsigned int n, char const *names[],
-                              blob uuids[]));
-  MOCK_METHOD2(delete_node_address, void(unsigned int n, node_address *na));
-  MOCK_METHOD3(xcom_client_add_node, bool(connection_descriptor *con,
-                                          node_list *nl, uint32_t group_id));
-  MOCK_METHOD3(xcom_client_get_event_horizon,
-               bool(connection_descriptor *con, uint32_t group_id,
-                    xcom_event_horizon &event_horizon));
-  MOCK_METHOD2(xcom_client_get_event_horizon,
-               bool(uint32_t group_id, xcom_event_horizon &event_horizon));
-  MOCK_METHOD3(xcom_client_set_event_horizon,
-               bool(connection_descriptor *con, uint32_t group_id,
-                    xcom_event_horizon event_horizon));
-  MOCK_METHOD2(xcom_client_set_event_horizon,
-               bool(uint32_t group_id, xcom_event_horizon event_horizon));
-  MOCK_METHOD2(xcom_client_set_max_leaders,
-               bool(uint32_t group_id, node_no max_leaders));
-  MOCK_METHOD4(xcom_client_set_leaders,
-               bool(uint32_t group_id, u_int n, char const *names[],
-                    node_no max_nr_leaders));
-  MOCK_METHOD2(xcom_client_get_leaders,
-               bool(uint32_t gid, leader_info_data &leaders));
-  MOCK_METHOD4(xcom_client_get_synode_app_data,
-               bool(connection_descriptor *con, uint32_t group_id,
-                    synode_no_array &synodes, synode_app_data_array &reply));
-  MOCK_METHOD1(xcom_client_set_cache_size, bool(uint64_t size));
-  MOCK_METHOD2(xcom_client_remove_node, bool(node_list *nl, uint32_t group_id));
-  MOCK_METHOD3(xcom_client_remove_node, bool(connection_descriptor *con,
-                                             node_list *nl, uint32_t group_id));
-  MOCK_METHOD2(xcom_client_boot, bool(node_list *nl, uint32_t group_id));
-  MOCK_METHOD2(xcom_client_open_connection,
-               connection_descriptor *(std::string, xcom_port port));
-  MOCK_METHOD1(xcom_client_close_connection, bool(connection_descriptor *con));
-  MOCK_METHOD2(xcom_client_send_data,
-               bool(unsigned long long size, char *data));
-  MOCK_METHOD1(xcom_init, void(xcom_port listen_port));
-  MOCK_METHOD0(xcom_exit, void());
-  MOCK_METHOD0(xcom_set_cleanup, void());
-  MOCK_METHOD1(xcom_get_ssl_mode, int(const char *mode));
-  MOCK_METHOD1(xcom_set_ssl_mode, int(int mode));
-  MOCK_METHOD1(xcom_get_ssl_fips_mode, int(const char *mode));
-  MOCK_METHOD1(xcom_set_ssl_fips_mode, int(int mode));
-  MOCK_METHOD0(xcom_init_ssl, bool());
-  MOCK_METHOD0(xcom_destroy_ssl, void());
-  MOCK_METHOD0(xcom_use_ssl, bool());
-  MOCK_METHOD2(xcom_set_ssl_parameters,
-               void(ssl_parameters ssl, tls_parameters tls));
-  MOCK_METHOD1(find_site_def, site_def const *(synode_no synode));
-  MOCK_METHOD0(xcom_wait_ready, enum_gcs_error());
-  MOCK_METHOD0(xcom_is_ready, bool());
-  MOCK_METHOD1(xcom_set_ready, void(bool value));
-  MOCK_METHOD0(xcom_signal_ready, void());
-  MOCK_METHOD1(xcom_wait_for_xcom_comms_status_change, void(int &status));
-  MOCK_METHOD0(xcom_has_comms_status_changed, bool());
-  MOCK_METHOD1(xcom_set_comms_status, void(int status));
-  MOCK_METHOD1(xcom_signal_comms_status_changed, void(int status));
-  MOCK_METHOD0(xcom_wait_exit, enum_gcs_error());
-  MOCK_METHOD0(xcom_is_exit, bool());
-  MOCK_METHOD1(xcom_set_exit, void(bool));
-  MOCK_METHOD0(xcom_signal_exit, void());
-  MOCK_METHOD3(xcom_client_force_config, int(connection_descriptor *fd,
-                                             node_list *nl, uint32_t group_id));
-  MOCK_METHOD2(xcom_client_force_config,
-               bool(node_list *nl, uint32_t group_id));
+  MOCK_METHOD(node_address *, new_node_address_uuid,
+              (unsigned int n, char const *names[], blob uuids[]), (override));
+  MOCK_METHOD(void, delete_node_address, (unsigned int n, node_address *na),
+              (override));
+  MOCK_METHOD(bool, xcom_client_add_node,
+              (connection_descriptor * con, node_list *nl, uint32_t group_id),
+              (override));
+  MOCK_METHOD(bool, xcom_client_get_event_horizon,
+              (connection_descriptor * con, uint32_t group_id,
+               xcom_event_horizon &event_horizon),
+              (override));
+  MOCK_METHOD(bool, xcom_client_get_event_horizon,
+              (uint32_t group_id, xcom_event_horizon &event_horizon),
+              (override));
+  MOCK_METHOD(bool, xcom_client_set_event_horizon,
+              (connection_descriptor * con, uint32_t group_id,
+               xcom_event_horizon event_horizon),
+              (override));
+  MOCK_METHOD(bool, xcom_client_set_event_horizon,
+              (uint32_t group_id, xcom_event_horizon event_horizon),
+              (override));
+  MOCK_METHOD(bool, xcom_client_set_max_leaders,
+              (uint32_t group_id, node_no max_leaders), (override));
+  MOCK_METHOD(bool, xcom_client_set_leaders,
+              (uint32_t group_id, u_int n, char const *names[],
+               node_no max_nr_leaders),
+              (override));
+  MOCK_METHOD(bool, xcom_client_get_leaders,
+              (uint32_t gid, leader_info_data &leaders), (override));
+  MOCK_METHOD(bool, xcom_client_get_synode_app_data,
+              (connection_descriptor * con, uint32_t group_id,
+               synode_no_array &synodes, synode_app_data_array &reply),
+              (override));
+  MOCK_METHOD(bool, xcom_client_set_cache_size, (uint64_t size), (override));
+  MOCK_METHOD(bool, xcom_client_remove_node,
+              (node_list * nl, uint32_t group_id), (override));
+  MOCK_METHOD(bool, xcom_client_remove_node,
+              (connection_descriptor * con, node_list *nl, uint32_t group_id),
+              (override));
+  MOCK_METHOD(bool, xcom_client_boot, (node_list * nl, uint32_t group_id),
+              (override));
+  MOCK_METHOD(connection_descriptor *, xcom_client_open_connection,
+              (std::string, xcom_port port), (override));
+  MOCK_METHOD(bool, xcom_client_close_connection, (connection_descriptor * con),
+              (override));
+  MOCK_METHOD(bool, xcom_client_send_data,
+              (unsigned long long size, char *data), (override));
+  MOCK_METHOD(void, xcom_init, (xcom_port listen_port));
+  MOCK_METHOD(void, xcom_exit, (), (override));
+  MOCK_METHOD(void, xcom_set_cleanup, (), (override));
+  MOCK_METHOD(int, xcom_get_ssl_mode, (const char *mode), (override));
+  MOCK_METHOD(int, xcom_set_ssl_mode, (int mode), (override));
+  MOCK_METHOD(int, xcom_get_ssl_fips_mode, (const char *mode), (override));
+  MOCK_METHOD(int, xcom_set_ssl_fips_mode, (int mode), (override));
+  MOCK_METHOD(bool, xcom_init_ssl, (), (override));
+  MOCK_METHOD(void, xcom_destroy_ssl, (), (override));
+  MOCK_METHOD(bool, xcom_use_ssl, (), (override));
+  MOCK_METHOD(void, xcom_set_ssl_parameters,
+              (ssl_parameters ssl, tls_parameters tls), (override));
+  MOCK_METHOD(site_def const *, find_site_def, (synode_no synode), (override));
+  MOCK_METHOD(enum_gcs_error, xcom_wait_ready, (), (override));
+  MOCK_METHOD(bool, xcom_is_ready, (), (override));
+  MOCK_METHOD(void, xcom_set_ready, (bool value), (override));
+  MOCK_METHOD(void, xcom_signal_ready, (), (override));
+  MOCK_METHOD(void, xcom_wait_for_xcom_comms_status_change, (int &status),
+              (override));
+  MOCK_METHOD(bool, xcom_has_comms_status_changed, (), (override));
+  MOCK_METHOD(void, xcom_set_comms_status, (int status), (override));
+  MOCK_METHOD(void, xcom_signal_comms_status_changed, (int status), (override));
+  MOCK_METHOD(enum_gcs_error, xcom_wait_exit, (), (override));
+  MOCK_METHOD(bool, xcom_is_exit, (), (override));
+  MOCK_METHOD(void, xcom_set_exit, (bool), (override));
+  MOCK_METHOD(void, xcom_signal_exit, (), (override));
+  MOCK_METHOD(int, xcom_client_force_config,
+              (connection_descriptor * fd, node_list *nl, uint32_t group_id),
+              (override));
+  MOCK_METHOD(bool, xcom_client_force_config,
+              (node_list * nl, uint32_t group_id), (override));
 
-  MOCK_METHOD0(get_should_exit, bool());
-  MOCK_METHOD1(set_should_exit, void(bool should_exit));
+  MOCK_METHOD(bool, get_should_exit, (), (override));
+  MOCK_METHOD(void, set_should_exit, (bool should_exit), (override));
 
-  MOCK_METHOD2(xcom_input_connect,
-               bool(std::string const &address, xcom_port port));
-  MOCK_METHOD0(xcom_input_disconnect, void());
-  MOCK_METHOD1(xcom_input_try_push, bool(app_data_ptr data));
+  MOCK_METHOD(bool, xcom_input_connect,
+              (std::string const &address, xcom_port port), (override));
+  MOCK_METHOD(void, xcom_input_disconnect, (), (override));
+  MOCK_METHOD(bool, xcom_input_try_push, (app_data_ptr data), (override));
   /* Mocking fails compilation on Windows. It attempts to copy the std::future
    * which is non-copyable. */
   Gcs_xcom_input_queue::future_reply xcom_input_try_push_and_get_reply(
       app_data_ptr) {
     return std::future<std::unique_ptr<Gcs_xcom_input_queue::Reply>>();
   }
-  MOCK_METHOD0(xcom_input_try_pop, xcom_input_request_ptr());
-  MOCK_METHOD2(test_xcom_tcp_connection,
-               bool(std::string &host, xcom_port port));
+  MOCK_METHOD(xcom_input_request_ptr, xcom_input_try_pop, (), (override));
+  MOCK_METHOD(bool, test_xcom_tcp_connection,
+              (std::string & host, xcom_port port), (override));
 };
 
 class mock_gcs_control_event_listener : public Gcs_control_event_listener {
  public:
-  MOCK_CONST_METHOD2(on_view_changed,
-                     void(const Gcs_view &new_view,
-                          const Exchanged_data &exchanged_data));
-  MOCK_CONST_METHOD0(get_exchangeable_data, Gcs_message_data *());
-  MOCK_CONST_METHOD2(
-      on_suspicions,
-      void(const std::vector<Gcs_member_identifier> &members,
-           const std::vector<Gcs_member_identifier> &unreachable));
+  MOCK_METHOD(void, on_view_changed,
+              (const Gcs_view &new_view, const Exchanged_data &exchanged_data),
+              (const, override));
+  MOCK_METHOD(Gcs_message_data *, get_exchangeable_data, (), (const, override));
+  MOCK_METHOD(void, on_suspicions,
+              (const std::vector<Gcs_member_identifier> &members,
+               const std::vector<Gcs_member_identifier> &unreachable),
+              (const, override));
 };
 
 class mock_my_xp_socket_util : public My_xp_socket_util {
@@ -453,7 +466,7 @@ class mock_my_xp_socket_util : public My_xp_socket_util {
     ON_CALL(*this, disable_nagle_in_socket(_)).WillByDefault(Return(0));
   }
 
-  MOCK_METHOD1(disable_nagle_in_socket, int(int fd));
+  MOCK_METHOD(disable_nagle_in_socket, int(int fd));
 };
 
 class mock_gcs_network_provider_operations_interface
@@ -469,16 +482,16 @@ class mock_gcs_network_provider_operations_interface
         .WillByDefault(Return(false));
   }
 
-  MOCK_METHOD0(start_active_network_provider, bool());
-  MOCK_METHOD0(stop_all_network_providers, bool());
-  MOCK_METHOD0(stop_active_network_provider, bool());
-  MOCK_METHOD1(configure_active_provider,
-               bool(Network_configuration_parameters &params));
-  MOCK_METHOD1(configure_active_provider_secure_connections,
-               bool(Network_configuration_parameters &params));
-  MOCK_METHOD0(remove_all_network_provider, void());
-  MOCK_METHOD1(remove_network_provider,
-               void(enum_transport_protocol provider_key));
+  MOCK_METHOD(bool, start_active_network_provider, (), (override));
+  MOCK_METHOD(bool, stop_all_network_providers, (), (override));
+  MOCK_METHOD(bool, stop_active_network_provider, (), (override));
+  MOCK_METHOD(bool, configure_active_provider,
+              (Network_configuration_parameters & params), (override));
+  MOCK_METHOD(bool, configure_active_provider_secure_connections,
+              (Network_configuration_parameters & params), (override));
+  MOCK_METHOD(void, remove_all_network_provider, vod(), (override));
+  MOCK_METHOD(void, remove_network_provider,
+              (enum_transport_protocol provider_key), (override));
 };
 
 class Mock_gcs_xcom_statistics_manager

--- a/unittest/gunit/libmysqlgcs/xcom/gcs_xcom_group_management-t.cc
+++ b/unittest/gunit/libmysqlgcs/xcom/gcs_xcom_group_management-t.cc
@@ -41,105 +41,116 @@ class mock_gcs_xcom_proxy : public Gcs_xcom_proxy_base {
         .WillByDefault(Invoke(::delete_node_address));
   }
 
-  MOCK_METHOD3(new_node_address_uuid,
-               node_address *(unsigned int n, char const *names[],
-                              blob uuids[]));
-  MOCK_METHOD2(delete_node_address, void(unsigned int n, node_address *na));
-  MOCK_METHOD3(xcom_client_add_node, bool(connection_descriptor *fd,
-                                          node_list *nl, uint32_t group_id));
-  MOCK_METHOD2(xcom_client_remove_node, bool(node_list *nl, uint32_t group_id));
-  MOCK_METHOD3(xcom_client_remove_node, bool(connection_descriptor *fd,
-                                             node_list *nl, uint32_t group_id));
-  MOCK_METHOD2(xcom_client_get_event_horizon,
-               bool(uint32_t group_id, xcom_event_horizon &event_horizon));
-  MOCK_METHOD2(xcom_client_set_event_horizon,
-               bool(uint32_t group_id, xcom_event_horizon event_horizon));
-  MOCK_METHOD2(xcom_client_set_max_leaders,
-               bool(uint32_t group_id, node_no max_leaders));
-  MOCK_METHOD4(xcom_client_set_leaders,
-               bool(uint32_t group_id, u_int n, char const *names[],
-                    node_no max_nr_leaders));
-  MOCK_METHOD2(xcom_client_get_leaders,
-               bool(uint32_t gid, leader_info_data &leaders));
-  MOCK_METHOD4(xcom_client_get_synode_app_data,
-               bool(connection_descriptor *con, uint32_t group_id_hash,
-                    synode_no_array &synodes, synode_app_data_array &reply));
-  MOCK_METHOD1(xcom_client_set_cache_size, bool(uint64_t size));
-  MOCK_METHOD2(xcom_client_boot, bool(node_list *nl, uint32_t group_id));
-  MOCK_METHOD2(xcom_client_open_connection,
-               connection_descriptor *(std::string, xcom_port port));
-  MOCK_METHOD1(xcom_client_close_connection, bool(connection_descriptor *fd));
-  MOCK_METHOD2(xcom_client_send_data,
-               bool(unsigned long long size, char *data));
-  MOCK_METHOD1(xcom_init, void(xcom_port listen_port));
-  MOCK_METHOD0(xcom_exit, void());
-  MOCK_METHOD0(xcom_set_cleanup, void());
-  MOCK_METHOD1(xcom_get_ssl_mode, int(const char *mode));
-  MOCK_METHOD1(xcom_set_ssl_mode, int(int mode));
-  MOCK_METHOD1(xcom_get_ssl_fips_mode, int(const char *mode));
-  MOCK_METHOD1(xcom_set_ssl_fips_mode, int(int mode));
-  MOCK_METHOD0(xcom_init_ssl, bool());
-  MOCK_METHOD0(xcom_destroy_ssl, void());
-  MOCK_METHOD0(xcom_use_ssl, bool());
-  MOCK_METHOD2(xcom_set_ssl_parameters,
-               void(ssl_parameters ssl, tls_parameters tls));
-  MOCK_METHOD1(find_site_def, site_def const *(synode_no synode));
-  MOCK_METHOD0(xcom_wait_ready, enum_gcs_error());
-  MOCK_METHOD0(xcom_is_ready, bool());
-  MOCK_METHOD1(xcom_set_ready, void(bool value));
-  MOCK_METHOD0(xcom_signal_ready, void());
-  MOCK_METHOD1(xcom_wait_for_xcom_comms_status_change, void(int &status));
-  MOCK_METHOD0(xcom_has_comms_status_changed, bool());
-  MOCK_METHOD1(xcom_set_comms_status, void(int status));
-  MOCK_METHOD1(xcom_signal_comms_status_changed, void(int status));
-  MOCK_METHOD0(xcom_wait_exit, enum_gcs_error());
-  MOCK_METHOD0(xcom_is_exit, bool());
-  MOCK_METHOD1(xcom_set_exit, void(bool));
-  MOCK_METHOD0(xcom_signal_exit, void());
-  MOCK_METHOD3(xcom_client_force_config, int(connection_descriptor *fd,
-                                             node_list *nl, uint32_t group_id));
-  MOCK_METHOD2(xcom_client_force_config,
-               bool(node_list *nl, uint32_t group_id));
+  MOCK_METHOD(node_address *, new_node_address_uuid,
+              (unsigned int n, char const *names[], blob uuids[]), (override));
+  MOCK_METHOD(void, delete_node_address, (unsigned int n, node_address *na),
+              (override));
+  MOCK_METHOD(bool, xcom_client_add_node,
+              (connection_descriptor * fd, node_list *nl, uint32_t group_id),
+              (override));
+  MOCK_METHOD(bool, xcom_client_remove_node,
+              (node_list * nl, uint32_t group_id), (override));
+  MOCK_METHOD(bool, xcom_client_remove_node,
+              (connection_descriptor * fd, node_list *nl, uint32_t group_id),
+              (override));
+  MOCK_METHOD(bool, xcom_client_get_event_horizon,
+              (uint32_t group_id, xcom_event_horizon &event_horizon),
+              (override));
+  MOCK_METHOD(bool, xcom_client_set_event_horizon,
+              (uint32_t group_id, xcom_event_horizon event_horizon),
+              (override));
+  MOCK_METHOD(bool, xcom_client_set_max_leaders,
+              (uint32_t group_id, node_no max_leaders), (override));
+  MOCK_METHOD(bool, xcom_client_set_leaders,
+              (uint32_t group_id, u_int n, char const *names[],
+               node_no max_nr_leaders),
+              (override));
+  MOCK_METHOD(bool, xcom_client_get_leaders,
+              (uint32_t gid, leader_info_data &leaders), (override));
+  MOCK_METHOD(bool, xcom_client_get_synode_app_data,
+              (connection_descriptor * con, uint32_t group_id_hash,
+               synode_no_array &synodes, synode_app_data_array &reply),
+              (override));
+  MOCK_METHOD(bool, xcom_client_set_cache_size, (uint64_t size), (override));
+  MOCK_METHOD(bool, xcom_client_boot, (node_list * nl, uint32_t group_id),
+              (override));
+  MOCK_METHOD(connection_descriptor *, xcom_client_open_connection,
+              (std::string, xcom_port port), (override));
+  MOCK_METHOD(bool, xcom_client_close_connection, (connection_descriptor * fd),
+              (override));
+  MOCK_METHOD(bool, xcom_client_send_data,
+              (unsigned long long size, char *data), (override));
+  MOCK_METHOD(void, xcom_init, (xcom_port listen_port), (override));
+  MOCK_METHOD(void, xcom_exit, (), (override));
+  MOCK_METHOD(void, xcom_set_cleanup, (), (override));
+  MOCK_METHOD(int, xcom_get_ssl_mode, (const char *mode), (override));
+  MOCK_METHOD(int, xcom_set_ssl_mode, (int mode), (override));
+  MOCK_METHOD(int, xcom_get_ssl_fips_mode, (const char *mode), (override));
+  MOCK_METHOD(int, xcom_set_ssl_fips_mode, (int mode), (override));
+  MOCK_METHOD(bool, xcom_init_ssl, ());
+  MOCK_METHOD(void, xcom_destroy_ssl, (), (override));
+  MOCK_METHOD(bool, xcom_use_ssl, (), (override));
+  MOCK_METHOD(void, xcom_set_ssl_parameters,
+              (ssl_parameters ssl, tls_parameters tls), (override));
+  MOCK_METHOD(site_def const *, find_site_def, (synode_no synode), (override));
+  MOCK_METHOD(enum_gcs_error, xcom_wait_ready, (), (override));
+  MOCK_METHOD(bool, xcom_is_ready, (), (override));
+  MOCK_METHOD(void, xcom_set_ready, (bool value), (override));
+  MOCK_METHOD(void, xcom_signal_ready, (), (override));
+  MOCK_METHOD(void, xcom_wait_for_xcom_comms_status_change, (int &status),
+              (override));
+  MOCK_METHOD(bool, xcom_has_comms_status_changed, (), (override));
+  MOCK_METHOD(void, xcom_set_comms_status, (int status), (override));
+  MOCK_METHOD(void, xcom_signal_comms_status_changed, (int status), (override));
+  MOCK_METHOD(enum_gcs_error, xcom_wait_exit, (), (override));
+  MOCK_METHOD(bool, xcom_is_exit, (), (override));
+  MOCK_METHOD(void, xcom_set_exit, vd(bool), (override));
+  MOCK_METHOD(void, xcom_signal_exit, (), (override));
+  MOCK_METHOD(int, xcom_client_force_config,
+              (connection_descriptor * fd, node_list *nl, uint32_t group_id),
+              (override));
+  MOCK_METHOD(bool, xcom_client_force_config,
+              (node_list * nl, uint32_t group_id), (override));
 
-  MOCK_METHOD0(get_should_exit, bool());
-  MOCK_METHOD1(set_should_exit, void(bool should_exit));
+  MOCK_METHOD(bool, get_should_exit, (), (override));
+  MOCK_METHOD(void, set_should_exit, (bool should_exit), (override));
 
-  MOCK_METHOD2(xcom_input_connect,
-               bool(std::string const &address, xcom_port port));
-  MOCK_METHOD0(xcom_input_disconnect, void());
-  MOCK_METHOD1(xcom_input_try_push, bool(app_data_ptr data));
+  MOCK_METHOD(bool, xcom_input_connect,
+              (std::string const &address, xcom_port port), (override));
+  MOCK_METHOD(void, xcom_input_disconnect, (), (override));
+  MOCK_METHOD(bool, xcom_input_try_push, (app_data_ptr data), (override));
   /* Mocking fails compilation on Windows. It attempts to copy the std::future
    * which is non-copyable. */
   Gcs_xcom_input_queue::future_reply xcom_input_try_push_and_get_reply(
       app_data_ptr) override {
     return std::future<std::unique_ptr<Gcs_xcom_input_queue::Reply>>();
   }
-  MOCK_METHOD0(xcom_input_try_pop, xcom_input_request_ptr());
+  MOCK_METHOD(xcom_input_request_ptr, xcom_input_try_pop, (), (override));
 };
 
 class mock_gcs_xcom_view_change_control_interface
     : public Gcs_xcom_view_change_control_interface {
  public:
-  MOCK_METHOD0(start_view_exchange, void());
-  MOCK_METHOD0(end_view_exchange, void());
-  MOCK_METHOD0(wait_for_view_change_end, void());
-  MOCK_METHOD0(is_view_changing, bool());
-  MOCK_METHOD0(start_leave, bool());
-  MOCK_METHOD0(end_leave, void());
-  MOCK_METHOD0(is_leaving, bool());
-  MOCK_METHOD0(start_join, bool());
-  MOCK_METHOD0(end_join, void());
-  MOCK_METHOD0(is_joining, bool());
+  MOCK_METHOD(void, start_view_exchange, (), (override));
+  MOCK_METHOD(void, end_view_exchange, (), (override));
+  MOCK_METHOD(void, wait_for_view_change_end, (), (override));
+  MOCK_METHOD(bool, is_view_changing, (), (override));
+  MOCK_METHOD(bool, start_leave, (), (override));
+  MOCK_METHOD(void, end_leave, (), (override));
+  MOCK_METHOD(bool, is_leaving, (), (override));
+  MOCK_METHOD(bool, start_join, (), (override));
+  MOCK_METHOD(void, end_join, (), (override));
+  MOCK_METHOD(bool, is_joining, (), (override));
 
-  MOCK_METHOD1(set_current_view, void(Gcs_view *));
-  MOCK_METHOD0(get_current_view, Gcs_view *());
-  MOCK_METHOD0(belongs_to_group, bool());
-  MOCK_METHOD1(set_belongs_to_group, void(bool));
-  MOCK_METHOD1(set_unsafe_current_view, void(Gcs_view *));
-  MOCK_METHOD0(get_unsafe_current_view, Gcs_view *());
+  MOCK_METHOD(void, set_current_view, (Gcs_view *), (override));
+  MOCK_METHOD(Gcs_view *, get_current_view, (), (override));
+  MOCK_METHOD(bool, belongs_to_group, (), (override));
+  MOCK_METHOD(void, set_belongs_to_group, (bool), (override));
+  MOCK_METHOD(void, set_unsafe_current_view, (Gcs_view *), (override));
+  MOCK_METHOD(Gcs_view *, get_unsafe_current_view, (), (override));
 
-  MOCK_METHOD0(finalize, void());
-  MOCK_METHOD0(is_finalized, bool());
+  MOCK_METHOD(void, finalize, (), (override));
+  MOCK_METHOD(bool, is_finalized, (), (override));
 };
 
 class XcomGroupManagementTest : public GcsBaseTest {

--- a/unittest/gunit/libmysqlgcs/xcom/gcs_xcom_input_queue-t.cc
+++ b/unittest/gunit/libmysqlgcs/xcom/gcs_xcom_input_queue-t.cc
@@ -38,7 +38,7 @@ namespace gcs_xcom_input_queue_unittest {
 class MockGcsMpscQueue : public Gcs_mpsc_queue<xcom_input_request,
                                                xcom_input_request_ptr_deleter> {
  public:
-  MOCK_METHOD1(push, bool(xcom_input_request *payload));
+  MOCK_METHOD(bool, push, (xcom_input_request * payload), (override));
 
   MockGcsMpscQueue() { ON_CALL(*this, push(_)).WillByDefault(Return(false)); }
   ~MockGcsMpscQueue() = default;

--- a/unittest/gunit/libmysqlgcs/xcom/gcs_xcom_networking-t.cc
+++ b/unittest/gunit/libmysqlgcs/xcom/gcs_xcom_networking-t.cc
@@ -34,15 +34,15 @@ void clean_sock_probe(sock_probe *s) { free(s); }
 
 class mock_gcs_sock_probe_interface : public Gcs_sock_probe_interface {
  public:
-  MOCK_METHOD1(init_sock_probe, int(sock_probe *s));
-  MOCK_METHOD1(number_of_interfaces, int(sock_probe *s));
-  MOCK_METHOD3(get_sockaddr_address,
-               void(sock_probe *s, int count, struct sockaddr **out));
-  MOCK_METHOD3(get_sockaddr_netmask,
-               void(sock_probe *s, int count, struct sockaddr **out));
-  MOCK_METHOD2(get_if_name, char *(sock_probe *s, int count));
-  MOCK_METHOD2(is_if_running, bool_t(sock_probe *s, int count));
-  MOCK_METHOD1(close_sock_probe, void(sock_probe *s));
+  MOCK_METHOD(int, init_sock_probe, (sock_probe * s), (override));
+  MOCK_METHOD(int, number_of_interfaces, (sock_probe * s), (override));
+  MOCK_METHOD(void, get_sockaddr_address,
+              (sock_probe * s, int count, struct sockaddr **out), (override));
+  MOCK_METHOD(void, get_sockaddr_netmask,
+              (sock_probe * s, int count, struct sockaddr **out), (override));
+  MOCK_METHOD(char *, get_if_name, (sock_probe * s, int count), (override));
+  MOCK_METHOD(bool_t, is_if_running, (sock_probe * s, int count), (override));
+  MOCK_METHOD(void, close_sock_probe, (sock_probe * s), (override));
 
   void mock_gcs_sock_probe_interface_default() {
     ON_CALL(*this, close_sock_probe(_)).WillByDefault(Invoke(clean_sock_probe));

--- a/unittest/gunit/libmysqlgcs/xcom/gcs_xcom_state_exchange-t.cc
+++ b/unittest/gunit/libmysqlgcs/xcom/gcs_xcom_state_exchange-t.cc
@@ -39,53 +39,58 @@ namespace gcs_xcom_state_exchange_unittest {
 
 class mock_gcs_control_interface : public Gcs_control_interface {
  public:
-  MOCK_METHOD0(join, enum_gcs_error());
-  MOCK_METHOD0(leave, enum_gcs_error());
-  MOCK_METHOD0(belongs_to_group, bool());
-  MOCK_METHOD0(get_current_view, Gcs_view *());
-  MOCK_CONST_METHOD0(get_local_member_identifier,
-                     const Gcs_member_identifier());
-  MOCK_METHOD0(get_minimum_write_concurrency, uint32_t());
-  MOCK_METHOD0(get_maximum_write_concurrency, uint32_t());
-  MOCK_METHOD1(get_write_concurrency,
-               enum_gcs_error(uint32_t &write_concurrency));
-  MOCK_METHOD1(set_write_concurrency,
-               enum_gcs_error(uint32_t write_concurrency));
-  MOCK_METHOD1(set_xcom_cache_size, enum_gcs_error(uint64_t));
-  MOCK_METHOD1(add_event_listener,
-               int(const Gcs_control_event_listener &event_listener));
-  MOCK_METHOD1(remove_event_listener, void(int event_listener_handle));
+  MOCK_METHOD(enum_gcs_error, join, (), (override));
+  MOCK_METHOD(enum_gcs_error, leave, (), (override));
+  MOCK_METHOD(bool, belongs_to_group, (), (override));
+  MOCK_METHOD(Gcs_view *, get_current_view, (), (override));
+  MOCK_METHOD(const Gcs_member_identifier, get_local_member_identifier, (),
+              (const, override));
+  MOCK_METHOD(uint32_t, get_minimum_write_concurrency, (), (override));
+  MOCK_METHOD(uint32_t, get_maximum_write_concurrency, (), (override));
+  MOCK_METHOD(enum_gcs_error, get_write_concurrency,
+              (uint32_t &write_concurrency), (override));
+  MOCK_METHOD(enum_gcs_error set_write_concurrency,
+              (uint32_t write_concurrency), (override));
+  MOCK_METHOD(enum_gcs_error, set_xcom_cache_size, (uint64_t), (override));
+  MOCK_METHOD(int, add_event_listener,
+              (const Gcs_control_event_listener &event_listener), (override));
+  MOCK_METHOD(void, remove_event_listener, (int event_listener_handle),
+              (override));
 };
 
 class mock_gcs_xcom_communication_interface
     : public Gcs_xcom_communication_interface {
  public:
-  MOCK_METHOD1(send_message,
-               enum_gcs_error(const Gcs_message &message_to_send));
-  MOCK_METHOD1(add_event_listener,
-               int(const Gcs_communication_event_listener &event_listener));
-  MOCK_METHOD1(remove_event_listener, void(int event_listener_handle));
-  MOCK_METHOD3(do_send_message,
-               enum_gcs_error(const Gcs_message &message_to_send,
-                              unsigned long long *message_length,
-                              Cargo_type type));
+  MOCK_METHOD(enum_gcs_error, send_message,
+              (const Gcs_message &message_to_send), (override));
+  MOCK_METHOD(int, add_event_listener,
+              (const Gcs_communication_event_listener &event_listener),
+              (override));
+  MOCK_METHOD(void, remove_event_listener, (int event_listener_handle),
+              (override));
+  MOCK_METHOD(enum_gcs_error, do_send_message,
+              (const Gcs_message &message_to_send,
+               unsigned long long *message_length, Cargo_type type),
+              (override));
   /* Mocking fails compilation on Windows. It attempts to copy the
    * std::unique_ptr which is non-copyable. */
   void buffer_incoming_packet(Gcs_packet &&packet,
                               std::unique_ptr<Gcs_xcom_nodes> &&xcom_nodes) {
     buffer_incoming_packet_mock(packet, xcom_nodes);
   }
-  MOCK_METHOD2(buffer_incoming_packet_mock,
-               void(Gcs_packet &packet,
-                    std::unique_ptr<Gcs_xcom_nodes> &xcom_nodes));
-  MOCK_METHOD0(deliver_buffered_packets, void());
-  MOCK_METHOD0(cleanup_buffered_packets, void());
-  MOCK_METHOD0(number_buffered_packets, size_t());
-  MOCK_METHOD2(update_members_information, void(const Gcs_member_identifier &me,
-                                                const Gcs_xcom_nodes &members));
-  MOCK_METHOD1(
-      recover_packets,
-      bool(std::unordered_set<Gcs_xcom_synode> const &required_synods));
+  MOCK_METHOD(void, buffer_incoming_packet_mock,
+              (Gcs_packet & packet,
+               std::unique_ptr<Gcs_xcom_nodes> &xcom_nodes),
+              (override));
+  MOCK_METHOD(void, deliver_buffered_packets, (), (override));
+  MOCK_METHOD(void, cleanup_buffered_packets, (), (override));
+  MOCK_METHOD(size_t, number_buffered_packets, (), (override));
+  MOCK_METHOD(void, update_members_information,
+              (const Gcs_member_identifier &me, const Gcs_xcom_nodes &members),
+              (override));
+  MOCK_METHOD(bool, recover_packets,
+              (std::unordered_set<Gcs_xcom_synode> const &required_synods),
+              (override));
   /*
    Mocking fails compilation on Windows. It attempts to copy the
    std::unique_ptr which is non-copyable.
@@ -94,9 +99,10 @@ class mock_gcs_xcom_communication_interface
       Gcs_packet &&packet, std::unique_ptr<Gcs_xcom_nodes> &&xcom_nodes) {
     return convert_packet_to_message_mock(packet, xcom_nodes);
   }
-  MOCK_METHOD2(convert_packet_to_message_mock,
-               Gcs_message *(Gcs_packet &packet,
-                             std::unique_ptr<Gcs_xcom_nodes> &xcom_nodes));
+  MOCK_METHOD(Gcs_message *, convert_packet_to_message_mock,
+              (Gcs_packet & packet,
+               std::unique_ptr<Gcs_xcom_nodes> &xcom_nodes),
+              (override));
   /*
    Mocking fails compilation on Windows. It attempts to copy the
    std::unique_ptr which is non-copyable.
@@ -105,10 +111,12 @@ class mock_gcs_xcom_communication_interface
                                 std::unique_ptr<Gcs_xcom_nodes> &&xcom_nodes) {
     process_user_data_packet_mock(packet, xcom_nodes);
   }
-  MOCK_METHOD2(process_user_data_packet_mock,
-               void(Gcs_packet &packet,
-                    std::unique_ptr<Gcs_xcom_nodes> &xcom_nodes));
-  MOCK_CONST_METHOD0(get_protocol_version, Gcs_protocol_version());
+  MOCK_METHOD(void, process_user_data_packet_mock,
+              (Gcs_packet & packet,
+               std::unique_ptr<Gcs_xcom_nodes> &xcom_nodes),
+              (override));
+  MOCK_METHOD(Gcs_protocol_version, get_protocol_version, (),
+              (const, override));
   /*
    Mocking fails compilation on Windows. It attempts to copy the std::future
    which is non-copyable.
@@ -120,20 +128,21 @@ class mock_gcs_xcom_communication_interface
     });
     return std::make_pair(true, std::move(future));
   }
-  MOCK_METHOD1(set_protocol_version_mock,
-               void(Gcs_protocol_version new_version));
-  MOCK_METHOD2(update_in_transit,
-               void(Gcs_message const &message, Cargo_type cargo));
-  MOCK_CONST_METHOD0(is_protocol_change_ongoing, bool());
-  MOCK_METHOD1(set_groups_maximum_supported_protocol_version,
-               void(Gcs_protocol_version version));
-  MOCK_CONST_METHOD0(get_maximum_supported_protocol_version,
-                     Gcs_protocol_version());
-  MOCK_METHOD1(set_communication_protocol,
-               void(enum_transport_protocol protocol));
-  MOCK_METHOD1(add_communication_provider,
-               void(std::shared_ptr<Network_provider> provider));
-  MOCK_METHOD0(get_incoming_connections_protocol, enum_transport_protocol());
+  MOCK_METHOD(void, set_protocol_version_mock,
+              (Gcs_protocol_version new_version), (override));
+  MOCK_METHOD(void, update_in_transit,
+              (Gcs_message const &message, Cargo_type cargo), (override));
+  MOCK_METHOD(bool, is_protocol_change_ongoing, (), (const, override));
+  MOCK_METHOD(void, set_groups_maximum_supported_protocol_version,
+              (Gcs_protocol_version version), (override));
+  MOCK_METHOD(Gcs_protocol_version, get_maximum_supported_protocol_version, (),
+              (const, override));
+  MOCK_METHOD(void, set_communication_protocol,
+              (enum_transport_protocol protocol), (override));
+  MOCK_METHOD(void, add_communication_provider,
+              (std::shared_ptr<Network_provider> provider), (override));
+  MOCK_METHOD(enum_transport_protocol, get_incoming_connections_protocol, (),
+              (override));
 
   virtual Gcs_message_pipeline &get_msg_pipeline() { return m_msg_pipeline; }
 

--- a/unittest/gunit/mysys_my_pwrite-t.cc
+++ b/unittest/gunit/mysys_my_pwrite-t.cc
@@ -52,7 +52,8 @@ using ::testing::SetErrnoAndReturn;
 class MockWrite {
  public:
   virtual ~MockWrite() = default;
-  MOCK_METHOD4(mockwrite, ssize_t(int, const void *, size_t, off_t));
+  MOCK_METHOD(ssize_t, mockwrite, (int, const void *, size_t, off_t),
+              (override));
 };
 
 MockWrite *mockfs = nullptr;

--- a/unittest/gunit/mysys_my_read-t.cc
+++ b/unittest/gunit/mysys_my_read-t.cc
@@ -50,7 +50,7 @@ using ::testing::SetErrnoAndReturn;
 class MockRead {
  public:
   virtual ~MockRead() = default;
-  MOCK_METHOD3(mockread, ssize_t(int, void *, size_t));
+  MOCK_METHOD(ssize_t, mockread, (int, void *, size_t), (override));
 };
 
 MockRead *mockfs = nullptr;

--- a/unittest/gunit/mysys_my_write-t.cc
+++ b/unittest/gunit/mysys_my_write-t.cc
@@ -50,7 +50,7 @@ using ::testing::SetErrnoAndReturn;
 class MockWrite {
  public:
   virtual ~MockWrite() = default;
-  MOCK_METHOD3(mockwrite, ssize_t(int, const void *, size_t));
+  MOCK_METHOD(ssize_t, mockwrite, (int, const void *, size_t), (override));
 };
 
 MockWrite *mockfs = nullptr;

--- a/unittest/gunit/select_lex_visitor-t.cc
+++ b/unittest/gunit/select_lex_visitor-t.cc
@@ -105,7 +105,7 @@ class Stack_allocated_item : public Item_class {
 class Mock_item_int : public Stack_allocated_item<Item_int> {
  public:
   Mock_item_int() : Stack_allocated_item<Item_int>(42) {}
-  MOCK_METHOD3(walk, bool(Item_processor, enum_walk, uchar *));
+  MOCK_METHOD(bool, walk, (Item_processor, enum_walk, uchar *), (override));
 };
 
 TEST_F(SelectLexVisitorTest, SelectLex) {

--- a/unittest/gunit/xplugin/xpl/callback_command_delegate_t.cc
+++ b/unittest/gunit/xplugin/xpl/callback_command_delegate_t.cc
@@ -63,8 +63,9 @@ using namespace ::testing;  // NOLINT(build/namespaces)
 
 class Mock_callback_commands {
  public:
-  MOCK_METHOD0(start_row, Callback_command_delegate::Row_data *());
-  MOCK_METHOD1(end_row, bool(Callback_command_delegate::Row_data *));
+  MOCK_METHOD(Callback_command_delegate::Row_data *, start_row, (), (override));
+  MOCK_METHOD(bool, end_row, (Callback_command_delegate::Row_data *),
+              (override));
 };
 
 MATCHER_P(Eq_mysql_time, n, "") {

--- a/unittest/gunit/xplugin/xpl/getter_any_t.cc
+++ b/unittest/gunit/xplugin/xpl/getter_any_t.cc
@@ -48,13 +48,13 @@ class Type_handler {
 class Mock_type_handler : public Type_handler {
  public:
   // Workaround for GMOCK undefined behaviour with ResultHolder
-  MOCK_METHOD1(put_void, bool(const ::google::protobuf::int64 &));
-  MOCK_METHOD1(put_void, bool(const ::google::protobuf::uint64 &));
-  MOCK_METHOD1(put_void, bool(const double &));
-  MOCK_METHOD1(put_void, bool(const float &));
-  MOCK_METHOD1(put_void, bool(const bool &));
-  MOCK_METHOD1(put_void, bool(const std::string &));
-  MOCK_METHOD0(put_void, bool());
+  MOCK_METHOD(bool, put_void, (const ::google::protobuf::int64 &), (override));
+  MOCK_METHOD(bool, put_void, (const ::google::protobuf::uint64 &), (override));
+  MOCK_METHOD(bool, put_void, (const double &), (override));
+  MOCK_METHOD(bool, put_void, (const float &), (override));
+  MOCK_METHOD(bool, put_void, (const bool &), (override));
+  MOCK_METHOD(bool, put_void, (const std::string &), (override));
+  MOCK_METHOD(bool, put_void, (), (override));
 
   void put(const ::google::protobuf::int64 &arg) override { put_void(arg); }
 

--- a/unittest/gunit/xplugin/xpl/mock/component_services.h
+++ b/unittest/gunit/xplugin/xpl/mock/component_services.h
@@ -54,12 +54,13 @@ class Service_registry {
   Service_registry();
   ~Service_registry();
 
-  MOCK_METHOD2(acquire, mysql_service_status_t(const char *service_name,
-                                               my_h_service *out_service));
-  MOCK_METHOD3(acquire_related,
-               mysql_service_status_t(const char *service_name,
-                                      my_h_service service,
-                                      my_h_service *out_service));
+  MOCK_METHOD(mysql_service_status_t, acquire,
+              (const char *service_name, my_h_service *out_service),
+              (override));
+  MOCK_METHOD(mysql_service_status_t, acquire_related,
+              (const char *service_name, my_h_service service,
+               my_h_service *out_service),
+              (override));
   MOCK_METHOD(mysql_service_status_t, release, (my_h_service service));
 
   SERVICE_TYPE_NO_CONST(registry) * get() { return &m_registry; }

--- a/unittest/gunit/xplugin/xpl/mock/sha256_password_cache.h
+++ b/unittest/gunit/xplugin/xpl/mock/sha256_password_cache.h
@@ -43,8 +43,9 @@ class Sha256_password_cache : public iface::SHA256_password_cache {
   Sha256_password_cache();
   virtual ~Sha256_password_cache() override;
 
-  MOCK_METHOD3(upsert, bool(const std::string &, const std::string &,
-                            const std::string &));
+  MOCK_METHOD(bool, upsert,
+              (const std::string &, const std::string &, const std::string &),
+              (override));
   MOCK_METHOD(bool, remove, (const std::string &, const std::string &),
               (override));
   using Entry = std::pair<bool, std::string>;

--- a/unittest/gunit/xplugin/xpl/mock/sql_session.h
+++ b/unittest/gunit/xplugin/xpl/mock/sql_session.h
@@ -60,9 +60,9 @@ class Sql_session : public iface::Sql_session {
               (const char *, std::size_t, iface::Resultset *), (override));
   MOCK_METHOD(ngs::Error_code, execute_sql,
               (const char *, std::size_t, iface::Resultset *), (override));
-  MOCK_METHOD3(fetch_cursor,
-               ngs::Error_code(const std::uint32_t, const std::uint32_t,
-                               iface::Resultset *));
+  MOCK_METHOD(ngs::Error_code, fetch_cursor,
+              (const std::uint32_t, const std::uint32_t, iface::Resultset *),
+              (override));
   MOCK_METHOD(ngs::Error_code, prepare_prep_stmt,
               (const char *, std::size_t, iface::Resultset *), (override));
   MOCK_METHOD(ngs::Error_code, deallocate_prep_stmt,


### PR DESCRIPTION
Replace `MOCK_METHODN` and `MOCK_CONST_METHODN` with general `MOCK_METHOD`
https://google.github.io/googletest/reference/mocking.html