### PR TITLE
Bug #115503 The `sql_log_off` parameter is not working as expected at the session level

### DIFF
--- a/sql/log.cc
+++ b/sql/log.cc
@@ -1367,7 +1367,9 @@ static bool log_command(THD *thd, enum_server_command command) {
     Security_context *sctx = thd->security_context();
     if ((thd->variables.option_bits & OPTION_LOG_OFF) &&
         (sctx->check_access(SUPER_ACL) ||
-         sctx->has_global_grant(STRING_WITH_LEN("CONNECTION_ADMIN")).first)) {
+         sctx->has_global_grant(STRING_WITH_LEN("CONNECTION_ADMIN")).first ||
+         sctx->has_global_grant(STRING_WITH_LEN("SESSION_VARIABLES_ADMIN")).first ||
+         sctx->has_global_grant(STRING_WITH_LEN("SYSTEM_VARIABLES_ADMIN")).first)) {
       /* No logging */
       return false;
     }


### PR DESCRIPTION
When we modify a session variable, the changes should be reflected in the same session. The new privilege SESSION_VARIABLES_ADMIN controls the setting of certain variables, including sql_log_off. However, even after a user with the SESSION_VARIABLES_ADMIN privilege changes the session value of sql_log_off, the change is not applicable to the session unless the user also has additional admin privileges. To be precise, it appears that we are checking for the SUPER or CONNECTION_ADMIN privilege to turn off logging at the session level.

This change address the issue by allowing users with SESSION_VARIABLES_ADMIN or SYSTEM_VARIABLES_ADMIN privilege to turn off logging at the session level, in addition to users with the SUPER privilege.

This commit fixes the bug https://bugs.mysql.com/bug.php?id=115503

This contribution is under the OCA signed by Amazon and covering submissions to the MySQL project.