### PR TITLE
Minor Update to MySQL Documentation in sql_class.h

### DIFF
--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -2544,7 +2544,7 @@ class THD : public MDL_context_owner,
   bool m_server_idle;
 
   /*
-    Id of current query. Statement can be reused to execute several queries
+    Id of current query. Statement can be reused to execute several queries.
     query_id is global in context of the whole MySQL server.
     ID is automatically generated from mutex-protected counter.
     It's used in handler code for various purposes: to check which columns


### PR DESCRIPTION
Hello,

I've noticed a minor punctuation issue in the sql_class.h documentation where a period is missing, affecting sentence separation. I propose adding the necessary punctuation to improve readability.

Thank you for reviewing this correction.

Best regards,
Rong