### PR TITLE
Bug #119302: Fix insert statement in rpl_parallel_multi_db test

### DIFF
--- a/mysql-test/suite/rpl/t/rpl_parallel_multi_db.test
+++ b/mysql-test/suite/rpl/t/rpl_parallel_multi_db.test
@@ -201,7 +201,7 @@ while ($k)
 {
    let $n= `select floor(rand()*$dbs + 1)`;
    let $m= `select floor(rand()*$tables + 1)`;
-   eval insert into d$n.t$n values (2);
+   eval insert into d$n.t$m values (2);
    dec $k;
 }
 --enable_warnings


### PR DESCRIPTION
The test used the wrong variable in one INSERT statement, causing values inserted on the master to differ from the expected values on the replica. This led to inconsistent behavior when running with parallel replication workers.

Fixed by replacing the incorrect variable with the intended one.