### PR TITLE
Fix buffer overflow in ndb config

### DIFF
--- a/storage/ndb/src/common/portlib/NdbConfig.cpp
+++ b/storage/ndb/src/common/portlib/NdbConfig.cpp
@@ -71,7 +71,7 @@ char *NdbConfig_NdbCfgName(int with_ndb_home) {
     len = (int)strlen(buf);
   } else
     buf = (char *)malloc(PATH_MAX);
-  snprintf(buf + len, PATH_MAX, "Ndb.cfg");
+  snprintf(buf + len, PATH_MAX - len, "Ndb.cfg");
   return buf;
 }
 


### PR DESCRIPTION
In case `with_ndb_home` is set, `buf` is allocated with `PATH_MAX` and the home is already written into the buffer.

The additional path is written using `snprintf` and it starts off at `len`. It still can write up to `PATH_MAX` though which is wrong, since if we already have a home written into it, we only have `PATH_MAX - len` available in the buffer.

On Ubuntu 24.04 with debug builds this is caught and it crashes:

```
*** buffer overflow detected ***: terminated
Signal 6 thrown, attempting backtrace.
stack_bottom = 0 thread_stack 0x0
 #0 0x604895341cb6 <unknown>
 #1 0x7ff22524531f <unknown> at sysdeps/unix/sysv/linux/x86_64/libc_sigaction.c:0
 #2 0x7ff22529eb1c __pthread_kill_implementation at ./nptl/pthread_kill.c:44
 #3 0x7ff22529eb1c __pthread_kill_internal at ./nptl/pthread_kill.c:78
 #4 0x7ff22529eb1c __GI___pthread_kill at ./nptl/pthread_kill.c:89
 #5 0x7ff22524526d __GI_raise at sysdeps/posix/raise.c:26
 #6 0x7ff2252288fe __GI_abort at ./stdlib/abort.c:79
 #7 0x7ff2252297b5 __libc_message_impl at sysdeps/posix/libc_fatal.c:132
 #8 0x7ff225336c18 __GI___fortify_fail at ./debug/fortify_fail.c:24
 #9 0x7ff2253365d3 __GI___chk_fail at ./debug/chk_fail.c:28
 #10 0x7ff225337db4 ___snprintf_chk at ./debug/snprintf_chk.c:29
 #11 0x6048953593ba <unknown>
 #12 0x604895331a3d <unknown>
 #13 0x6048953206e7 <unknown>
 #14 0x60489531f4b1 <unknown>
 #15 0x60489531e8e6 <unknown>
 #16 0x7ff22522a1c9 __libc_start_call_main at sysdeps/nptl/libc_start_call_main.h:58
 #17 0x7ff22522a28a __libc_start_main_impl at csu/libc-start.c:360
 #18 0x60489531ed54 <unknown>
 #19 0xffffffffffffffff <unknown>
```

In practice this buffer overflow only would happen with very long paths.