### PR TITLE
Fix issues with mysql::serialization doc

### DIFF
--- a/libs/mysql/serialization/readme.md
+++ b/libs/mysql/serialization/readme.md
@@ -145,8 +145,6 @@ field_data can be one of:
 
 - fixlen_integer_format - fixed-length integer, encoded using a fixed number of
   bytes, signed or unsigned
-- varlen_integer_format - variable-length integer field, encoded using 1-9 bytes,
-  depending on the field value
 - floating_point_integer_format - floating point number field:
   - sp_floating_point_integer_format - single precision floating point number
   - dp_floating_point_integer_format - double precision floating point number
@@ -157,7 +155,7 @@ field_data can be one of:
 - message_format - nested message
 - varlen_integer_format - format used to encode signed/unsigned integers using
   1-9 bytes, depending on the integer value. Format is described in detail
-  in the [Variable-length integers](#variable-length-integers).
+  in the [Variable-length integers](#varint).
 
 ```
 {
@@ -198,7 +196,7 @@ String format consists of:
 - string_length - the number of 1 byte elements in the string
 - string characters, 1 byte unsigned integers
 
-#### Variable-length integers
+#### Variable-length integers {#varint}
 
 Variable-length integers are encoded using 1-9 bytes, depending on the
 value of a particular field. Bytes are always stored using in LE byte order.


### PR DESCRIPTION
- `varlen_integer_format` was mentioned twice in the list of what `field_data` can be.
- Doxygen didn't create an anchor for `#variable-length-integers` like other markdown software would do. So manually set the anchor.

With this PR:
![image](https://github.com/user-attachments/assets/b128252e-c7ab-432e-b136-2b84222b2144)

Without this PR:
![image](https://github.com/user-attachments/assets/91660548-599f-465f-bd84-be2e3b53e609)
