### PR TITLE
Return the correct collation for temporal results

### DIFF
--- a/mysql-test/r/func_str.result
+++ b/mysql-test/r/func_str.result
@@ -673,6 +673,15 @@ latin2_general_ci	4
 select collation(replace(_latin2'abcd',_latin2'b',_latin2'B')), coercibility(replace(_latin2'abcd',_latin2'b',_latin2'B'));
 collation(replace(_latin2'abcd',_latin2'b',_latin2'B'))	coercibility(replace(_latin2'abcd',_latin2'b',_latin2'B'))
 latin2_general_ci	4
+select collation(greatest(date'2010-01-01', date'2011-01-01'));
+collation(greatest(date'2010-01-01', date'2011-01-01'))
+binary
+select collation(least(date'2010-01-01', date'2011-01-01'));
+collation(least(date'2010-01-01', date'2011-01-01'))
+binary
+select collation(coalesce(null, date'2010-01-01', date'2011-01-01'));
+collation(coalesce(null, date'2010-01-01', date'2011-01-01'))
+binary
 create table t1 charset latin1
 select
 bin(130),

--- a/mysql-test/t/func_str.test
+++ b/mysql-test/t/func_str.test
@@ -352,6 +352,9 @@ select collation(soundex(_latin2'ab')), coercibility(soundex(_latin2'ab'));
 select collation(substring(_latin2'ab',1)), coercibility(substring(_latin2'ab',1));
 select collation(insert(_latin2'abcd',2,3,_latin2'ef')), coercibility(insert(_latin2'abcd',2,3,_latin2'ef'));
 select collation(replace(_latin2'abcd',_latin2'b',_latin2'B')), coercibility(replace(_latin2'abcd',_latin2'b',_latin2'B'));
+select collation(greatest(date'2010-01-01', date'2011-01-01'));
+select collation(least(date'2010-01-01', date'2011-01-01'));
+select collation(coalesce(null, date'2010-01-01', date'2011-01-01'));
 
 create table t1 charset latin1
 select

--- a/sql/item_func.cc
+++ b/sql/item_func.cc
@@ -1888,6 +1888,11 @@ bool Item_func_numhybrid::get_time(MYSQL_TIME *ltime) {
   }
 }
 
+const CHARSET_INFO *Item_func_numhybrid::charset_for_protocol() {
+  if (is_temporal_type(data_type())) return &my_charset_bin;
+  return Item_func::charset_for_protocol();
+}
+
 void Item_typecast_signed::print(const THD *thd, String *str,
                                  enum_query_type query_type) const {
   str->append(STRING_WITH_LEN("cast("));

--- a/sql/item_func.h
+++ b/sql/item_func.h
@@ -909,6 +909,7 @@ class Item_func_numhybrid : public Item_func {
   bool resolve_type_inner(THD *thd) override;
   void fix_num_length_and_dec() override;
   virtual void set_numeric_type() = 0;  // To be called from resolve_type()
+  const CHARSET_INFO *charset_for_protocol() override;
 
   double val_real() override;
   longlong val_int() override;


### PR DESCRIPTION
When functions like `GREATEST`, `LEAST` and `COALESCE` return a temporal result, the collation is not set to `binary` as expected.

The collation for temporal types normally is always `binary` which is the case for fields and for functions inheriting from `Item_temporal_func`.

The comparison functions mentioned here though don't inherit from that and can return various types. Internally they do set the numeric collation correctly, but at the protocol level (and for what the `COLLATION` function returns), it is translated to the binary collation.

This translation does not happen before this change for the given functions, so we add it here.

Before:

```
mysql> select collation(date'2010-01-01');
+-----------------------------+
| collation(date'2010-01-01') |
+-----------------------------+
| binary                      |
+-----------------------------+
1 row in set (0.00 sec)

mysql> select collation(greatest(date'2010-01-01', date'2009-01-01'));
+---------------------------------------------------------+
| collation(greatest(date'2010-01-01', date'2009-01-01')) |
+---------------------------------------------------------+
| latin1_swedish_ci                                       |
+---------------------------------------------------------+
1 row in set (0.00 sec)
```

After:

```
mysql> select collation(date'2010-01-01');
+-----------------------------+
| collation(date'2010-01-01') |
+-----------------------------+
| binary                      |
+-----------------------------+
1 row in set (0.00 sec)

mysql> select collation(greatest(date'2010-01-01', date'2009-01-01'));
+---------------------------------------------------------+
| collation(greatest(date'2010-01-01', date'2009-01-01')) |
+---------------------------------------------------------+
| binary                                                  |
+---------------------------------------------------------+
1 row in set (0.00 sec)
```

This issue applies to all supported MySQL versions, starting from 8.0.x and later at least. 