### PR TITLE
mysql.h: include plugin_auth_common.h for net_async_status enum

### DIFF
--- a/include/mysql.h
+++ b/include/mysql.h
@@ -79,6 +79,7 @@ typedef int my_socket;
 #include "field_types.h"
 #include "my_list.h"
 #include "mysql_com.h"
+#include "plugin_auth_common.h"
 
 /* Include declarations of plug-in API */
 #include "mysql/client_plugin.h"  // IWYU pragma: keep


### PR DESCRIPTION
Function declarations in `mysql.h` refer to `enum net_async_status enum` which is defined in `plugin_auth_common.h`

With g++ 9.5.0 under Ubuntu 22.04.1 LTS, the following errors are produced:
```
error: use of enum ‘net_async_status’ without previous declaration
 enum net_async_status STDCALL mysql_real_connect_nonblocking(
      ^~~~~~~~~~~~~~~~
error: use of enum ‘net_async_status’ without previous declaration
 enum net_async_status STDCALL mysql_send_query_nonblocking(
      ^~~~~~~~~~~~~~~~
error: use of enum ‘net_async_status’ without previous declaration
 enum net_async_status STDCALL mysql_real_query_nonblocking(
      ^~~~~~~~~~~~~~~~
error: use of enum ‘net_async_status’ without previous declaration
 enum net_async_status STDCALL
      ^~~~~~~~~~~~~~~~
error: use of enum ‘net_async_status’ without previous declaration
 enum net_async_status STDCALL mysql_next_result_nonblocking(MYSQL *mysql);
      ^~~~~~~~~~~~~~~~
error: use of enum ‘net_async_status’ without previous declaration
 enum net_async_status STDCALL mysql_select_db_nonblocking(MYSQL *mysql,
      ^~~~~~~~~~~~~~~~
error: use of enum ‘net_async_status’ without previous declaration
 enum net_async_status STDCALL mysql_free_result_nonblocking(MYSQL_RES *result);
      ^~~~~~~~~~~~~~~~
error: use of enum ‘net_async_status’ without previous declaration
 enum net_async_status STDCALL mysql_fetch_row_nonblocking(MYSQL_RES *res,
      ^~~~~~~~~~~~~~~~
```

This issue was also reported by https://github.com/vincefn/objcryst/issues/48

I confirm the code being submitted is offered under the terms of the OCA, and that I am authorized to contribute it.