### PR TITLE
Fix crash inside InnoDB when resizing

### DIFF
--- a/mysql-test/suite/innodb/r/buf_pool_resize_crash.result
+++ b/mysql-test/suite/innodb/r/buf_pool_resize_crash.result
@@ -1,0 +1,8 @@
+SET GLOBAL innodb_buffer_pool_size=128974848;
+SELECT SLEEP(1);
+SLEEP(1)
+0
+SET GLOBAL innodb_buffer_pool_size=127926272;
+SELECT SLEEP(1);
+SLEEP(1)
+0

--- a/mysql-test/suite/innodb/t/buf_pool_resize_crash-master.opt
+++ b/mysql-test/suite/innodb/t/buf_pool_resize_crash-master.opt
@@ -1,0 +1,3 @@
+--innodb_buffer_pool_chunk_size=1M
+--innodb_buffer_pool_instances=1
+--innodb_buffer_pool_size=128MB

--- a/mysql-test/suite/innodb/t/buf_pool_resize_crash.test
+++ b/mysql-test/suite/innodb/t/buf_pool_resize_crash.test
@@ -1,0 +1,15 @@
+SET GLOBAL innodb_buffer_pool_size=128974848;
+SELECT SLEEP(1);
+SET GLOBAL innodb_buffer_pool_size=127926272;
+SELECT SLEEP(1);
+
+# This test verifies a scenario where buffer pool chunks
+# are not aligned at InnoDB page sizes, which means they
+# can contain one fewer page than requested. This also means
+# that it's not reliably possible to resize it back to the
+# original value. In that case, it ends up having a smaller
+# buffer pool than requested due to the mismatched alignment
+# of the chunks.
+#
+# So instead we here restart so we get the original values again.
+--source include/force_restart.inc

--- a/storage/innobase/buf/buf0buddy.cc
+++ b/storage/innobase/buf/buf0buddy.cc
@@ -761,7 +761,6 @@ bool buf_buddy_realloc(buf_pool_t *buf_pool, void *buf, ulint size) {
 @param[in]      buf_pool        buffer pool instance */
 void buf_buddy_condense_free(buf_pool_t *buf_pool) {
   mutex_enter(&buf_pool->zip_free_mutex);
-  ut_ad(buf_pool->curr_size < buf_pool->old_size);
 
   for (ulint i = 0; i < UT_ARR_SIZE(buf_pool->zip_free); ++i) {
     buf_buddy_free_t *buf = UT_LIST_GET_FIRST(buf_pool->zip_free[i]);

--- a/storage/innobase/include/buf0buf.ic
+++ b/storage/innobase/include/buf0buf.ic
@@ -1124,7 +1124,6 @@ withdraw target of the currently ongoing buffer pool resize.
 if the buffer pool is not currently being resized. */
 static inline ulint buf_get_withdraw_depth(buf_pool_t *buf_pool) {
   os_rmb;
-  if (buf_pool->curr_size >= buf_pool->old_size) return 0;
   ulint withdraw_len = UT_LIST_GET_LEN(buf_pool->withdraw);
   return (buf_pool->withdraw_target > withdraw_len
               ? buf_pool->withdraw_target - withdraw_len


### PR DESCRIPTION
It is possible to hit an assertion bug when resizing the InnoDB buffer pool that crashes MySQL. In production builds, the assertion would not hit but it catches a valid scenario and MySQL would crash later on if it would try to use an already free'd buffer chunk.

The crash can be reproduced while running the newly added `innodb.buf_pool_resize_crash` test. It hits the following assertion:

```
2025-01-07T14:19:31.163266Z 0 [ERROR] [MY-011910] [InnoDB] [FATAL] Free list len 6589, free blocks 6526. Aborting...
2025-01-07T14:19:31.163415Z 0 [ERROR] [MY-013183] [InnoDB] Assertion failure: buf0buf.cc:6266:ib::fatal triggered thread 0x16deff000
InnoDB: We intentionally generate a memory trap.
InnoDB: Submit a detailed bug report to http://bugs.mysql.com.
InnoDB: If you get repeated assertion failures or crashes, even
InnoDB: immediately after the mysqld startup, there may be
InnoDB: corruption in the InnoDB tablespace. Please refer to
InnoDB: http://dev.mysql.com/doc/refman/9.1/en/forcing-innodb-recovery.html
InnoDB: about forcing recovery.
2025-01-07T14:19:31Z UTC - mysqld got signal 6 ;
Most likely, you have hit a bug, but this error can also be caused by malfunctioning hardware.
Thread pointer: 0x0
Attempting backtrace. You can use the following information to find out
where mysqld died. If you see no messages after this, something went
terribly wrong...
stack_bottom = 0 thread_stack 0x100000
0   mysqld                              0x0000000104c9ccbc my_print_stacktrace(unsigned char const*, unsigned long) + 72
1   mysqld                              0x0000000103a33514 print_fatal_signal(int, __siginfo*) + 796
2   mysqld                              0x0000000103a337e4 my_server_abort() + 112
3   mysqld                              0x0000000104c8d560 my_abort() + 20
4   mysqld                              0x00000001056b7c30 ut_dbg_assertion_failed(char const*, char const*, unsigned long long) + 536
5   mysqld                              0x00000001056c89cc ib::fatal::~fatal() + 144
6   mysqld                              0x00000001056c89f4 ib::fatal::~fatal() + 28
7   mysqld                              0x0000000104e1779c buf_pool_validate_instance(buf_pool_t*) + 2812
8   mysqld                              0x0000000104e0b71c buf_validate() + 72
9   mysqld                              0x0000000104e08fcc buf_pool_resize() + 8240
10  mysqld                              0x0000000104e06cbc buf_resize_thread() + 400
11  mysqld                              0x0000000104d580bc decltype(std::declval<void (*)()>()()) std::__1::__invoke[abi:ne180100]<void (*)()>(void (*&&)()) + 28
12  mysqld                              0x0000000104d57ef8 std::__1::invoke_result<void (*)()>::type std::__1::invoke[abi:ne180100]<void (*)()>(void (*&&)()) + 24
13  mysqld                              0x0000000104d57e1c void Detached_thread::operator()<void (*)()>(void (*&&)()) + 184
14  mysqld                              0x0000000104d57d08 decltype(std::declval<Detached_thread>()(std::declval<void (*)()>())) std::__1::__invoke[abi:ne180100]<Detached_thread, void (*)()>(Detached_thread&&, void (*&&)()) + 32
15  mysqld                              0x0000000104d57c9c void std::__1::__thread_execute[abi:ne180100]<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, Detached_thread, void (*)(), 2ul>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, Detached_thread, void (*)()>&, std::__1::__tuple_indices<2ul>) + 48
16  mysqld                              0x0000000104d57428 void* std::__1::__thread_proxy[abi:ne180100]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, Detached_thread, void (*)()>>(void*) + 84
17  libsystem_pthread.dylib             0x00000001810142e4 _pthread_start + 136
18  libsystem_pthread.dylib             0x000000018100f0fc thread_start + 8
The manual page at http://dev.mysql.com/doc/mysql/en/crashing.html contains
information that should help you find out what is causing the crash.
Writing a core file
safe_process[7648]: Child process: 7649, killed by signal: 6
```

The resize process works by setting the `curr_size` of the pool to the new desired number of pages. This resize assumes implicitly that it's a multiple of `UNIV_PAGE_SIZE`. This is however a upper limit of the number of pages.

It is an upper limit due to how chunks are allocated. Chunks end up being aligned to the 16K `UNIV_PAGE_SIZE` size, but are allocated aligned to the OS page size. With small pages, this is 4K. This means that if the allocation is not aligned, there's 1 page fewer available in the allocated chunk. This is also described in `buf0buf.cc:1020`.

The consequence of that is that the computation of the new `curr_size` can be off and is later on corrected to the actual number of pages in the pool, which starts at `buf0buf.cc:2485`.

The problem now happens on the next resize. In the test scenario here, there's chunks of 1M in size, which can contain up to 64 pages of 16K each. In case we have non-alignment, it would only store up to 63 pages.

When there's enough entries with 63 pages set as the actual storage size like here, the size of the new buffer pool in the optimistic scenario of 64 pages per chunk means that the new computed `curr_size` for the second shrinking is actually *smaller* than the current number of available pages.

In the example in the test, there's 128 chunks of 1M each but with 63 pages instead of 64, there's 1/64th of the total number of chunks that the calculation can be off. So it's not unexpected that if you lower the available memory with 1 chunk, the initial computed value for `curr_size` is higher.

When running inside a debugger, the first time we see these values and the `old_size` is smaller than the `curr_size`:

```
Process 45296 stopped
* thread #23, name = 'ib_buf_resize', stop reason = breakpoint 1.1
    frame #0: 0x00000001021f7688 mysqld`buf_pool_resize() at buf0buf.cc:2214:9
   2211   /* wait for the number of blocks fit to the new size (if needed)*/
   2212   for (ulint i = 0; i < srv_buf_pool_instances; i++) {
   2213     buf_pool = buf_pool_from_array(i);
-> 2214     if (buf_pool->curr_size < buf_pool->old_size) {
   2215       should_retry_withdraw |= buf_pool_withdraw_blocks(buf_pool);
   2216     }
   2217     if (!should_retry_withdraw) {
Target 0: (mysqld) stopped.
(lldb) p buf_pool->curr_size
(ulint) 7872
(lldb) p buf_pool->old_size
(ulint) 8064
```

Here it also can be seen that the new computed target size is `7872` pages (`128974848 / 16384`). On the second resize, these are the values:

```
Process 45296 stopped
* thread #23, name = 'ib_buf_resize', stop reason = breakpoint 1.1
    frame #0: 0x00000001021f7688 mysqld`buf_pool_resize() at buf0buf.cc:2214:9
   2211   /* wait for the number of blocks fit to the new size (if needed)*/
   2212   for (ulint i = 0; i < srv_buf_pool_instances; i++) {
   2213     buf_pool = buf_pool_from_array(i);
-> 2214     if (buf_pool->curr_size < buf_pool->old_size) {
   2215       should_retry_withdraw |= buf_pool_withdraw_blocks(buf_pool);
   2216     }
   2217     if (!should_retry_withdraw) {
Target 0: (mysqld) stopped.
(lldb) p buf_pool->curr_size
(ulint) 7808
(lldb) p buf_pool->old_size
(ulint) 7749
```

What can be seen here is that `old_size` is now smaller than the requested `curr_size`. What has happened is that even though `7872`
pages were requested, only `7749` pages are available due to the chunks not being aligned to 16K boundaries. In this example, none of the pages are aligned so we have `123 * 63 = 7749` available pages.

This higher value has a consequence, which is that in `buf0buf.cc:2215`, we don't end up calling buf_pool_withdraw_blocks for the pool in case we shrink it in that case.

That in turn means that we don't mark the pages in the pool as withdrawn but later on, we do free the actual chunk. This means that the chunks is removed, while the pages are still in the free list. This leads to the assertion being hit that crashes MySQL.

The fix here is to remove the assumption that we can short cut in case that `curr_size` is larged than the `old_size`, because as this test shows, this assumption is wrong. There are cases where this is not true but where we do need to withdraw the blocks correctly. This assumption is also copied in some more locations as either a check too or a debug assertion that we need to remove.

This affects all versions all the way back to MySQL 8.0.x at least (potentially even older).