### PR TITLE
Added documentation for unused bytes at the end of Protocol::ColumnDefinition41

### DIFF
--- a/sql/protocol_classic.cc
+++ b/sql/protocol_classic.cc
@@ -3096,6 +3096,9 @@ bool Protocol_classic::end_result_metadata() {
         <li>0x1f for dynamic strings, double, float</li>
         <li>0x00 to 0x51 for decimals</li>
         </ul></td></tr>
+  <tr><td>@ref a_protocol_type_int2 "int&lt;2&gt;"</td>
+      <td>reserved</td>
+      <td>reserved. All 0s.</td></tr>
   </table>
 
   @note `decimals` and `column_length` can be used for text output formatting


### PR DESCRIPTION
# Two unused, undocumented extra bytes in each ColumnDefinition Packet

Here is a packet capture of the Column definitions from a `select * from db;` query where the default mysql schema is selected. I have added a space to pad between the packet header and body.
```
01000001 16
27000002 03646566056d7973716c02646202646204486f737404486f73740cff00fc030000fe0340000000
23000003 03646566056d7973716c0264620264620244620244620cff0000010000fe8340000000
27000004 03646566056d7973716c026462026462045573657204557365720cff0080000000fe8b40000000
35000005 03646566056d7973716c0264620264620b53656c6563745f707269760b53656c6563745f707269760cff0004000000fe0101000000
35000006 03646566056d7973716c0264620264620b496e736572745f707269760b496e736572745f707269760cff0004000000fe0101000000
35000007 03646566056d7973716c0264620264620b5570646174655f707269760b5570646174655f707269760cff0004000000fe0101000000
35000008 03646566056d7973716c0264620264620b44656c6574655f707269760b44656c6574655f707269760cff0004000000fe0101000000
35000009 03646566056d7973716c0264620264620b4372656174655f707269760b4372656174655f707269760cff0004000000fe0101000000
3100000a 03646566056d7973716c0264620264620944726f705f707269760944726f705f707269760cff0004000000fe0101000000
3300000b 03646566056d7973716c0264620264620a4772616e745f707269760a4772616e745f707269760cff0004000000fe0101000000
3d00000c 03646566056d7973716c0264620264620f5265666572656e6365735f707269760f5265666572656e6365735f707269760cff0004000000fe0101000000
3300000d 03646566056d7973716c0264620264620a496e6465785f707269760a496e6465785f707269760cff0004000000fe0101000000
3300000e 03646566056d7973716c0264620264620a416c7465725f707269760a416c7465725f707269760cff0004000000fe0101000000
4900000f 03646566056d7973716c026462026462154372656174655f746d705f7461626c655f70726976154372656174655f746d705f7461626c655f707269760cff0004000000fe0101000000
3f000010 03646566056d7973716c026462026462104c6f636b5f7461626c65735f70726976104c6f636b5f7461626c65735f707269760cff0004000000fe0101000000
3f000011 03646566056d7973716c026462026462104372656174655f766965775f70726976104372656174655f766965775f707269760cff0004000000fe0101000000
3b000012 03646566056d7973716c0264620264620e53686f775f766965775f707269760e53686f775f766965775f707269760cff0004000000fe0101000000
45000013 03646566056d7973716c026462026462134372656174655f726f7574696e655f70726976134372656174655f726f7574696e655f707269760cff0004000000fe0101000000
43000014 03646566056d7973716c02646202646212416c7465725f726f7574696e655f7072697612416c7465725f726f7574696e655f707269760cff0004000000fe0101000000
37000015 03646566056d7973716c0264620264620c457865637574655f707269760c457865637574655f707269760cff0004000000fe0101000000
33000016 03646566056d7973716c0264620264620a4576656e745f707269760a4576656e745f707269760cff0004000000fe0101000000
37000017 03646566056d7973716c0264620264620c547269676765725f707269760c547269676765725f707269760cff0004000000fe0101000000
.......................<ResultSet Row Packets Truncated>.......................
```

As described by https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_query_response_text_resultset.html, the first packet contains the count of columns. 
Whereas the following packets shall contain `ColumnDefinition`s. Parsing the `ColumnDefinition` packets as documented in https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_query_response_text_resultset_column_definition.html,

We get:

| Hex          | Name                           | Type                        | Value    |
|--------------|--------------------------------|-----------------------------|----------|
| 03646566     | catalog                        | string                      | def      |
| 056d7973716c | schema                         | string                      | mysql    |
| 026462       | table                          | string                      | db       |
| 026462       | org_table                      | string                      | db       |
| 04486f7374   | name                           | string                      | Host     |
| 04486f7374   | org_name                       | string                      | Host     |
| 0c           | length                         | int                         | 0c       |
| ff00         | charset                        | int                         | ff00     |
| fc030000     | col_length                     | int                         | fc030000 |
| fe           | type                           | int                         | fe       |
| 0340         | flags                          | int                         | 0340     |
| 00           | decimals                       | int                         | 00       |
| 0000         | ?????????????????????????????? | -> Two bytes, undocumented.         ||

Looking into the source code, these fields are reserved for future use.

```
    pos[9] = (char)field->decimals;
    pos[10] = 0;  // For the future
    pos[11] = 0;  // For the future
    pos += 12;
```


Mysql CLI dump for reference:

```
➜  ~ mysql -V                   
mysql  Ver 8.0.40-0ubuntu0.24.10.1 for Linux on x86_64 ((Ubuntu))
~ mysql -uroot -pasd -h127.0.0.1 -P3307 --ssl-mode=DISABLED
mysql: [Warning] Using a password on the command line interface can be insecure.
Welcome to the MySQL monitor.  Commands end with ; or \g.
Your MySQL connection id is 66
Server version: 8.0.32 MySQL Community Server - GPL

Copyright (c) 2000, 2024, Oracle and/or its affiliates.

Oracle is a registered trademark of Oracle Corporation and/or its
affiliates. Other names may be trademarks of their respective
owners.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

mysql> SELECT VERSION();
+-----------+
| VERSION() |
+-----------+
| 8.0.32    |
+-----------+
1 row in set (0.00 sec)

mysql> use mysql;
Reading table information for completion of table and column names
You can turn off this feature to get a quicker startup with -A

Database changed
mysql> select * from db;
+-----------+--------------------+---------------+-------------+-------------+-------------+-------------+-------------+-----------+------------+-----------------+------------+------------+-----------------------+------------------+------------------+----------------+---------------------+--------------------+--------------+------------+--------------+
| Host      | Db                 | User          | Select_priv | Insert_priv | Update_priv | Delete_priv | Create_priv | Drop_priv | Grant_priv | References_priv | Index_priv | Alter_priv | Create_tmp_table_priv | Lock_tables_priv | Create_view_priv | Show_view_priv | Create_routine_priv | Alter_routine_priv | Execute_priv | Event_priv | Trigger_priv |
+-----------+--------------------+---------------+-------------+-------------+-------------+-------------+-------------+-----------+------------+-----------------+------------+------------+-----------------------+------------------+------------------+----------------+---------------------+--------------------+--------------+------------+--------------+
| localhost | performance_schema | mysql.session | Y           | N           | N           | N           | N           | N         | N          | N               | N          | N          | N                     | N                | N                | N              | N                   | N                  | N            | N          | N            |
| localhost | sys                | mysql.sys     | N           | N           | N           | N           | N           | N         | N          | N               | N          | N          | N                     | N                | N                | N              | N                   | N                  | N            | N          | Y            |
+-----------+--------------------+---------------+-------------+-------------+-------------+-------------+-------------+-----------+------------+-----------------+------------+------------+-----------------------+------------------+------------------+----------------+---------------------+--------------------+--------------+------------+--------------+
2 rows in set (0.00 sec)

mysql> 
```
