### PR TITLE
Fix NUL characters in FORMAT() output

### DIFF
--- a/sql/item_strfunc.cc
+++ b/sql/item_strfunc.cc
@@ -2441,7 +2441,7 @@ String *Item_func_format::val_str_ascii(String *str) {
         count will be initialized to -1 and
         we'll never get into this "if" anymore.
       */
-      if (count == 0) {
+      if ((count == 0) && (lc->thousand_sep != '\0')) {
         *--dst = lc->thousand_sep;
         if (grouping[1]) grouping++;
         count = *grouping;


### PR DESCRIPTION
Fixes https://bugs.mysql.com/bug.php?id=82085

In `sql/sql/locale.cc` there is this for `bg_BG`:
```
                          '\0',       /* thousands_sep bg_BG */
                          "\x03\x03", /* grouping      bg_BG */
```

Other locales that set `\0` as thousounds separator have grouping set to `\x80\x80`, but the `bg_BG` locale doesn't.

The result is that `FORMAT(12345.67,3,'bg_BG')` has a NUL character as thousands separator.

Before this commit:
```
mysql> SELECT FORMAT(12345.67, 3, 'bg_BG');
+------------------------------+
| FORMAT(12345.67, 3, 'bg_BG') |
+------------------------------+
| 12 345,670                   |
+------------------------------+
1 row in set (0.001 sec)

mysql> SELECT HEX(FORMAT(12345.67, 3, 'bg_BG'));
+-----------------------------------+
| HEX(FORMAT(12345.67, 3, 'bg_BG')) |
+-----------------------------------+
| 3132003334352C363730              |
+-----------------------------------+
1 row in set (0.001 sec)
```

With this commit:
```
mysql> SELECT FORMAT(12345.67,3,'bg_BG');
+----------------------------+
| FORMAT(12345.67,3,'bg_BG') |
+----------------------------+
| 12345,670                  |
+----------------------------+
1 row in set (0.001 sec)

mysql> SELECT HEX(FORMAT(12345.67,3,'bg_BG'));
+---------------------------------+
| HEX(FORMAT(12345.67,3,'bg_BG')) |
+---------------------------------+
| 31323334352C363730              |
+---------------------------------+
1 row in set (0.001 sec)
```

Other options considered:
1. Change the grouping for `bg_BG` to `\x80\x80`. This would probably have the same result, but allows for newly added locales to have the same issue later on.
2. Change the thousands separator for `bg_BG` to ` ` (space, 0x20). This would result in output that may be visually similar depending on the client, but it seems like no thousands separator was the intended behavior.