### PR TITLE
Document previously undocumented behavior regarding the sending of default values in ColumnDefinition for CLIENT_PROTOCOL_41.

### DIFF
--- a/mysys/pack.cc
+++ b/mysys/pack.cc
@@ -110,7 +110,7 @@ uint64_t net_field_length_ll(uchar **packet) {
 }
 
 /*
-  Store an integer with simple packing into a output package
+  Store an integer with simple packing into an output package
 
   SYNOPSIS
     net_store_length()

--- a/sql/protocol_classic.cc
+++ b/sql/protocol_classic.cc
@@ -131,7 +131,7 @@
   @section sect_protocol_basic_dt_string_le Protocol::LengthEncodedString
 
   A length encoded string is a string that is prefixed with length encoded
-  integer describing the length of the string.
+  integer describing the length of the string. NULL if first byte is 0xFB.
 
   It is a special case of @ref sect_protocol_basic_dt_string_var
 
@@ -3099,6 +3099,11 @@ bool Protocol_classic::end_result_metadata() {
   <tr><td>@ref a_protocol_type_int2 "int&lt;2&gt;"</td>
       <td>reserved</td>
       <td>reserved. All 0s.</td></tr>
+  <tr><td colspan="3">if command was COM_FIELD_LIST {</td></tr>
+  <tr><td>@ref sect_protocol_basic_dt_string_le "string&lt;lenenc&gt;"</td>
+      <td>default value</td>
+      <td>NULL if 0xFB</td></tr>
+  <tr><td colspan="3">}</td></tr>
   </table>
 
   @note `decimals` and `column_length` can be used for text output formatting

--- a/sql/protocol_classic.cc
+++ b/sql/protocol_classic.cc
@@ -3096,6 +3096,9 @@ bool Protocol_classic::end_result_metadata() {
         <li>0x1f for dynamic strings, double, float</li>
         <li>0x00 to 0x51 for decimals</li>
         </ul></td></tr>
+  <tr><td>@ref a_protocol_type_int2 "int&lt;2&gt;"</td>
+      <td>reserved</td>
+      <td>reserved. All 0s.</td></tr>
   </table>
 
   @note `decimals` and `column_length` can be used for text output formatting


### PR DESCRIPTION
Though as per the [documentation](https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_field_list.html#sect_protocol_com_field_list_response) `COM_FIELD_LIST` is deprecated, mysql client version 8.0.41 still uses it. Upon connecting to the server without the `-A` flag, the client issues a `COM_FIELD_LIST` command as soon as a database is selected, or upon successful connection to the server if the database was mentioned during the connection phase.

As per the documentation of `COM_FIELD_LIST`, the response contains several `ColumnDefinition` packets. These packets contain the default values as part of the packet body, however, this behaviour is not mentioned on the `ColumnDefinition` documentation for `Protocol::ColumnDefinition41` (it is mentioned for ` Protocol::ColumnDefinition320`). This behaviour is exclusive to `COM_FIELD_LIST` as it is the only invocation of `THD::send_result_metadata` with the `Protocol::SEND_DEFAULTS` flag(`sql/sql_show.cc:1417`).



## Modifications

* Addition of rows describing the condition for presence of default values in `ColumnDefinition`.
* Previously accepted changes in the same section (https://bugs.mysql.com/bug.php?id=117346).

### Minor modifications:

* `mysys/pack.cc:113`: Fix gramatical error.
* `sql/protocol_classic.cc:134`: Mention NULL condition for `Protocol::LengthEncodedString`, previously undocumented.



## Steps to replicate:

Commands mentioned in the next section.

## Console Logs and Packet Capture follows:

### Console Logs:

`--get-server-public-key=true --ssl-mode=DISABLED` flags added to allow plaintext capture of packets.

```
➜  ~ mysql -V                                                                                     
mysql  Ver 8.0.41-0ubuntu0.24.10.1 for Linux on x86_64 ((Ubuntu))
➜  ~ mysql -uroot -pasd -P6033 -h127.0.0.1 mysql --get-server-public-key=true --ssl-mode=DISABLED;
mysql: [Warning] Using a password on the command line interface can be insecure.
Reading table information for completion of table and column names
You can turn off this feature to get a quicker startup with -A

Welcome to the MySQL monitor.  Commands end with ; or \g.
Your MySQL connection id is 15
Server version: 8.0.32 MySQL Community Server - GPL

Copyright (c) 2000, 2025, Oracle and/or its affiliates.

Oracle is a registered trademark of Oracle Corporation and/or its
affiliates. Other names may be trademarks of their respective
owners.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

mysql> select version()
    -> ;
+-----------+
| version() |
+-----------+
| 8.0.32    |
+-----------+
1 row in set (0.00 sec)

mysql> 
```

### Packet Capture

`ColumnDefinition` packet for `Drop_role_priv` column of `mysql.user` table. (Default value is `N`).

```
0000   41 00 00 2f 03 64 65 66 05 6d 79 73 71 6c 04 75   A../.def.mysql.u
0010   73 65 72 04 75 73 65 72 0e 44 72 6f 70 5f 72 6f   ser.user.Drop_ro
0020   6c 65 5f 70 72 69 76 0e 44 72 6f 70 5f 72 6f 6c   le_priv.Drop_rol
0030   65 5f 70 72 69 76 0c ff 00 04 00 00 00 fe 01 01   e_priv..........
0040   00 00 00 01 4e                                    ....N
```

`ColumnDefinition` packet for `User_attributes` column of `mysql.user` table. (Default value is `NULL`).


```
0000   42 00 00 33 03 64 65 66 05 6d 79 73 71 6c 04 75   B..3.def.mysql.u
0010   73 65 72 04 75 73 65 72 0f 55 73 65 72 5f 61 74   ser.user.User_at
0020   74 72 69 62 75 74 65 73 0f 55 73 65 72 5f 61 74   tributes.User_at
0030   74 72 69 62 75 74 65 73 0c 3f 00 ff ff ff ff f5   tributes.?......
0040   90 00 00 00 00 fb                                 ......
```

