### PR TITLE
fix mysqlslap --ssl-mode=disable not working issue

### DIFF
--- a/client/mysqlslap.cc
+++ b/client/mysqlslap.cc
@@ -212,6 +212,8 @@ static uint opt_protocol = 0;
 static int get_options(int *argc, char ***argv);
 static uint opt_mysql_port = 0;
 
+static int set_mysql_options(MYSQL *mysql);
+
 static const char *load_default_groups[] = {"mysqlslap", "client", nullptr};
 
 typedef struct statement statement;
@@ -349,44 +351,20 @@ int main(int argc, char **argv) {
     my_end(0);
     return EXIT_FAILURE;
   }
-  mysql_init(&mysql);
-  if (opt_compress) mysql_options(&mysql, MYSQL_OPT_COMPRESS, NullS);
 
-  if (opt_compress_algorithm)
-    mysql_options(&mysql, MYSQL_OPT_COMPRESSION_ALGORITHMS,
-                  opt_compress_algorithm);
-
-  mysql_options(&mysql, MYSQL_OPT_ZSTD_COMPRESSION_LEVEL,
-                &opt_zstd_compress_level);
-
-  if (SSL_SET_OPTIONS(&mysql)) {
-    fprintf(stderr, "%s", SSL_SET_OPTIONS_ERROR);
-    return EXIT_FAILURE;
+  if (!(mysql_init(&mysql))) {
+     fprintf(stderr, "%s: mysql_init() failed ERROR : %s\n", my_progname, mysql_error(&mysql));
+     my_end(0);
+     return EXIT_FAILURE;
   }
-  if (opt_protocol)
-    mysql_options(&mysql, MYSQL_OPT_PROTOCOL, (char *)&opt_protocol);
-#if defined(_WIN32)
-  if (shared_memory_base_name)
-    mysql_options(&mysql, MYSQL_SHARED_MEMORY_BASE_NAME,
-                  shared_memory_base_name);
-#endif
-  mysql_options(&mysql, MYSQL_SET_CHARSET_NAME, default_charset);
 
-  if (opt_plugin_dir && *opt_plugin_dir)
-    mysql_options(&mysql, MYSQL_PLUGIN_DIR, opt_plugin_dir);
+  if (set_mysql_options(&mysql) != 0) {
+     fprintf(stderr, "%s: set_mysql_options() failed\n", my_progname);
+     mysql_close(&mysql);
+     my_end(0);
+     return EXIT_FAILURE;
+  }
 
-  if (opt_default_auth && *opt_default_auth)
-    mysql_options(&mysql, MYSQL_DEFAULT_AUTH, opt_default_auth);
-
-  mysql_options(&mysql, MYSQL_OPT_CONNECT_ATTR_RESET, nullptr);
-  mysql_options4(&mysql, MYSQL_OPT_CONNECT_ATTR_ADD, "program_name",
-                 "mysqlslap");
-  if (using_opt_enable_cleartext_plugin)
-    mysql_options(&mysql, MYSQL_ENABLE_CLEARTEXT_PLUGIN,
-                  (char *)&opt_enable_cleartext_plugin);
-  set_server_public_key(&mysql);
-  set_get_server_public_key_option(&mysql);
-  set_password_options(&mysql);
   if (!opt_only_print) {
     if (!(mysql_real_connect(&mysql, host, user, nullptr, nullptr,
                              opt_mysql_port, opt_mysql_unix_port,
@@ -1415,6 +1393,47 @@ static int get_options(int *argc, char ***argv) {
   return 0;
 }
 
+static int set_mysql_options(MYSQL *mysql) {
+  if (opt_compress) mysql_options(mysql, MYSQL_OPT_COMPRESS, NullS);
+
+  if (opt_compress_algorithm)
+    mysql_options(mysql, MYSQL_OPT_COMPRESSION_ALGORITHMS,
+                  opt_compress_algorithm);
+
+  mysql_options(mysql, MYSQL_OPT_ZSTD_COMPRESSION_LEVEL,
+                &opt_zstd_compress_level);
+
+  if (SSL_SET_OPTIONS(mysql)) {
+    fprintf(stderr, "%s", SSL_SET_OPTIONS_ERROR);
+    return EXIT_FAILURE;
+  }
+  if (opt_protocol)
+    mysql_options(mysql, MYSQL_OPT_PROTOCOL, (char *)&opt_protocol);
+#if defined(_WIN32)
+  if (shared_memory_base_name)
+    mysql_options(mysql, MYSQL_SHARED_MEMORY_BASE_NAME,
+                  shared_memory_base_name);
+#endif
+  mysql_options(mysql, MYSQL_SET_CHARSET_NAME, default_charset);
+
+  if (opt_plugin_dir && *opt_plugin_dir)
+    mysql_options(mysql, MYSQL_PLUGIN_DIR, opt_plugin_dir);
+
+  if (opt_default_auth && *opt_default_auth)
+    mysql_options(mysql, MYSQL_DEFAULT_AUTH, opt_default_auth);
+
+  mysql_options(mysql, MYSQL_OPT_CONNECT_ATTR_RESET, nullptr);
+  mysql_options4(mysql, MYSQL_OPT_CONNECT_ATTR_ADD, "program_name",
+                 "mysqlslap");
+  if (using_opt_enable_cleartext_plugin)
+    mysql_options(mysql, MYSQL_ENABLE_CLEARTEXT_PLUGIN,
+                  (char *)&opt_enable_cleartext_plugin);
+  set_server_public_key(mysql);
+  set_get_server_public_key_option(mysql);
+  set_password_options(mysql);
+  return 0;
+}
+
 static int run_query(MYSQL *mysql, const char *query, size_t len) {
   if (opt_only_print) {
     printf("%.*s;\n", (int)len, query);
@@ -1701,6 +1720,12 @@ extern "C" void *run_task(void *p) {
       exit(0);
     }
 
+    if (set_mysql_options(mysql) != 0) {
+       fprintf(stderr, "%s: set_mysql_options() failed\n", my_progname);
+       mysql_close(mysql);
+       exit(0);
+    }
+
     if (mysql_thread_init()) {
       fprintf(stderr, "%s: mysql_thread_init() failed ERROR : %s\n",
               my_progname, mysql_error(mysql));
@@ -1731,6 +1756,11 @@ extern "C" void *run_task(void *p) {
         if (!(mysql = mysql_init(nullptr))) {
           fprintf(stderr, "%s: mysql_init() failed ERROR : %s\n", my_progname,
                   mysql_error(mysql));
+          goto end;
+        }
+
+        if (set_mysql_options(mysql) != 0) {
+          fprintf(stderr, "%s: set_mysql_options() failed\n", my_progname);
           goto end;
         }
 


### PR DESCRIPTION
Description:
Specifying --ssl-mode=disable in mysqlslap has no effect, SSL is still used.

How to repeat:
1. first create a test database and account.
```
create database mysqlslap;
create user 'root'@'127.0.0.1' identified by '123456';
grant all on *.* to 'root'@'127.0.0.1';
set global general_log=on;
```
2. then execute the mysqlslap
`./mysqlslap --host=127.0.0.1 --port=3316 --user=root --password="123456" --concurrency=1 --iterations=1 --query="select 1" --ssl-mode=disable`

3. check the output of general log.
```
2024-11-17T19:17:15.942857+08:00           14 Connect   root@127.0.0.1 on  using TCP/IP
2024-11-17T19:17:15.958012+08:00           15 Connect   root@127.0.0.1 on mysqlslap using SSL/TLS
2024-11-17T19:17:15.958916+08:00           15 Query     select 1
2024-11-17T19:17:15.959572+08:00           15 Quit
2024-11-17T19:17:15.960218+08:00           14 Quit
```

Why it happens:
In the run_task function, after initializing MYSQL, MYSQL is not set according to the options in the mysqlslap command. This step is only done in the main function.

How to fix:
Put the MYSQL setting operation separately in the set_mysql_options function. After initializing MYSQL, call set_mysql_options to set MYSQL.