### PR TITLE
Bug #119302: Fix insert statement in rpl_parallel_multi_db test

### DIFF
--- a/mysql-test/suite/rpl/t/rpl_parallel_multi_db.test
+++ b/mysql-test/suite/rpl/t/rpl_parallel_multi_db.test
@@ -201,7 +201,7 @@ while ($k)
 {
    let $n= `select floor(rand()*$dbs + 1)`;
    let $m= `select floor(rand()*$tables + 1)`;
-   eval insert into d$n.t$n values (2);
+   eval insert into d$n.t$m values (2);
    dec $k;
 }
 --enable_warnings


### PR DESCRIPTION
Problem
The test rpl_parallel_multi_db uses an incorrect variable inside one of the INSERT statements.
Because of this, when different values are assigned to variables, the inserted value does not match the intended test logic and leads to unexpected replication behavior during parallel worker execution.

Fix
- Corrected the variable used in the INSERT statement to the intended value.
- Ensured that subsequent checks in the test align with the updated INSERT logic.
- No changes were required for the .result file beyond this fix (or update if needed).

Notes
- This change affects only the test logic and does not modify server code or behavior.
- Improves reliability and correctness of the replication parallelism test.