### PR TITLE
 bug#114904 Rename table with COPY does not change the constraint nam…

### DIFF
--- a/storage/innobase/dict/dict0dd.cc
+++ b/storage/innobase/dict/dict0dd.cc
@@ -4567,7 +4567,12 @@ dberr_t dd_table_check_for_child(dd::cache::Dictionary_client *client,
       if (foreign_table) {
         for (auto &fk : foreign_table->foreign_set) {
           if (strcmp(fk->referenced_table_name, tbl_name) != 0) {
-            continue;
+            if (m_table->refresh_fk) {//after alter rename copy, child fk reference table not update,bug-114904
+              fk->referenced_table_name = mem_heap_strdup(fk->heap, tbl_name);
+              dict_mem_referenced_table_name_lookup_set(fk, true);
+            } else {
+              continue;
+            }
           }
 
           if (fk->referenced_table) {


### PR DESCRIPTION
…e, the bug reason is alter rename table by ALGORITHM COPY not update child table reference tablename in dict_foreign_t cache, The solution is reset chiild table reference table if refresh_fk is true in dd_table_check_for_child