### PR TITLE
Adding 'sb' instruction to spin_delay() for ARM v8.5 onward

### DIFF
--- a/extra/gperftools/gperftools-2.15/src/base/spinlock.cc
+++ b/extra/gperftools/gperftools-2.15/src/base/spinlock.cc
@@ -37,6 +37,10 @@
 #include "base/spinlock_internal.h"
 #include "base/sysinfo.h"   /* for GetSystemCPUsCount() */
 
+#if defined(__GNUC__) && defined(__aarch64__)
+#include <sys/auxv.h>
+#endif // end __aarch64__
+
 // NOTE on the Lock-state values:
 //
 // kSpinLockFree represents the unlocked state
@@ -68,7 +72,20 @@ inline void SpinlockPause(void) {
 #if defined(__GNUC__) && (defined(__i386__) || defined(__x86_64__))
   __asm__ __volatile__("rep; nop" : : );
 #elif defined(__GNUC__) && defined(__aarch64__)
-  __asm__ __volatile__("isb" : : );
+  static int use_spin_delay_sb = -1;
+
+  // Use SB instruction if available otherwise ISB
+  if (__builtin_expect(use_spin_delay_sb == 1, 1)) {
+    __asm__ __volatile__(".inst 0xd50330ff  \n");   // SB instruction encoding
+  } else if (use_spin_delay_sb == 0) {
+    __asm__ __volatile__(" isb;  \n");
+  } else {
+    // Initialize variable and use getauxval fuction as delay
+    if (getauxval(AT_HWCAP) & HWCAP_SB)
+      use_spin_delay_sb = 1;
+    else
+      use_spin_delay_sb = 0;
+    }
 #endif
 }
 

--- a/storage/innobase/include/ut0ut.h
+++ b/storage/innobase/include/ut0ut.h
@@ -56,6 +56,10 @@ this program; if not, write to the Free Software Foundation, Inc.,
 #include <thread>
 #include <type_traits>
 
+#if defined(__GNUC__) && defined(__aarch64__)
+#include <sys/auxv.h>
+#endif // end __aarch64__
+
 #ifdef UNIV_DEBUG
 #include <limits>
 #include <random>
@@ -101,12 +105,33 @@ independent way by using YieldProcessor. */
 #define UT_RELAX_CPU() YieldProcessor()
 #elif defined(__aarch64__)
 /* A "yield" instruction in aarch64 is essentially a nop, and does not cause
-enough delay to help backoff. "isb" is a barrier that, especially inside a
-loop, creates a small delay without consuming ALU resources.
-Experiments shown that adding the isb instruction improves stability and reduces
-result jitter. Adding more delay to the UT_RELAX_CPU than a single isb reduces
-performance. */
-#define UT_RELAX_CPU() __asm__ __volatile__("isb" ::: "memory")
+enough delay to help backoff. For CPUs that support AArch64 <v8.5, an "isb"
+can be used in a loop.  It creates a small delay without consuming ALU resources,
+by forcing a CPU flush.  Experiments shown that adding the isb instruction improves
+stability and reduces result jitter.
+
+For CPUs supporting AArch64 >=v8.5 an "sb" is a better choice.  It also creates
+a small delay, but instead of flushing the CPU it does so by serializing older instructions
+to be non-speculative before it completes. This is less disruptive than an "isb" to high
+performance CPUs.
+*/
+#define UT_RELAX_CPU() spin_delay()
+static __inline__ void spin_delay(void) {
+  static int use_spin_delay_sb = -1;
+
+  // Use SB instruction if available otherwise ISB
+  if (__builtin_expect(use_spin_delay_sb == 1, 1)) {
+    __asm__ __volatile__(".inst 0xd50330ff  \n");   // SB instruction encoding
+  } else if (use_spin_delay_sb == 0) {
+    __asm__ __volatile__(" isb;  \n");
+  } else {
+    // Initialize variable and use getauxval fuction as delay
+    if (getauxval(AT_HWCAP) & HWCAP_SB)
+      use_spin_delay_sb = 1;
+    else
+      use_spin_delay_sb = 0;
+    }
+}
 #else
 #define UT_RELAX_CPU() __asm__ __volatile__("" ::: "memory")
 #endif


### PR DESCRIPTION
We would like to propose this optimization for ARM architecture that, at runtime, it switches to SB instruction if supported by the system. SB (Speculation Barrier) is a modern barrier, available from armv8.5a. It achieves the same result as issuing ISB, but without having the CPU to drop its instruction pipeline.

Our performance evaluation based on 50 repetitions of the attached benchmark (inspired from https://bugs.mysql.com/bug.php?id=74832) conducted on Ubuntu 24.04 on m8g.24xlarge AWS instance using trunk MySQL branch, shows on average up to 28% reduction of the script execution time when `sb` instruction is used. Also linux perf shows ~11% drop of ut_delay function usage. Here the data:

```bash
sudo systemctl restart mysqld.service && sudo systemctl status mysqld.service

echo "Loading"
mysql -u root -pmysql < sql
sleep 5s

echo "Warmup"
for i in {1..5}; do 
    /usr/bin/time  --format="%e real,\t%U user,\t%S sys" ./psdoit 500
    sleep 5s;
done

echo "Benchmark"
for i in {1..50}; do 
    /usr/bin/time  --format="%e real,\t%U user,\t%S sys" --output=psdoit.sb.log --append ./psdoit 500
    sleep 5s;
done


# Results
$ cat psdoit.isb.log  | cut -f1 -d' ' | awk '{sum += $1; count++} END {print sum/count}'
32.445
$ cat psdoit.sb.log  | cut -f1 -d' ' | awk '{sum += $1; count++} END {print sum/count}'
24.504

# Perf ut_delay improvement
## ISB
+   18.87%    18.86%  connection  mysqld [.] ut_delay(unsigned long)

## SB
+    7.76%     7.76%  connection  mysqld  [.] ut_delay(unsigned long)
```



[sql.txt](https://github.com/user-attachments/files/20197312/sql.txt)
[psdoit.txt](https://github.com/user-attachments/files/20197313/psdoit.txt)
