### PR TITLE
Set $HOME for logrotate script

### DIFF
--- a/packaging/rpm-common/mysql.logrotate.in
+++ b/packaging/rpm-common/mysql.logrotate.in
@@ -30,7 +30,7 @@
 #       if test -x @bindir@/mysqladmin && \
 #          @bindir@/mysqladmin ping &>/dev/null
 #       then
-#          @bindir@/mysqladmin flush-logs
+#          env HOME=/root/ @bindir@/mysqladmin flush-logs
 #       fi
 #    endscript
 #}


### PR DESCRIPTION
> When executing from cron, the HOME term environment variable will be blank. Meaning: /usr/bin/mysqladmin won’t be able to find the file with the access credentials (user and password) and thus cannot execute the “flush-logs” command.

See: https://www.percona.com/blog/log-rotate-and-the-deleted-mysql-log-file-mystery/

This error is mostly invisible unless one looks at logrotate’s own log since the `mysqld.log` gets rotated even when `flush-logs` fails.