### PR TITLE
Remove whitespace between INSERT/REPLACE and IGNORE in database dumps

### DIFF
--- a/client/mysqldump.cc
+++ b/client/mysqldump.cc
@@ -2950,7 +2950,7 @@ static uint get_table_structure(const char *table, char *db, char *table_type,
       dynstr_set_checked(&insert_pat, "");
   }
 
-  insert_option = ((opt_ignore || skip_ddl) ? " IGNORE " : "");
+  insert_option = ((opt_ignore || skip_ddl) ? "IGNORE " : "");
 
   verbose_msg("-- Retrieving table structure for table %s...\n", table);
 


### PR DESCRIPTION
since we do not need a double space when 1 is suffice.

See #524 for more info.