### PR TITLE
bug-115707 LOAD XML INFILE chooses child entity attribute instead of one within the tag

### DIFF
--- a/sql/sql_load.cc
+++ b/sql/sql_load.cc
@@ -1658,6 +1658,17 @@ bool Sql_cmd_load_table::read_xml_field(THD *thd, COPY_INFO &info,
       while (tag && strcmp(tag->field.c_ptr(), item->item_name.ptr()) != 0)
         tag = xmlit++;
 
+      if (tag) {  // bug-115707 use lower level tag
+        XML_TAG *tmp = xmlit++;
+        while (tmp) {
+          if (strcmp(tmp->field.c_ptr(), item->item_name.ptr()) == 0 &&
+              tmp->level < tag->level) {
+            tag = tmp;
+          }
+          tmp = xmlit++;
+        }
+      }
+
       item = item->real_item();
 
       if (!tag)  // found null


### PR DESCRIPTION
bug-115707 Change the LOAD XML processor to choose the matched column names to elements by the depth that they are away from the tag from ROWS IDENTIFIED BY, such that those at the same level are chosen if present, then down through the nested XML.