### PR TITLE
A log record can span 3 log pages

### DIFF
--- a/storage/ndb/src/kernel/blocks/dblqh/Dblqh.hpp
+++ b/storage/ndb/src/kernel/blocks/dblqh/Dblqh.hpp
@@ -108,7 +108,7 @@ class FsReadWriteReq;
 #define ZMAX_MM_BUFFER_SIZE 32  // Main memory window during log execution
 
 #define ZMAX_PAGES_WRITTEN 8     // Max pages before writing to disk (=> config)
-#define ZMIN_READ_BUFFER_SIZE 2  // Minimum number of pages to execute log
+#define ZMIN_READ_BUFFER_SIZE 3  // Minimum number of pages to execute log
 #define ZMIN_LOG_PAGES_OPERATION 10  // Minimum no of pages before stopping
 
 #define ZPOS_CHECKSUM 0


### PR DESCRIPTION
The test case ndb.ndb_backup_nowait occasionally crashes in the REDO log execution
in the stepAhead function. The reason is that this test case can create PREPARE log
records that span 3 log pages (a log record can be 30000 + header + 4096 + 4 * 512 bytes
in the worst case). The parameter ZMIN_READ_BUFFER_LOG_SIZE is set to 2, thus only
log records spanning 2 log pages are safe to call stepAhead with. To ensure all log records
are safe to call stepAhead one needs to increase ZMIN_READ_BUFFER_LOG_SIZE to 3.

When this happens the node is unrecoverable until this patch is applied.