### PR TITLE
docs: Use unversioned reference manual link

### DIFF
--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -45,7 +45,7 @@
 
   For other sections, only links are provided, as a starting point into the component.
 
-  For the user manual, see http://dev.mysql.com/doc/refman/8.0/en/
+  For the reference manual, see http://dev.mysql.com/doc/en/
 
   This documentation is published for each release, starting with MySQL 8.0.
 


### PR DESCRIPTION
https://dev.mysql.com/doc/dev/mysql-server/9.2.0/ is for 9.2.0, but the reference manual link is for 8.0. This avoids this issue by using an unversioned link instead.