### PR TITLE
Fix spelling mistakes: "recieve" corrected to "receive" in comments, documentation, and logs

### DIFF
--- a/components/test/udf_services/test_udf_extension.cc
+++ b/components/test/udf_services/test_udf_extension.cc
@@ -357,7 +357,7 @@ bool Test_udf_charset_base::run_return_udf(UDF_INIT *initid, UDF_ARGS *args,
                                            unsigned long &result_len) {
   for (uint i = 0; i < args->arg_count; i++) {
     if (!args->args[i]) {
-      s_message << "Recieved argument " << i + 1
+      s_message << "Received argument " << i + 1
                 << " as null. Specify valid argument";
       return true;
     }
@@ -468,7 +468,7 @@ bool Test_udf_charset_base::run_args_udf(UDF_INIT *initid, UDF_ARGS *args,
                                          unsigned long &result_len) {
   for (uint i = 0; i < args->arg_count; i++) {
     if (!args->args[i]) {
-      s_message << "Recieved argument " << i + 1
+      s_message << "Received argument " << i + 1
                 << " as null. Specify valid argument";
       return true;
     }

--- a/mysql-test/r/big_packets.result
+++ b/mysql-test/r/big_packets.result
@@ -13,11 +13,11 @@ DROP USER foo@localhost;
 CREATE USER foo@localhost IDENTIFIED BY 'pwd';
 #
 # Blocking client
-# Send/Recieve a large packet with following options :-
+# Send/Receive a large packet with following options :-
 # Compress option : COMPRESS
 # Compress algorithm : zstd
 # Packet size : 64*1024*1024
 #
-############ Verify Send and Recieve 67108864 bytes packet #################
+############ Verify Send and Receive 67108864 bytes packet #################
 ############ Verify the packet contents #################################
 DROP USER foo@localhost;

--- a/mysql-test/r/big_packets_async.result
+++ b/mysql-test/r/big_packets_async.result
@@ -13,11 +13,11 @@ DROP USER foo@localhost;
 CREATE USER foo@localhost IDENTIFIED BY 'pwd';
 #
 # Nonblocking client
-# Send/Recieve a large packet with following options :-
+# Send/Receive a large packet with following options :-
 # Compress option : COMPRESS
 # Compress algorithm : zstd
 # Packet size : 64*1024*1024
 #
-############ Verify Send and Recieve 67108864 bytes packet #################
+############ Verify Send and Receive 67108864 bytes packet #################
 ############ Verify the packet contents #################################
 DROP USER foo@localhost;

--- a/mysql-test/r/big_packets_boundary.result
+++ b/mysql-test/r/big_packets_boundary.result
@@ -99,22 +99,22 @@ DROP USER foo@localhost;
 CREATE USER foo@localhost IDENTIFIED BY 'pwd';
 #
 # Blocking client
-# Send/Recieve a large packet with following options :-
+# Send/Receive a large packet with following options :-
 # Compress option : COMPRESS
 # Compress algorithm : zstd
 # Packet size : 67108851
 #
-############ Verify Send and Recieve 67108851 bytes packet #################
+############ Verify Send and Receive 67108851 bytes packet #################
 ############ Verify the packet contents #################################
 DROP USER foo@localhost;
 CREATE USER foo@localhost IDENTIFIED BY 'pwd';
 #
 # Blocking client
-# Send/Recieve a large packet with following options :-
+# Send/Receive a large packet with following options :-
 # Compress option : COMPRESS
 # Compress algorithm : zlib
 # Packet size : 16777211
 #
-############ Verify Send and Recieve 16777211 bytes packet #################
+############ Verify Send and Receive 16777211 bytes packet #################
 ############ Verify the packet contents #################################
 DROP USER foo@localhost;

--- a/mysql-test/r/big_packets_boundary_async.result
+++ b/mysql-test/r/big_packets_boundary_async.result
@@ -99,22 +99,22 @@ DROP USER foo@localhost;
 CREATE USER foo@localhost IDENTIFIED BY 'pwd';
 #
 # Nonblocking client
-# Send/Recieve a large packet with following options :-
+# Send/Receive a large packet with following options :-
 # Compress option : COMPRESS
 # Compress algorithm : zstd
 # Packet size : 67108851
 #
-############ Verify Send and Recieve 67108851 bytes packet #################
+############ Verify Send and Receive 67108851 bytes packet #################
 ############ Verify the packet contents #################################
 DROP USER foo@localhost;
 CREATE USER foo@localhost IDENTIFIED BY 'pwd';
 #
 # Nonblocking client
-# Send/Recieve a large packet with following options :-
+# Send/Receive a large packet with following options :-
 # Compress option : COMPRESS
 # Compress algorithm : zlib
 # Packet size : 16777211
 #
-############ Verify Send and Recieve 16777211 bytes packet #################
+############ Verify Send and Receive 16777211 bytes packet #################
 ############ Verify the packet contents #################################
 DROP USER foo@localhost;

--- a/mysql-test/suite/group_replication/t/gr_logged_view_change_events.test
+++ b/mysql-test/suite/group_replication/t/gr_logged_view_change_events.test
@@ -12,7 +12,7 @@
 # Test:
 # 0. The test requires three servers: M1, M2 and M3.
 # 1. Bootstrap group with M1. Create table t1 on M1. Start GR on M2. Check that
-#    M2 recieves view change from M1, create table, view change by M2.
+#    M2 receives view change from M1, create table, view change by M2.
 # 2. Make M2 leave and join again. Check that exists one more event after join
 #    in the binlog.
 # 3. Stop GR on M2. Join and leave M3. Start GR on M2. Check on M2 it should

--- a/mysql-test/t/async_client.inc
+++ b/mysql-test/t/async_client.inc
@@ -3,7 +3,7 @@ enable_async_client;
 
 --echo #
 --echo # Nonblocking client
---echo # Send/Recieve a large packet with following options :-
+--echo # Send/Receive a large packet with following options :-
 --echo # Compress option : $COMPRESS_OPTION
 --echo # Compress algorithm : $COMPRESS_ALGORITHM
 --echo # Packet size : $SIZE
@@ -20,7 +20,7 @@ connect(foo_con,localhost,foo,pwd,,,,SSL,,);
 --let $x_str = `SELECT REPEAT('X', $SIZE)`
 --let $SIZE =  `SELECT ($SIZE)`
 
---echo ############ Verify Send and Recieve $SIZE bytes packet #################
+--echo ############ Verify Send and Receive $SIZE bytes packet #################
 
 --let $str = `SELECT "$x_str"`
 --let $x_str = 0

--- a/mysql-test/t/connection_compression_zstd.test
+++ b/mysql-test/t/connection_compression_zstd.test
@@ -3,7 +3,7 @@
 # Aim of the test is to test compression between the mysql client   #
 # and server using the zstd library. It does the following :-       #
 #  - Loads table with appropriate data.                             #
-#  - Recieves it through the client using different compression     #
+#  - Receives it through the client using different compression     #
 #    levels.                                                        #
 #  - Compares the number of bytes sent from the server for each     #
 #    instance.                                                      #

--- a/mysql-test/t/sync_client.inc
+++ b/mysql-test/t/sync_client.inc
@@ -2,7 +2,7 @@ CREATE USER foo@localhost IDENTIFIED BY 'pwd';
 
 --echo #
 --echo # Blocking client
---echo # Send/Recieve a large packet with following options :-
+--echo # Send/Receive a large packet with following options :-
 --echo # Compress option : $COMPRESS_OPTION
 --echo # Compress algorithm : $COMPRESS_ALGORITHM
 --echo # Packet size : $SIZE
@@ -19,7 +19,7 @@ connect(foo_con,localhost,foo,pwd,,,,SSL,,);
 --let $x_str = `SELECT REPEAT('X', $SIZE)`
 --let $SIZE =  `SELECT ($SIZE)`
 
---echo ############ Verify Send and Recieve $SIZE bytes packet #################
+--echo ############ Verify Send and Receive $SIZE bytes packet #################
 
 --let $str = `SELECT "$x_str"`
 --let $x_str = 0

--- a/plugin/udf_services/test_udf_extension.cc
+++ b/plugin/udf_services/test_udf_extension.cc
@@ -384,7 +384,7 @@ bool Test_udf_charset_base::run_return_udf(UDF_INIT *initid, UDF_ARGS *args,
                                            unsigned long &result_len) {
   for (uint i = 0; i < args->arg_count; i++) {
     if (!args->args[i]) {
-      *s_message << "Recieved argument " << i + 1
+      *s_message << "Received argument " << i + 1
                  << " as null. Specify valid argument";
       return true;
     }
@@ -497,7 +497,7 @@ bool Test_udf_charset_base::run_args_udf(UDF_INIT *initid, UDF_ARGS *args,
                                          unsigned long &result_len) {
   for (uint i = 0; i < args->arg_count; i++) {
     if (!args->args[i]) {
-      *s_message << "Recieved argument " << i + 1
+      *s_message << "Received argument " << i + 1
                  << " as null. Specify valid argument";
       return true;
     }

--- a/sql/rpl_mi.h
+++ b/sql/rpl_mi.h
@@ -322,7 +322,7 @@ class Master_info : public Rpl_info {
   ulonglong last_heartbeat;
 
   /// The decompressed size of the transaction that is currently in progress of
-  /// being queued, if any. This is private to the reciever.
+  /// being queued, if any. This is private to the receiver.
   int64_t m_queueing_transaction_size{0};
   /// The size of the gtid event for the  transaction that is currently in
   /// progress of being queued. This is private to the receiver.

--- a/storage/ndb/src/mgmapi/ndb_logevent.cpp
+++ b/storage/ndb/src/mgmapi/ndb_logevent.cpp
@@ -152,7 +152,7 @@ struct Ndb_logevent_body_row ndb_logevent_body[] = {
 
     ROW(NDBStartCompleted, "version", 1, version),
 
-    //  ROW( STTORRYRecieved),
+    //  ROW( STTORRYReceived),
 
     ROW(StartPhaseCompleted, "phase", 1, phase),
     ROW(StartPhaseCompleted, "starttype", 2, starttype),


### PR DESCRIPTION
This pull request fixes multiple spelling mistakes across the repository. Specifically:
- Corrected "recieve" to "receive".
- Corrected "recieved" to "received".
- Corrected "reciever" to "receiver".

### Scope of Changes:
- **Comments**: Fixed occurrences of misspellings in code comments.
- **Documentation**: Corrected misspellings in markdown files and documentation files.
- **Logs**: Updated log messages to ensure proper spelling.

### Why These Changes?
- Enhances readability and professionalism in the repository.
- Ensures logs and documentation are accurate for users and developers.

### Notes:
- These changes do not modify any functional code or logic.
- Let me know if there are additional files or areas that need similar corrections.

Thank you for reviewing this PR!
