### PR TITLE
Bug#111210 Extend pfs.replication_group_members to include MEMBER_WEIGHT

### DIFF
--- a/include/mysql/plugin_group_replication.h
+++ b/include/mysql/plugin_group_replication.h
@@ -87,6 +87,7 @@ struct GROUP_REPLICATION_GROUP_MEMBERS_CALLBACKS {
   void (*set_member_incoming_communication_protocol)(void *const context,
                                                      const char &value,
                                                      size_t length);
+  void (*set_member_weight)(void *const context, unsigned int value);
 };
 
 /*

--- a/mysql-test/suite/perfschema/r/table_schema.result
+++ b/mysql-test/suite/perfschema/r/table_schema.result
@@ -1166,6 +1166,7 @@ def	performance_schema	replication_group_members	MEMBER_STATE	5	NULL	NO	char	64	
 def	performance_schema	replication_group_members	MEMBER_ROLE	6	NULL	NO	char	64	256	NULL	NULL	NULL	utf8mb4	utf8mb4_bin	char(64)			select,insert,update,references			NULL
 def	performance_schema	replication_group_members	MEMBER_VERSION	7	NULL	NO	char	64	256	NULL	NULL	NULL	utf8mb4	utf8mb4_bin	char(64)			select,insert,update,references			NULL
 def	performance_schema	replication_group_members	MEMBER_COMMUNICATION_STACK	8	NULL	NO	char	64	256	NULL	NULL	NULL	utf8mb4	utf8mb4_bin	char(64)			select,insert,update,references			NULL
+def	performance_schema	replication_group_members	MEMBER_WEIGHT	9	NULL	YES	int	NULL	NULL	10	0	NULL	NULL	NULL	int			select,insert,update,references			NULL
 def	performance_schema	replication_group_member_stats	CHANNEL_NAME	1	NULL	NO	char	64	256	NULL	NULL	NULL	utf8mb4	utf8mb4_0900_ai_ci	char(64)			select,insert,update,references			NULL
 def	performance_schema	replication_group_member_stats	VIEW_ID	2	NULL	NO	char	60	240	NULL	NULL	NULL	utf8mb4	utf8mb4_bin	char(60)			select,insert,update,references			NULL
 def	performance_schema	replication_group_member_stats	MEMBER_ID	3	NULL	NO	char	36	144	NULL	NULL	NULL	utf8mb4	utf8mb4_bin	char(36)			select,insert,update,references			NULL

--- a/plugin/group_replication/src/ps_information.cc
+++ b/plugin/group_replication/src/ps_information.cc
@@ -134,6 +134,8 @@ bool get_group_members_info(
       callbacks.context, *incoming_connection_protocol,
       strlen(incoming_connection_protocol));
 
+  callbacks.set_member_weight(callbacks.context, member_info.get_member_weight());
+
   return false;
 }
 

--- a/storage/perfschema/pfs_dd_version.h
+++ b/storage/perfschema/pfs_dd_version.h
@@ -233,8 +233,13 @@
    - Bug#31763497 PERFORMANCE DEGRADATION CAUSED BY MONITORING
      SYS.INNODB_LOCK_WAITS IN MYSQL 8.0
      - Table performance_schema.data_lock_waits, add PRIMARY KEY.
+
+  80041:
+
+  - Bug#111210 Include MEMBER_WEIGHT in replication_group_members
+
 */
 
-static const uint PFS_DD_VERSION = 80040;
+static const uint PFS_DD_VERSION = 80041;
 
 #endif /* PFS_DD_VERSION_H */

--- a/storage/perfschema/table_replication_group_members.cc
+++ b/storage/perfschema/table_replication_group_members.cc
@@ -123,6 +123,11 @@ static void set_member_communication_stack(void *const context,
   memcpy(row->member_communication_stack, &value, length);
 }
 
+static void set_member_weight(void *const context, unsigned int value) {
+  auto *row = static_cast<struct st_row_group_members *>(context);
+  row->member_weight = value;
+}
+
 THR_LOCK table_replication_group_members::m_table_lock;
 
 Plugin_table table_replication_group_members::m_table_def(
@@ -139,7 +144,8 @@ Plugin_table table_replication_group_members::m_table_def(
     "  MEMBER_ROLE CHAR(64) collate utf8mb4_bin not null,\n"
     "  MEMBER_VERSION CHAR(64) collate utf8mb4_bin not null,\n"
     "  MEMBER_COMMUNICATION_STACK CHAR(64) collate utf8mb4_bin not "
-    "null\n",
+    "null,\n"
+    "  MEMBER_WEIGHT INTEGER\n",
     /* Options */
     " ENGINE=PERFORMANCE_SCHEMA",
     /* Tablespace */
@@ -214,12 +220,14 @@ int table_replication_group_members::make_row(uint index) {
   m_row.member_version_length = 0;
   m_row.member_role_length = 0;
   m_row.member_communication_stack_length = 0;
+  m_row.member_weight = 0;
 
   // Set callbacks on GROUP_REPLICATION_GROUP_MEMBERS_CALLBACKS.
   const GROUP_REPLICATION_GROUP_MEMBERS_CALLBACKS callbacks = {
       &m_row,           &set_channel_name,   &set_member_id,
       &set_member_host, &set_member_port,    &set_member_state,
       &set_member_role, &set_member_version, &set_member_communication_stack,
+      &set_member_weight,
   };
 
   // Query plugin and let callbacks do their job.
@@ -276,6 +284,13 @@ int table_replication_group_members::read_row_values(TABLE *table,
         case 7: /** member_incoming_protocol */
           set_field_char_utf8mb4(f, m_row.member_communication_stack,
                                  m_row.member_communication_stack_length);
+          break;
+        case 8: /** member_weight */
+          if (m_row.member_weight > 0) {
+            set_field_ulong(f, m_row.member_weight);
+          } else {
+            f->set_null();
+          }
           break;
         default:
           assert(false);

--- a/storage/perfschema/table_replication_group_members.h
+++ b/storage/perfschema/table_replication_group_members.h
@@ -70,6 +70,7 @@ struct st_row_group_members {
   uint member_version_length;
   char member_communication_stack[NAME_LEN];
   uint member_communication_stack_length;
+  uint member_weight;
 };
 
 /** Table PERFORMANCE_SCHEMA.replication_group_members. */


### PR DESCRIPTION
In single-primary group-replication clusters, it may be necessary to
set group_replication_member_weight to ensure a host under (automated)
maintenance will not be elected to primary. Automation systems may also
need to identify the preferred secondary, which would be easier if the
value of group_replication_member_weight for each cluster member were
available in performance_schema.replication_group_members.