### PR TITLE
Fix syntax error in SHOW BINARY LOG STATUS

### DIFF
--- a/scripts/sys_schema/procedures/diagnostics.sql
+++ b/scripts/sys_schema/procedures/diagnostics.sql
@@ -659,9 +659,9 @@ BEGIN
         -- other tables, so include them even though they are no longer optimal solutions and if present get the additional
         -- information from the other tables available.
         IF (@@log_bin = 1) THEN
-            SELECT 'SHOW BINARY LOG STATUS' AS 'The following output is:';
-            SHOW BINARY LOG STATUS;
-        END IF;
+            SELECT 'SHOW BINARY LOGS' AS 'The following output is:';
+            SHOW BINARY LOGS;
+        END IF; 
 
         IF (v_has_replication <> 'NO') THEN
             SELECT 'SHOW REPLICA STATUS' AS 'The following output is:';


### PR DESCRIPTION
After having manually prepared the environment after accidentally deleting sys, I ran into a syntax error with SHOW BINARY LOG STATUS. The correct statement is SHOW BINARY LOGS, since MySQL does not recognize SHOW BINARY LOG STATUS.  This fix guarantees that this script runs correctly without any syntax errors, and has been improved for general compatibility with different versions of MySQL.

![image](https://github.com/user-attachments/assets/d1c95947-65b4-46b5-97f4-50df3666589f)
