### PR TITLE
[RONDB-892] File system password length check

### DIFF
--- a/storage/ndb/src/kernel/ndbd.cpp
+++ b/storage/ndb/src/kernel/ndbd.cpp
@@ -1149,6 +1149,12 @@ void ndbd_run(bool foreground, int report_fd, const char *connect_str,
           "empty password not allowed");
       ndbd_exit(-1);
     }
+    if (pwd_size > MAX_BACKUP_ENCRYPTION_PASSWORD_LENGTH) {
+      g_eventLogger->info(
+          "Invalid filesystem password, "
+          "too long");
+      ndbd_exit(-1);
+    }
 
     memcpy(globalData.filesystemPassword, pwd, pwd_size);
     globalData.filesystemPassword[pwd_size] = '\0';


### PR DESCRIPTION
Check that password is not too long, as that would lead to memory corruption.