### PR TITLE
Optimize hash_table_locks

### DIFF
--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -22537,13 +22537,11 @@ static MYSQL_SYSVAR_ULONGLONG(
     ulonglong{srv_buf_pool_chunk_unit_max},
     ulonglong{srv_buf_pool_chunk_unit_blk_sz});
 
-#if defined UNIV_DEBUG || defined UNIV_PERF_DEBUG
 static MYSQL_SYSVAR_ULONG(page_hash_locks, srv_n_page_hash_locks,
                           PLUGIN_VAR_OPCMDARG | PLUGIN_VAR_READONLY,
                           "Number of rw_locks protecting buffer pool "
                           "page_hash. Rounded up to the next power of 2",
                           nullptr, nullptr, 16, 1, MAX_PAGE_HASH_LOCKS, 0);
-#endif /* defined UNIV_DEBUG || defined UNIV_PERF_DEBUG */
 
 static MYSQL_SYSVAR_BOOL(
     validate_tablespace_paths, srv_validate_tablespace_paths,
@@ -23588,9 +23586,7 @@ static SYS_VAR *innobase_system_variables[] = {
     MYSQL_SYSVAR(merge_threshold_set_all_debug),
     MYSQL_SYSVAR(semaphore_wait_timeout_debug),
 #endif /* UNIV_DEBUG */
-#if defined UNIV_DEBUG || defined UNIV_PERF_DEBUG
     MYSQL_SYSVAR(page_hash_locks),
-#endif /* defined UNIV_DEBUG || defined UNIV_PERF_DEBUG */
     MYSQL_SYSVAR(validate_tablespace_paths),
     MYSQL_SYSVAR(use_fdatasync),
     MYSQL_SYSVAR(status_output),

--- a/storage/innobase/include/buf0buf.h
+++ b/storage/innobase/include/buf0buf.h
@@ -111,7 +111,7 @@ constexpr ulint MAX_BUFFER_POOLS = (1 << MAX_BUFFER_POOLS_BITS);
 #define BUF_POOL_WATCH_SIZE (srv_n_purge_threads + 1)
 
 /** The maximum number of page_hash locks */
-constexpr ulint MAX_PAGE_HASH_LOCKS = 1024;
+constexpr ulint MAX_PAGE_HASH_LOCKS = 1048576;
 
 /** The buffer pools of the database */
 extern buf_pool_t *buf_pool_ptr;


### PR DESCRIPTION
### Analysis
Under high throughput, a hotspot caused by `rw_lock_s_lock_func` can be observed in MySQL, originating from `Buf_fetch_normal::get`. The key call path is: `buf_page_get_gen → Buf_fetch::single_page → Buf_fetch_normal::get`.

The function of `Buf_fetch_normal::get` is to retrieve the pointer to a data block (i.e., `buf_block_t*`) in the buffer pool for a target data page, which involves querying the buffer pool using (space_id, page_no) to read or write page content. This mapping relationship is maintained by a hash table called page_hash, protected by `hash_table_locks`. The `rw_lock_s_lock_func` hotspot arises from the read-lock operation on these `hash_table_locks`.
<img width="682" height="211" alt="image" src="https://github.com/user-attachments/assets/3a4326f8-e034-4003-9ae8-9235cfe78cdb" />

On the other hand, sharding the lock objects with fierce competition is a common optimization method. In MySQL source code, `hash_table_locks` has been optimized through sharding. The number of shards is controlled by `srv_n_page_hash_locks`, but it is hard-coded to 16.
<img width="600" height="55" alt="image" src="https://github.com/user-attachments/assets/4eb7132f-2ba2-4ce3-a46b-509a40b1871d" />

### Optimization
<img width="4404" height="1338" alt="hash" src="https://github.com/user-attachments/assets/88d6ebcc-d8d3-4ac9-b3ec-5b53402bb762" />
