### PR TITLE
Optimize process of thread counter

### DIFF
--- a/sql/event_scheduler.cc
+++ b/sql/event_scheduler.cc
@@ -172,7 +172,6 @@ bool post_init_event_thread(THD *thd) {
 
   Global_THD_manager *thd_manager = Global_THD_manager::get_instance();
   thd_manager->add_thd(thd);
-  thd_manager->inc_thread_running();
   return false;
 }
 
@@ -192,7 +191,6 @@ void deinit_event_thread(THD *thd) {
   DBUG_PRINT("exit", ("Event thread finishing"));
   thd->release_resources();
   thd_manager->remove_thd(thd);
-  thd_manager->dec_thread_running();
   delete thd;
 }
 

--- a/sql/mysqld_thd_manager.cc
+++ b/sql/mysqld_thd_manager.cc
@@ -364,6 +364,31 @@ THD_ptr Global_THD_manager::find_thd(Find_thd_with_id *func) {
   return THD_ptr{nullptr};
 }
 
+/**
+  This class implements callback for do_for_all_thd().
+  It counts the total number of running threads from global thread list.
+*/
+class Count_thread_running : public Do_THD_Impl {
+  public:
+    Count_thread_running() : m_count(0) {}
+    ~Count_thread_running() {}
+  virtual void operator()(THD *thd) {
+    if (thd->get_command() != COM_SLEEP) {
+      m_count++;
+    }
+  }
+  int get_count() { return m_count; }
+
+  private:
+    int m_count;
+};
+
+void Global_THD_manager::count_num_thread_running() {
+  Count_thread_running count_thread_running;
+  do_for_all_thd(&count_thread_running);
+  atomic_num_thread_running = count_thread_running.get_count();
+}
+
 void inc_thread_created() {
   Global_THD_manager::get_instance()->inc_thread_created();
 }

--- a/sql/mysqld_thd_manager.h
+++ b/sql/mysqld_thd_manager.h
@@ -254,20 +254,15 @@ class Global_THD_manager {
   void remove_thd(THD *thd);
 
   /**
+    Count thread running statistic variable.
+  */
+  void count_num_thread_running();
+
+  /**
     Retrieves thread running statistic variable.
     @return int Returns the total number of threads currently running
   */
   int get_num_thread_running() const { return atomic_num_thread_running; }
-
-  /**
-    Increments thread running statistic variable.
-  */
-  void inc_thread_running() { atomic_num_thread_running++; }
-
-  /**
-    Decrements thread running statistic variable.
-  */
-  void dec_thread_running() { atomic_num_thread_running--; }
 
   /**
     Retrieves thread created statistic variable.

--- a/storage/perfschema/pfs_variable.cc
+++ b/storage/perfschema/pfs_variable.cc
@@ -1189,6 +1189,16 @@ int PFS_status_variable_cache::do_materialize_global() {
                                         true,  /* THDs */
                                         &visitor);
   /*
+    Because of the reason described in 
+    PFS_status_variable_cache::do_materialize_all(THD *unsafe_thd),
+    PFS_status_variable_cache::do_materialize_session(THD *unsafe_thd) and
+    PFS_status_variable_cache::do_materialize_session(PFS_thread *pfs_thread),
+    count_num_thread_running() cannot put together with
+    get_num_thread_running(), so count_num_thread_running() is put here.
+  */
+  Global_THD_manager::get_instance()->count_num_thread_running();
+
+  /*
     Build the status variable cache using the SHOW_VAR array as a reference.
     Use the status totals collected from all threads.
   */
@@ -1232,6 +1242,22 @@ int PFS_status_variable_cache::do_materialize_all(THD *unsafe_thd) {
   if (!m_external_init) {
     init_show_var_array(OPT_SESSION, false);
   }
+
+  /*
+    count_num_thread_running() counts the total number of running threads
+    from global thread list, using LOCK_thd_list to protect sharded
+    global thread list. In lock_order_dependencies.txt, the lock order
+    is that LOCK_thd_list must be locked before LOCK_thd_data. In this
+    function, LOCK_thd_data is already locked in get_THD(), Then manifest()
+    will call get_num_thread_running(). If get_num_thread_running() counts
+    and returns the num, the lock order will be incorrect, which may
+    lead to dead lock. To prevent this situation, get_num_thread_running()
+    is split into two part, one is still called get_num_thread_running()
+    which returns the num, the other is called count_num_thread_running()
+    which counts the num and should be called before get_THD() and
+    get_num_thread_running(). So count_num_thread_running() is put here.
+  */
+  Global_THD_manager::get_instance()->count_num_thread_running();
 
   /* Get and lock a validated THD from the thread manager. */
   THD_ptr thd_ptr = get_THD(unsafe_thd);
@@ -1280,6 +1306,22 @@ int PFS_status_variable_cache::do_materialize_session(THD *unsafe_thd) {
     init_show_var_array(OPT_SESSION, true);
   }
 
+  /*
+    count_num_thread_running() counts the total number of running threads
+    from global thread list, using LOCK_thd_list to protect sharded
+    global thread list. In lock_order_dependencies.txt, the lock order
+    is that LOCK_thd_list must be locked before LOCK_thd_data. In this
+    function, LOCK_thd_data is already locked in get_THD(), Then manifest()
+    will call get_num_thread_running(). If get_num_thread_running() counts
+    and returns the num, the lock order will be incorrect, which may
+    lead to dead lock. To prevent this situation, get_num_thread_running()
+    is split into two part, one is still called get_num_thread_running()
+    which returns the num, the other is called count_num_thread_running()
+    which counts the num and should be called before get_THD() and
+    get_num_thread_running(). So count_num_thread_running() is put here.
+  */
+  Global_THD_manager::get_instance()->count_num_thread_running();
+
   /* Get and lock a validated THD from the thread manager. */
   THD_ptr thd_ptr = get_THD(unsafe_thd);
   m_safe_thd = thd_ptr.get();
@@ -1320,6 +1362,22 @@ int PFS_status_variable_cache::do_materialize_session(PFS_thread *pfs_thread) {
 
   /* The SHOW_VAR array must be initialized externally. */
   assert(m_initialized);
+
+  /*
+    count_num_thread_running() counts the total number of running threads
+    from global thread list, using LOCK_thd_list to protect sharded
+    global thread list. In lock_order_dependencies.txt, the lock order
+    is that LOCK_thd_list must be locked before LOCK_thd_data. In this
+    function, LOCK_thd_data is already locked in get_THD(), Then manifest()
+    will call get_num_thread_running(). If get_num_thread_running() counts
+    and returns the num, the lock order will be incorrect, which may
+    lead to dead lock. To prevent this situation, get_num_thread_running()
+    is split into two part, one is still called get_num_thread_running()
+    which returns the num, the other is called count_num_thread_running()
+    which counts the num and should be called before get_THD() and
+    get_num_thread_running(). So count_num_thread_running() is put here.
+  */
+  Global_THD_manager::get_instance()->count_num_thread_running();
 
   /* Get and lock a validated THD from the thread manager. */
   THD_ptr thd_ptr = get_THD(pfs_thread);
@@ -1367,6 +1425,17 @@ int PFS_status_variable_cache::do_materialize_client(PFS_client *pfs_client) {
     from disconnected threads.
   */
   m_sum_client_status(pfs_client, &status_totals);
+
+  /*
+    Because of the reason described in 
+    PFS_status_variable_cache::do_materialize_all(THD *unsafe_thd),
+    PFS_status_variable_cache::do_materialize_session(THD *unsafe_thd) and
+    PFS_status_variable_cache::do_materialize_session(PFS_thread *pfs_thread),
+    count_num_thread_running() cannot put together with
+    get_num_thread_running(), so count_num_thread_running() is put here.
+  */
+  Global_THD_manager::get_instance()->count_num_thread_running();
+
 
   /*
     Build the status variable cache using the SHOW_VAR array as a reference and

--- a/unittest/gunit/thd_manager-t.cc
+++ b/unittest/gunit/thd_manager-t.cc
@@ -84,14 +84,6 @@ TEST_F(ThreadManagerTest, AddRemoveTHDWithGuard) {
   EXPECT_EQ(0U, thd_manager->get_thd_count());
 }
 
-TEST_F(ThreadManagerTest, IncDecThreadRunning) {
-  EXPECT_EQ(0, thd_manager->get_num_thread_running());
-  thd_manager->inc_thread_running();
-  EXPECT_EQ(1, thd_manager->get_num_thread_running());
-  thd_manager->dec_thread_running();
-  EXPECT_EQ(0, thd_manager->get_num_thread_running());
-}
-
 TEST_F(ThreadManagerTest, IncThreadCreated) {
   EXPECT_EQ(0U, thd_manager->get_num_thread_created());
   thd_manager->inc_thread_created();


### PR DESCRIPTION
### Analysis
During MySQL's `sysbench point-select` performance testing, the server's CPU utilization approaches 100%. Using the perf top tool, it can be observed that the `dispatch_command` function in mysqld is a significant hotspot, accounting for over 20% of the CPU usage. Further analysis of `dispatch_command` reveals two atomic variable increment/decrement operations, each contributing to more than 40% of its execution time. These operations exhibit severe contention and represent clear bottlenecks, as illustrated in Figures 1 to 3.

Figure 1 - hotspots
<img width="688" height="152" alt="image" src="https://github.com/user-attachments/assets/c3496cd8-f28f-43d1-9938-efa00e53f40e" />

Figure 2 -  The first bottleneck in `dispatch_command`
<img width="749" height="244" alt="image" src="https://github.com/user-attachments/assets/8a38e9f8-b2fc-400b-b145-173f0008c0db" />

Figure 3 - The second bottleneck in  `dispatch_command`
<img width="770" height="170" alt="image" src="https://github.com/user-attachments/assets/3bfa7b31-0d33-4446-83c9-89143eca3749" />

### Optimization
The bottleneck code locations are as follows:
1. The first line performs an atomic increment operation on a shared variable.
2. The second line performs an atomic decrement operation on the same variable.

The primary reason these two lines become bottlenecks is due to severe contention caused by high-frequency atomic operations on the same variable.

Upon analyzing the related code, we found that these operations belong to the "running thread count" statistics and query module, which serves two key purposes:
- Increment/decrement the running thread count during SQL statement execution.
- Provide an interface to query the current running thread count.

The main workflow of this module is illustrated in Figure 4.

Figure 4 - Current main process of thread counter
<img width="2850" height="2158" alt="thread1" src="https://github.com/user-attachments/assets/adda5566-3603-4922-9ed1-5bb9f6b6f7a4" />

The current running thread count statistics and query mechanism works by incrementing/decrementing the atomic counter during SQL statement execution, while queries simply returned the atomic variable's value. This design significantly impacted business performance.

The optimization removes the atomic operations during SQL execution and instead calculates the running thread count only during queries. This trade-off boosts business performance at the cost of slightly slower queries, as illustrated in the optimized workflow (Figure 5).

Figure 5 - The optimized process of thread counter 
<img width="2337" height="1700" alt="thread2" src="https://github.com/user-attachments/assets/3ea06fd3-dbaa-4e0a-a7b4-63021584afcf" />
