### PR TITLE
BUG #96310 INSERT accepts invalid date from default val With Binlog Open

### DIFF
--- a/mysql-test/r/bug96310.result
+++ b/mysql-test/r/bug96310.result
@@ -1,0 +1,19 @@
+#
+# Bug#96130 Traditional: INSERT accepts invalid date from default val With Binlog Open
+#
+SET sql_mode='';
+CREATE TABLE default_date(a DATE NOT NULL DEFAULT '0000-00-00');
+INSERT INTO default_date VALUES();
+INSERT INTO default_date VALUES(DEFAULT);
+SET sql_mode=default;
+INSERT INTO default_date VALUES();
+ERROR 22007: Incorrect date value: '0000-00-00' for column 'a' at row 1
+INSERT INTO default_date VALUES(DEFAULT);
+ERROR 22007: Incorrect date value: '0000-00-00' for column 'a' at row 1
+INSERT INTO default_date VALUES('0000-00-00');
+ERROR 22007: Incorrect date value: '0000-00-00' for column 'a' at row 1
+SELECT * FROM default_date;
+a
+0000-00-00
+0000-00-00
+DROP TABLE default_date;

--- a/mysql-test/t/bug96310-master.opt
+++ b/mysql-test/t/bug96310-master.opt
@@ -1,0 +1,1 @@
+--log-bin=binlog

--- a/mysql-test/t/bug96310.test
+++ b/mysql-test/t/bug96310.test
@@ -1,0 +1,25 @@
+--echo #
+--echo # Bug#96130 Traditional: INSERT accepts invalid date from default val With Binlog Open
+--echo #
+
+SET sql_mode='';
+
+CREATE TABLE default_date(a DATE NOT NULL DEFAULT '0000-00-00');
+
+INSERT INTO default_date VALUES();
+INSERT INTO default_date VALUES(DEFAULT);
+
+SET sql_mode=default;
+
+--error ER_TRUNCATED_WRONG_VALUE
+INSERT INTO default_date VALUES();
+
+--error ER_TRUNCATED_WRONG_VALUE
+INSERT INTO default_date VALUES(DEFAULT);
+
+--error ER_TRUNCATED_WRONG_VALUE
+INSERT INTO default_date VALUES('0000-00-00');
+
+SELECT * FROM default_date;
+
+DROP TABLE default_date;

--- a/sql/table.cc
+++ b/sql/table.cc
@@ -6146,8 +6146,7 @@ void TABLE::set_created() {
   as changed.
 */
 
-void TABLE::mark_columns_needed_for_insert(THD *thd) {
-  mark_columns_per_binlog_row_image(thd);
+void TABLE::mark_columns_needed_for_insert(THD *thd [[maybe_unused]]) {
 
   if (found_next_number_field) mark_auto_increment_column();
   /* Mark all generated columns as writable */


### PR DESCRIPTION
Bugfix for https://bugs.mysql.com/bug.php?id=96310

I have signed OCA and my account in Oracle is kindaichweng@gmail.com

PROBLEM:
--------

When variable 'log_bin' is ON (that is, mysql will generate binary log for DML query) some invalid date from default value will be accepted by mysql.

Repeat:

SET sql_mode='';
CREATE TABLE default_date(a DATE NOT NULL DEFAULT '0000-00-00'); 

SET sql_mode=default;

INSERT INTO default_date VALUES();  -- invalid data will be accepted.

Solution:
--------

We need not mark_columns_per_binlog_row_image IN TABLE::mark_columns_needed_for_insert, which is unnecessary and  will change table->write_set and validate_default_values_of_unset_fields will skip data check finally