### PR TITLE
bug#115484: Modify BuildRequires: to include gcc-toolset-12 for compat libraries on 9.0.0

### DIFF
--- a/packaging/rpm-oel/mysql.spec.in
+++ b/packaging/rpm-oel/mysql.spec.in
@@ -188,6 +188,11 @@ BuildRequires:  cmake3 >= 3.14.6
 %{?el8:BuildRequires:  gcc-toolset-13-dwz}
 %{?el8:BuildRequires:  gcc-toolset-13-gcc-c++}
 %{?el8:BuildRequires:  gcc-toolset-13-gcc}
+%{?el9:BuildRequires:  gcc-toolset-12-annobin-annocheck}
+%{?el9:BuildRequires:  gcc-toolset-12-annobin-plugin-gcc}
+%{?el9:BuildRequires:  gcc-toolset-12-binutils}
+%{?el9:BuildRequires:  gcc-toolset-12-gcc}
+%{?el9:BuildRequires:  gcc-toolset-12-gcc-c++}
 %{?el9:BuildRequires:  gcc-toolset-13-annobin-annocheck}
 %{?el9:BuildRequires:  gcc-toolset-13-annobin-plugin-gcc}
 %{?el9:BuildRequires:  gcc-toolset-13-binutils}

--- a/packaging/rpm-oel/mysql.spec.in
+++ b/packaging/rpm-oel/mysql.spec.in
@@ -182,6 +182,11 @@ BuildRequires:  cmake3 >= 3.14.6
 %{?el7:BuildRequires:  devtoolset-11-binutils}
 %{?el7:BuildRequires:  devtoolset-11-dwz}
 %endif
+%{?el8:BuildRequires:  gcc-toolset-12-annobin-annocheck}
+%{?el8:BuildRequires:  gcc-toolset-12-annobin-plugin-gcc}
+%{?el8:BuildRequires:  gcc-toolset-12-binutils}
+%{?el8:BuildRequires:  gcc-toolset-12-gcc}
+%{?el8:BuildRequires:  gcc-toolset-12-gcc-c++}
 %{?el8:BuildRequires:  gcc-toolset-13-annobin-annocheck}
 %{?el8:BuildRequires:  gcc-toolset-13-annobin-plugin-gcc}
 %{?el8:BuildRequires:  gcc-toolset-13-binutils}


### PR DESCRIPTION
See: https://bugs.mysql.com/bug.php?id=115484

This is a minimal patch to fix the missing `BuildRequires:` for OL8/OL9, needed to build the `mysql-community-lib-compat` rpms.

While upstream RHEL8 / CentOS 8 is I believe EOL, it's not clear if OL8 is too. I believe longer support will be provided so building 9.0.0 and later may well still be handled on OL8/9.