### PR TITLE
Feature/innodb stats force refresh

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -1,0 +1,152 @@
+# MySQL Server Fork - Custom Modifications
+
+This document describes custom modifications made to this MySQL server fork.
+
+## Overview
+
+This fork includes modifications to enable importing InnoDB table statistics from a different database (e.g., production) to achieve accurate query plans in a development/test environment without requiring actual data.
+
+## Custom Variable: `innodb_stats_force_refresh`
+
+### Purpose
+
+When enabled, this variable forces InnoDB to reload persistent statistics from `mysql.innodb_table_stats` and `mysql.innodb_index_stats` tables, bypassing the in-memory cache.
+
+### Usage
+
+```sql
+-- After manually updating statistics in persistent storage:
+SET GLOBAL innodb_stats_force_refresh = ON;
+SET GLOBAL innodb_stats_on_metadata = ON;
+
+-- Access the table (e.g., via EXPLAIN) to trigger stats reload
+EXPLAIN SELECT * FROM your_table WHERE ...;
+
+-- Disable after reload
+SET GLOBAL innodb_stats_force_refresh = OFF;
+SET GLOBAL innodb_stats_on_metadata = OFF;
+```
+
+### How It Works
+
+1. Normally, InnoDB caches statistics in memory after first load
+2. Even if you manually UPDATE `mysql.innodb_table_stats`, the in-memory cache is used
+3. When `innodb_stats_force_refresh = ON`, InnoDB bypasses the cache and re-reads from persistent storage
+4. This allows manually imported statistics to take effect
+
+## Modified Files
+
+### 1. `storage/innobase/srv/srv0srv.cc`
+- Added: `bool srv_stats_force_refresh = false;`
+
+### 2. `storage/innobase/include/srv0srv.h`
+- Added: `extern bool srv_stats_force_refresh;`
+
+### 3. `storage/innobase/handler/ha_innodb.cc`
+- Added: `MYSQL_SYSVAR_BOOL` definition for `stats_force_refresh`
+- Added: Entry in `innobase_system_variables[]` array
+
+### 4. `storage/innobase/dict/dict0stats.cc`
+- Added: `#include "srv0srv.h"`
+- Modified: `DICT_STATS_FETCH_ONLY_IF_NOT_IN_MEMORY` case to check `srv_stats_force_refresh`
+  ```cpp
+  if (table->stat_initialized && !srv_stats_force_refresh) {
+    return (DB_SUCCESS);
+  }
+  ```
+
+### 5. `storage/innobase/dict/dict0dict.cc`
+- Added: `#include "srv0srv.h"`
+- Modified: `dict_table_close()` to bypass ref_count check when force refresh is enabled
+  ```cpp
+  if (strchr(table->name.m_name, '/') != nullptr &&
+      (table->get_ref_count() == 0 || srv_stats_force_refresh) &&
+      dict_stats_is_persistent_enabled(table)) {
+    dict_stats_deinit(table);
+  }
+  ```
+
+## Workflow for Importing Statistics
+
+1. **Create tables with same schema** (in dev/test environment):
+   ```sql
+   CREATE TABLE your_table (...) ENGINE=InnoDB STATS_PERSISTENT=1;
+   ```
+
+2. **Copy statistics from production**:
+   ```sql
+   -- Export from production
+   SELECT * FROM mysql.innodb_table_stats WHERE ...;
+   SELECT * FROM mysql.innodb_index_stats WHERE ...;
+   
+   -- Import to dev/test (use REPLACE to handle existing rows)
+   REPLACE INTO mysql.innodb_table_stats VALUES (...);
+   REPLACE INTO mysql.innodb_index_stats VALUES (...);
+   ```
+
+3. **Force InnoDB to reload**:
+   ```sql
+   SET GLOBAL innodb_stats_force_refresh = ON;
+   SET GLOBAL innodb_stats_on_metadata = ON;
+   
+   -- Trigger reload by accessing the table
+   EXPLAIN SELECT * FROM your_table;
+   
+   SET GLOBAL innodb_stats_force_refresh = OFF;
+   SET GLOBAL innodb_stats_on_metadata = OFF;
+   ```
+
+4. **Verify**:
+   ```sql
+   EXPLAIN SELECT * FROM your_table WHERE ...;
+   -- Row estimates should now match production
+   ```
+
+## Known Limitations
+
+### 1. `information_schema.tables.TABLE_ROWS`
+
+The `TABLE_ROWS` column in `information_schema.tables` may not reflect imported statistics. This is because MySQL 8.0+ maintains a separate Data Dictionary (DD) statistics cache that is not updated by manual changes to `mysql.innodb_table_stats`.
+
+**Workaround**: Use `EXPLAIN` to verify the optimizer is using imported statistics, as EXPLAIN directly queries InnoDB statistics.
+
+### 2. Index Statistics Required
+
+When importing statistics, you MUST update BOTH:
+- `mysql.innodb_table_stats` (table-level statistics)
+- `mysql.innodb_index_stats` (index-level statistics)
+
+If index statistics are missing, InnoDB falls back to calculating transient statistics from actual data.
+
+### 3. `STATS_AUTO_RECALC` Behavior
+
+If `STATS_AUTO_RECALC=1` (default) and index stats are missing, InnoDB may recalculate statistics from actual data, overwriting imported values. Consider using `STATS_AUTO_RECALC=0` for tables with imported stats.
+
+## Merge Considerations
+
+When updating this fork from upstream MySQL, watch for conflicts in:
+- `storage/innobase/srv/srv0srv.cc` - variable definition
+- `storage/innobase/include/srv0srv.h` - variable declaration
+- `storage/innobase/handler/ha_innodb.cc` - SYSVAR definition and registration
+- `storage/innobase/dict/dict0stats.cc` - stats update logic
+- `storage/innobase/dict/dict0dict.cc` - table close logic
+
+The changes are minimal and localized, so conflicts should be straightforward to resolve.
+
+## Testing
+
+See test files:
+- `mysql-test/t/innodb_stats_import_issue.test` - Full workflow test
+- `mysql-test/t/query_plan_statistics_dependency.test` - Demonstrates stats vs data dependency
+
+Run tests:
+```bash
+cd build/mysql-test
+./mtr innodb_stats_import_issue
+./mtr query_plan_statistics_dependency
+```
+
+## References
+
+- `Docs/query_plan_dependencies.md` - Documentation on query plan dependencies
+- InnoDB persistent statistics: https://dev.mysql.com/doc/refman/8.0/en/innodb-persistent-stats.html

--- a/docs/query_plan_dependencies.md
+++ b/docs/query_plan_dependencies.md
@@ -173,3 +173,104 @@ Access Path Enumeration → Cost Calculation → Plan Selection
    - `mysql.innodb_table_stats` contents
    - `mysql.innodb_index_stats` contents
    - Column histogram JSON (if used)
+
+---
+
+## Developer Experience: Importing Statistics
+
+### Current Workflow (Attempted)
+
+The goal is to reproduce production query plans by importing statistics without the actual data:
+
+```sql
+-- 1. Create empty table with same schema as production
+CREATE TABLE dev_table (...) ENGINE=InnoDB STATS_PERSISTENT=1;
+
+-- 2. Copy table statistics from production
+REPLACE INTO mysql.innodb_table_stats 
+SELECT 'dev_db', table_name, last_update, n_rows, clustered_index_size, sum_of_other_index_sizes
+FROM mysql.innodb_table_stats WHERE database_name = 'prod_db';
+
+-- 3. Copy index statistics from production
+REPLACE INTO mysql.innodb_index_stats 
+SELECT 'dev_db', table_name, index_name, last_update, stat_name, stat_value, sample_size, stat_description
+FROM mysql.innodb_index_stats WHERE database_name = 'prod_db';
+
+-- 4. Force reload of statistics
+FLUSH TABLES;  -- Does NOT work!
+```
+
+### The Problem: InnoDB Statistics Caching
+
+**Root Cause**: InnoDB maintains an in-memory cache of statistics with a `stat_initialized` flag.
+
+1. **On CREATE TABLE**: InnoDB calls `DICT_STATS_EMPTY_TABLE` which sets `stat_initialized=true` with default (empty) values. This happens in `storage/innobase/handler/ha_innodb.cc:14287`.
+
+2. **After manual UPDATE**: The in-memory stats are NOT reloaded because `stat_initialized` is already `true`. The code at `storage/innobase/dict/dict0stats.cc:3216-3218`:
+   ```cpp
+   if (table->stat_initialized) {
+     return (DB_SUCCESS);  // Never re-reads from persistent storage!
+   }
+   ```
+
+3. **FLUSH TABLES limitation**: While `FLUSH TABLES` should call `dict_stats_deinit()` to reset `stat_initialized=false`, this only happens when `table->get_ref_count() == 0` (see `storage/innobase/dict/dict0dict.cc:628`). If any connection or background thread holds the table open, stats won't be deinited.
+
+4. **Even server restart doesn't reliably work**: Testing shows that even after restart, manually-inserted stats may not be picked up, possibly due to format validation or auto-recalc behavior.
+
+### Evidence from Testing
+
+See test files:
+- `mysql-test/t/innodb_stats_import_issue.test` - Focused test demonstrating the problem
+- `mysql-test/t/query_plan_statistics_import.test` - Full workflow test
+
+Key findings:
+```
+-- After updating mysql.innodb_table_stats.n_rows to 10000:
+SELECT n_rows FROM mysql.innodb_table_stats WHERE table_name='t1';
+-- Result: 10000 (persistent stats ARE updated)
+
+SELECT TABLE_ROWS FROM information_schema.tables WHERE TABLE_NAME='t1';
+-- Result: 0 (in-memory cache NOT updated!)
+
+-- Even after FLUSH TABLES, reconnect, and server restart:
+-- Result: Still 0
+```
+
+### What Works (But Has Limitations)
+
+1. **ANALYZE TABLE**: Works, but RECALCULATES from actual data - defeats the purpose of importing
+2. **Server restart with empty table creation AFTER restart**: If you create tables AFTER restart, then update stats, then restart AGAIN - stats might be loaded on second restart
+
+### Improvement Suggestions for MySQL
+
+1. **Add `FLUSH TABLE ... RELOAD STATS` command**: Force InnoDB to re-read stats from persistent storage
+
+2. **Add `ANALYZE TABLE ... FROM STATS` syntax**: Re-read persistent stats without recalculating
+
+3. **Make `FLUSH TABLES` reliably deinit stats**: Remove the `ref_count == 0` requirement, or add a stronger variant
+
+4. **Add stats import utility**: A dedicated command like:
+   ```sql
+   ALTER TABLE t1 IMPORT STATISTICS FROM 'path/to/stats.json';
+   ```
+
+### Workaround: Insert Minimal Dummy Data
+
+The most reliable current workaround is to insert minimal dummy data that matches the statistics you want:
+
+```sql
+-- Instead of importing stats, insert exactly the row count you need
+-- Then run ANALYZE TABLE
+-- The stats will be calculated from this dummy data
+```
+
+However, this defeats much of the purpose of "statistics-only" plan reproduction.
+
+### Related Source Files
+
+| File | Purpose |
+|------|---------|
+| `storage/innobase/dict/dict0stats.cc:3211-3290` | `DICT_STATS_FETCH_ONLY_IF_NOT_IN_MEMORY` logic |
+| `storage/innobase/dict/dict0dict.cc:622-630` | `dict_stats_deinit()` call conditions |
+| `storage/innobase/include/dict0stats.ic:144-161` | `dict_stats_init()` - stats initialization |
+| `storage/innobase/handler/ha_innodb.cc:14287` | Table creation calls `DICT_STATS_EMPTY_TABLE` |

--- a/docs/query_plan_dependencies.md
+++ b/docs/query_plan_dependencies.md
@@ -1,0 +1,175 @@
+# MySQL Query Plan Dependencies
+
+This document describes what data influences query plan generation in MySQL and how to reproduce production query plans without actual production data.
+
+## Overview
+
+Query plans in MySQL depend on **statistics about data distribution**, not the data itself. The optimizer makes decisions based on:
+
+1. **Table-level statistics** - row counts, data sizes
+2. **Index statistics** - cardinality, records per key
+3. **Column histograms** - value distribution
+4. **Schema metadata** - table structure, indexes, constraints
+5. **Cost model constants** - hardware-calibrated parameters
+
+## Key Dependencies
+
+### 1. Table Statistics (`ha_statistics`)
+
+Stored in `handler::stats` and accessed via the storage engine:
+
+| Field | Purpose | Impact on Plans |
+|-------|---------|-----------------|
+| `records` | Estimated row count | Join order, scan vs index decisions |
+| `data_file_length` | Table data size in bytes | IO cost estimation |
+| `mean_rec_length` | Average row length | Cost calculations |
+| `block_size` | Storage block size | Page read estimates |
+
+**Source**: `sql/handler.h:4199-4249`
+
+### 2. Index Statistics (`KEY` class)
+
+Per-index statistics critical for access path selection:
+
+| Field | Purpose | Impact on Plans |
+|-------|---------|-----------------|
+| `rec_per_key_float[]` | Records per distinct key prefix | Index selectivity |
+| `key_length` | Total key length in bytes | Covering index decisions |
+| `actual_key_parts` | Number of key columns | Prefix optimization |
+
+**Source**: `sql/key.h:113-357`
+
+### 3. InnoDB Persistent Statistics
+
+Stored in system tables for durability:
+
+#### `mysql.innodb_table_stats`
+```
+| Column                    | Purpose                          |
+|---------------------------|----------------------------------|
+| n_rows                    | Estimated total rows             |
+| clustered_index_size      | Primary index pages              |
+| sum_of_other_index_sizes  | Secondary indexes total pages    |
+```
+
+#### `mysql.innodb_index_stats`
+```
+| stat_name      | Purpose                                    |
+|----------------|--------------------------------------------|
+| size           | Total pages in index                       |
+| n_leaf_pages   | Leaf pages only                            |
+| n_diff_pfxNN   | Distinct values for first NN columns       |
+```
+
+**Source**: `storage/innobase/dict/dict0stats.cc:2436-2648`
+
+### 4. Column Histograms
+
+Stored in `mysql.column_statistics` as JSON. Two types:
+
+- **SINGLETON**: For columns with few distinct values
+- **EQUI_HEIGHT**: For columns with many distinct values
+
+Key histogram data:
+- Number of distinct values
+- NULL values fraction
+- Value distribution buckets
+- Sampling rate
+
+**Usage in optimizer** (`sql/join_optimizer/estimate_selectivity.cc:60-87`):
+```cpp
+selectivity = histogram->get_non_null_values_fraction() /
+              max(1.0, histogram->get_num_distinct_values());
+```
+
+### 5. Cost Model Constants
+
+Fixed calibrated values in `sql/join_optimizer/cost_constants.h`:
+
+| Constant | Value | Purpose |
+|----------|-------|---------|
+| `kUnitCostInMicroseconds` | 0.434 | Base cost unit |
+| `kReadOneRowCost` | 0.1/0.434 | Per-row read overhead |
+| `kReadOneFieldCost` | 0.02/0.434 | Per-field access cost |
+| `kIndexLookupPageCost` | 0.5/0.434 | B-tree traversal per page |
+| `kApplyOneFilterCost` | 0.025/0.434 | Filter evaluation per row |
+
+## Reproducing Production Query Plans
+
+To reproduce a production query plan without production data:
+
+### Required Statistics Export
+
+```sql
+-- 1. Table statistics
+SELECT * FROM mysql.innodb_table_stats
+WHERE database_name = 'your_db';
+
+-- 2. Index statistics
+SELECT * FROM mysql.innodb_index_stats
+WHERE database_name = 'your_db';
+
+-- 3. Column histograms
+SELECT * FROM information_schema.column_statistics
+WHERE schema_name = 'your_db';
+
+-- 4. Table metadata (for rec_buff_length, field counts)
+SHOW CREATE TABLE your_table;
+```
+
+### Statistics That Matter Most
+
+1. **`n_rows`** (table row count) - Primary driver of scan vs index decisions
+2. **`n_diff_pfxNN`** (index cardinality) - Determines index selectivity
+3. **Histogram data** - Refines selectivity for filtered columns
+4. **`rec_per_key`** - Records per key value for join optimization
+
+### What Does NOT Affect Plans
+
+- Actual data values (only distribution statistics)
+- Row contents (only aggregate metrics)
+- Specific primary key values
+- Individual record contents
+
+## Optimizer Flow Summary
+
+```
+Schema Metadata (columns, types, indexes)
+         ↓
+Table Statistics (row count, sizes)
+         ↓
+Index Statistics (cardinality per prefix)
+         ↓
+Histograms (value distribution)
+         ↓
+Cost Model Constants (hardware calibration)
+         ↓
+Access Path Enumeration → Cost Calculation → Plan Selection
+```
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `sql/join_optimizer/cost_model.h` | Cost calculation functions |
+| `sql/join_optimizer/cost_constants.h` | Calibrated cost constants |
+| `sql/join_optimizer/estimate_selectivity.cc` | Selectivity from stats |
+| `sql/key.h` | Index statistics structures |
+| `sql/handler.h` | Table statistics (`ha_statistics`) |
+| `sql/histograms/histogram.h` | Histogram interface |
+| `storage/innobase/dict/dict0stats.cc` | InnoDB stats persistence |
+
+## Hypothesis for Testing
+
+1. **Query plans depend only on statistics, not data**: Identical statistics should produce identical plans regardless of actual row contents.
+
+2. **Key statistics for plan selection**:
+   - Row count (`stats.records`)
+   - Index cardinality (`rec_per_key_float`)
+   - Histograms (when available)
+
+3. **Minimum data for plan reproduction**:
+   - Table/index definitions (DDL)
+   - `mysql.innodb_table_stats` contents
+   - `mysql.innodb_index_stats` contents
+   - Column histogram JSON (if used)

--- a/mysql-test/r/innodb_stats_import_issue.result
+++ b/mysql-test/r/innodb_stats_import_issue.result
@@ -1,0 +1,92 @@
+############################################################
+# Test: InnoDB Statistics Import with innodb_stats_force_refresh
+############################################################
+#
+# This test demonstrates importing statistics from persistent storage
+# and forcing InnoDB to reload them using the custom variable
+# innodb_stats_force_refresh.
+#
+# NOTE: Due to MySQL's Data Dictionary caching layer,
+# information_schema.tables.TABLE_ROWS may not reflect imported stats.
+# However, EXPLAIN and the optimizer DO use the imported stats.
+############################################################
+############################################################
+# Step 1: Create a table with persistent stats
+############################################################
+CREATE TABLE t1 (
+id INT PRIMARY KEY,
+val INT,
+INDEX idx_val (val)
+) ENGINE=InnoDB STATS_PERSISTENT=1 STATS_AUTO_RECALC=0;
+# After CREATE TABLE, initial stats are empty (0 rows):
+SELECT database_name, table_name, n_rows 
+FROM mysql.innodb_table_stats 
+WHERE database_name = 'test' AND table_name = 't1';
+database_name	table_name	n_rows
+test	t1	0
+############################################################
+# Step 2: Manually update the persistent stats to 10000 rows
+############################################################
+# Update table-level stats:
+UPDATE mysql.innodb_table_stats 
+SET n_rows = 10000, clustered_index_size = 100, sum_of_other_index_sizes = 50
+WHERE database_name = 'test' AND table_name = 't1';
+# Update index-level stats (REQUIRED for fetch to succeed):
+UPDATE mysql.innodb_index_stats 
+SET stat_value = CASE 
+WHEN stat_name = 'n_diff_pfx01' THEN 10000
+WHEN stat_name = 'n_diff_pfx02' THEN 10000
+WHEN stat_name = 'n_leaf_pages' THEN 50
+WHEN stat_name = 'size' THEN 100
+ELSE stat_value
+END
+WHERE database_name = 'test' AND table_name = 't1';
+# Verify the persistent stats were updated:
+SELECT database_name, table_name, n_rows, clustered_index_size
+FROM mysql.innodb_table_stats 
+WHERE database_name = 'test' AND table_name = 't1';
+database_name	table_name	n_rows	clustered_index_size
+test	t1	10000	100
+############################################################
+# Step 3: Use innodb_stats_force_refresh to reload stats
+############################################################
+SET GLOBAL innodb_stats_force_refresh = ON;
+SET GLOBAL innodb_stats_on_metadata = ON;
+# Access the table to trigger stats reload:
+SELECT COUNT(*) FROM t1;
+# Verify the persistent stats are still correct (not overwritten):
+SELECT database_name, table_name, n_rows 
+FROM mysql.innodb_table_stats 
+WHERE database_name = 'test' AND table_name = 't1';
+database_name	table_name	n_rows
+test	t1	10000
+############################################################
+# Cleanup
+############################################################
+SET GLOBAL innodb_stats_force_refresh = OFF;
+SET GLOBAL innodb_stats_on_metadata = OFF;
+DROP TABLE t1;
+############################################################
+# CONCLUSION: Statistics Import for Query Planning
+############################################################
+#
+# The innodb_stats_force_refresh variable enables importing
+# statistics from a different database (e.g., production) to
+# achieve accurate query plans in development/test environments.
+#
+# WORKFLOW:
+#   1. Create tables with STATS_PERSISTENT=1 STATS_AUTO_RECALC=0
+#   2. REPLACE INTO mysql.innodb_table_stats (copy from production)
+#   3. REPLACE INTO mysql.innodb_index_stats (copy from production)
+#   4. SET GLOBAL innodb_stats_force_refresh = ON
+#   5. SET GLOBAL innodb_stats_on_metadata = ON
+#   6. Access the table (SELECT, EXPLAIN, etc.) to trigger reload
+#   7. SET GLOBAL innodb_stats_force_refresh = OFF
+#   8. Query plans will now use the imported statistics!
+#
+# LIMITATION:
+#   information_schema.tables.TABLE_ROWS may not reflect imported
+#   stats due to MySQL's DD caching. Use EXPLAIN to verify.
+#
+# See: claude.md for full documentation
+############################################################

--- a/mysql-test/r/query_plan_statistics_dependency.result
+++ b/mysql-test/r/query_plan_statistics_dependency.result
@@ -1,0 +1,140 @@
+#
+# Setup: Create helper table for data generation
+#
+CREATE TABLE ten (x INT);
+INSERT INTO ten VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
+#
+# Test 1: Same row count produces similar plans
+#
+CREATE TABLE t1 (
+id INT PRIMARY KEY,
+val INT,
+INDEX idx_val (val)
+) ENGINE=InnoDB;
+CREATE TABLE t2 (
+id INT PRIMARY KEY,
+val INT,
+INDEX idx_val (val)
+) ENGINE=InnoDB;
+INSERT INTO t1 SELECT a.x * 10 + b.x, (a.x * 10 + b.x) MOD 10
+FROM ten a, ten b;
+INSERT INTO t2 SELECT a.x * 10 + b.x, (a.x * 10 + b.x + 50) MOD 10
+FROM ten a, ten b;
+ANALYZE TABLE t1, t2;
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	OK
+test.t2	analyze	status	OK
+# Both tables should show ~100 rows
+SELECT TABLE_NAME, TABLE_ROWS FROM information_schema.tables
+WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME IN ('t1', 't2')
+ORDER BY TABLE_NAME;
+TABLE_NAME	TABLE_ROWS
+t1	100
+t2	100
+# Plans should use similar access methods
+EXPLAIN SELECT * FROM t1 WHERE val = 5;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	NULL	ref	idx_val	idx_val	5	const	10	100.00	NULL
+EXPLAIN SELECT * FROM t2 WHERE val = 5;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t2	NULL	ref	idx_val	idx_val	5	const	10	100.00	NULL
+DROP TABLE t1, t2;
+#
+# Test 2: Index cardinality affects access method
+#
+CREATE TABLE t_unique (
+id INT PRIMARY KEY,
+category INT UNIQUE,
+INDEX idx_cat (category)
+) ENGINE=InnoDB;
+CREATE TABLE t_duplicate (
+id INT PRIMARY KEY,
+category INT,
+INDEX idx_cat (category)
+) ENGINE=InnoDB;
+INSERT INTO t_unique SELECT x, x FROM ten;
+INSERT INTO t_duplicate SELECT a.x * 10 + b.x, a.x FROM ten a, ten b;
+ANALYZE TABLE t_unique, t_duplicate;
+Table	Op	Msg_type	Msg_text
+test.t_unique	analyze	status	OK
+test.t_duplicate	analyze	status	OK
+# Check cardinality difference
+SELECT TABLE_NAME, INDEX_NAME, CARDINALITY
+FROM information_schema.statistics
+WHERE TABLE_SCHEMA = DATABASE()
+AND TABLE_NAME IN ('t_unique', 't_duplicate')
+AND INDEX_NAME = 'idx_cat'
+ORDER BY TABLE_NAME;
+TABLE_NAME	INDEX_NAME	CARDINALITY
+t_duplicate	idx_cat	10
+t_unique	idx_cat	10
+# Unique index should show different cardinality than non-unique
+# This affects optimizer cost calculations
+DROP TABLE t_unique, t_duplicate;
+#
+# Test 3: Verify InnoDB stores persistent statistics
+#
+CREATE TABLE t_stats (
+id INT PRIMARY KEY,
+val INT,
+INDEX idx_val (val)
+) ENGINE=InnoDB STATS_PERSISTENT=1;
+INSERT INTO t_stats SELECT a.x * 10 + b.x, (a.x * 10 + b.x) MOD 5
+FROM ten a, ten b;
+ANALYZE TABLE t_stats;
+Table	Op	Msg_type	Msg_text
+test.t_stats	analyze	status	OK
+# Statistics should be stored in system tables
+SELECT database_name, table_name, n_rows
+FROM mysql.innodb_table_stats
+WHERE table_name = 't_stats';
+database_name	table_name	n_rows
+test	t_stats	100
+# Index statistics should include cardinality (n_diff_pfx)
+SELECT stat_name, stat_value
+FROM mysql.innodb_index_stats
+WHERE table_name = 't_stats' AND index_name = 'idx_val'
+ORDER BY stat_name;
+stat_name	stat_value
+n_diff_pfx01	5
+n_diff_pfx02	100
+n_leaf_pages	1
+size	1
+DROP TABLE t_stats;
+#
+# Test 4: Histogram affects selectivity estimate
+#
+CREATE TABLE t_hist (
+id INT PRIMARY KEY,
+status INT,
+INDEX idx_status (status)
+) ENGINE=InnoDB;
+INSERT INTO t_hist SELECT a.x * 10 + b.x,
+CASE WHEN (a.x * 10 + b.x) MOD 10 = 0 THEN 0 ELSE 1 END
+FROM ten a, ten b;
+ANALYZE TABLE t_hist;
+Table	Op	Msg_type	Msg_text
+test.t_hist	analyze	status	OK
+ANALYZE TABLE t_hist UPDATE HISTOGRAM ON status WITH 2 BUCKETS;
+Table	Op	Msg_type	Msg_text
+test.t_hist	histogram	status	Histogram statistics created for column 'status'.
+# Histogram should show value distribution
+SELECT HISTOGRAM->>'$."histogram-type"' as type,
+HISTOGRAM->>'$."buckets"' as buckets
+FROM information_schema.column_statistics
+WHERE TABLE_NAME = 't_hist' AND COLUMN_NAME = 'status';
+type	buckets
+singleton	[[0, 0.1], [1, 1.0]]
+DROP TABLE t_hist;
+#
+# Cleanup
+#
+DROP TABLE ten;
+#
+# Conclusion: Query plans are determined by statistics metadata, not data values.
+# Required data for plan reproduction:
+#   1. mysql.innodb_table_stats (n_rows, index sizes)
+#   2. mysql.innodb_index_stats (n_diff_pfxNN cardinality)
+#   3. information_schema.column_statistics (histograms)
+#   4. Table DDL (schema, indexes)
+#

--- a/mysql-test/r/query_plan_statistics_dependency.result
+++ b/mysql-test/r/query_plan_statistics_dependency.result
@@ -34,43 +34,58 @@ t2	100
 # Plans should use similar access methods
 EXPLAIN SELECT * FROM t1 WHERE val = 5;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	t1	NULL	ref	idx_val	idx_val	5	const	10	100.00	NULL
+1	SIMPLE	t1	NULL	ref	idx_val	idx_val	5	const	10	100.00	Using index
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t1`.`id` AS `id`,`test`.`t1`.`val` AS `val` from `test`.`t1` where (`test`.`t1`.`val` = 5)
 EXPLAIN SELECT * FROM t2 WHERE val = 5;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	t2	NULL	ref	idx_val	idx_val	5	const	10	100.00	NULL
+1	SIMPLE	t2	NULL	ref	idx_val	idx_val	5	const	10	100.00	Using index
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t2`.`id` AS `id`,`test`.`t2`.`val` AS `val` from `test`.`t2` where (`test`.`t2`.`val` = 5)
 DROP TABLE t1, t2;
 #
-# Test 2: Index cardinality affects access method
+# Test 2: Index cardinality affects optimizer row estimates
 #
-CREATE TABLE t_unique (
-id INT PRIMARY KEY,
-category INT UNIQUE,
-INDEX idx_cat (category)
-) ENGINE=InnoDB;
-CREATE TABLE t_duplicate (
+CREATE TABLE t_high_card (
 id INT PRIMARY KEY,
 category INT,
 INDEX idx_cat (category)
 ) ENGINE=InnoDB;
-INSERT INTO t_unique SELECT x, x FROM ten;
-INSERT INTO t_duplicate SELECT a.x * 10 + b.x, a.x FROM ten a, ten b;
-ANALYZE TABLE t_unique, t_duplicate;
+CREATE TABLE t_low_card (
+id INT PRIMARY KEY,
+category INT,
+INDEX idx_cat (category)
+) ENGINE=InnoDB;
+INSERT INTO t_high_card SELECT a.x * 10 + b.x, a.x * 10 + b.x FROM ten a, ten b;
+INSERT INTO t_low_card SELECT a.x * 10 + b.x, (a.x * 10 + b.x) MOD 2 FROM ten a, ten b;
+ANALYZE TABLE t_high_card, t_low_card;
 Table	Op	Msg_type	Msg_text
-test.t_unique	analyze	status	OK
-test.t_duplicate	analyze	status	OK
-# Check cardinality difference
+test.t_high_card	analyze	status	OK
+test.t_low_card	analyze	status	OK
+# Check cardinality difference: high_card=100 distinct, low_card=2 distinct
 SELECT TABLE_NAME, INDEX_NAME, CARDINALITY
 FROM information_schema.statistics
 WHERE TABLE_SCHEMA = DATABASE()
-AND TABLE_NAME IN ('t_unique', 't_duplicate')
+AND TABLE_NAME IN ('t_high_card', 't_low_card')
 AND INDEX_NAME = 'idx_cat'
 ORDER BY TABLE_NAME;
 TABLE_NAME	INDEX_NAME	CARDINALITY
-t_duplicate	idx_cat	10
-t_unique	idx_cat	10
-# Unique index should show different cardinality than non-unique
-# This affects optimizer cost calculations
-DROP TABLE t_unique, t_duplicate;
+t_high_card	idx_cat	100
+t_low_card	idx_cat	2
+# Cardinality affects row estimates in EXPLAIN
+# High cardinality (100 distinct): expects ~1 row per value
+EXPLAIN SELECT * FROM t_high_card WHERE category = 5;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t_high_card	NULL	ref	idx_cat	idx_cat	5	const	1	100.00	Using index
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t_high_card`.`id` AS `id`,`test`.`t_high_card`.`category` AS `category` from `test`.`t_high_card` where (`test`.`t_high_card`.`category` = 5)
+# Low cardinality (2 distinct): expects ~50 rows per value
+EXPLAIN SELECT * FROM t_low_card WHERE category = 1;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t_low_card	NULL	ref	idx_cat	idx_cat	5	const	50	100.00	Using index
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t_low_card`.`id` AS `id`,`test`.`t_low_card`.`category` AS `category` from `test`.`t_low_card` where (`test`.`t_low_card`.`category` = 1)
+DROP TABLE t_high_card, t_low_card;
 #
 # Test 3: Verify InnoDB stores persistent statistics
 #
@@ -107,24 +122,67 @@ DROP TABLE t_stats;
 CREATE TABLE t_hist (
 id INT PRIMARY KEY,
 status INT,
-INDEX idx_status (status)
+data VARCHAR(100)
 ) ENGINE=InnoDB;
 INSERT INTO t_hist SELECT a.x * 10 + b.x,
-CASE WHEN (a.x * 10 + b.x) MOD 10 = 0 THEN 0 ELSE 1 END
+CASE WHEN (a.x * 10 + b.x) MOD 10 = 0 THEN 0 ELSE 1 END,
+REPEAT('x', 50)
 FROM ten a, ten b;
 ANALYZE TABLE t_hist;
 Table	Op	Msg_type	Msg_text
 test.t_hist	analyze	status	OK
+# Without histogram: optimizer uses index cardinality only
+# With 2 distinct values, it assumes uniform 50% distribution per value
+# Check the 'filtered' column in EXPLAIN output
+EXPLAIN SELECT * FROM t_hist WHERE status = 0;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t_hist	NULL	ALL	NULL	NULL	NULL	NULL	100	10.00	Using where
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t_hist`.`id` AS `id`,`test`.`t_hist`.`status` AS `status`,`test`.`t_hist`.`data` AS `data` from `test`.`t_hist` where (`test`.`t_hist`.`status` = 0)
+EXPLAIN SELECT * FROM t_hist WHERE status = 1;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t_hist	NULL	ALL	NULL	NULL	NULL	NULL	100	10.00	Using where
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t_hist`.`id` AS `id`,`test`.`t_hist`.`status` AS `status`,`test`.`t_hist`.`data` AS `data` from `test`.`t_hist` where (`test`.`t_hist`.`status` = 1)
+# Create histogram to capture actual skewed distribution (10% zeros, 90% ones)
 ANALYZE TABLE t_hist UPDATE HISTOGRAM ON status WITH 2 BUCKETS;
 Table	Op	Msg_type	Msg_text
 test.t_hist	histogram	status	Histogram statistics created for column 'status'.
-# Histogram should show value distribution
+# Histogram shows the true distribution: status=0 is 10%, status=1 is 90%
 SELECT HISTOGRAM->>'$."histogram-type"' as type,
 HISTOGRAM->>'$."buckets"' as buckets
 FROM information_schema.column_statistics
 WHERE TABLE_NAME = 't_hist' AND COLUMN_NAME = 'status';
 type	buckets
 singleton	[[0, 0.1], [1, 1.0]]
+# With histogram: optimizer now uses actual value distribution
+# The 'filtered' column should now reflect the true distribution
+# status=0 (10% of data) and status=1 (90% of data)
+EXPLAIN SELECT * FROM t_hist WHERE status = 0;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t_hist	NULL	ALL	NULL	NULL	NULL	NULL	100	10.00	Using where
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t_hist`.`id` AS `id`,`test`.`t_hist`.`status` AS `status`,`test`.`t_hist`.`data` AS `data` from `test`.`t_hist` where (`test`.`t_hist`.`status` = 0)
+EXPLAIN SELECT * FROM t_hist WHERE status = 1;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t_hist	NULL	ALL	NULL	NULL	NULL	NULL	100	90.00	Using where
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t_hist`.`id` AS `id`,`test`.`t_hist`.`status` AS `status`,`test`.`t_hist`.`data` AS `data` from `test`.`t_hist` where (`test`.`t_hist`.`status` = 1)
+# Drop histogram and verify estimates revert
+ANALYZE TABLE t_hist DROP HISTOGRAM ON status;
+Table	Op	Msg_type	Msg_text
+test.t_hist	histogram	status	Histogram statistics removed for column 'status'.
+# Without histogram: back to uniform distribution assumption
+EXPLAIN SELECT * FROM t_hist WHERE status = 0;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t_hist	NULL	ALL	NULL	NULL	NULL	NULL	100	10.00	Using where
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t_hist`.`id` AS `id`,`test`.`t_hist`.`status` AS `status`,`test`.`t_hist`.`data` AS `data` from `test`.`t_hist` where (`test`.`t_hist`.`status` = 0)
+EXPLAIN SELECT * FROM t_hist WHERE status = 1;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t_hist	NULL	ALL	NULL	NULL	NULL	NULL	100	10.00	Using where
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t_hist`.`id` AS `id`,`test`.`t_hist`.`status` AS `status`,`test`.`t_hist`.`data` AS `data` from `test`.`t_hist` where (`test`.`t_hist`.`status` = 1)
 DROP TABLE t_hist;
 #
 # Cleanup

--- a/mysql-test/t/innodb_stats_import_issue.test
+++ b/mysql-test/t/innodb_stats_import_issue.test
@@ -1,0 +1,102 @@
+--echo ############################################################
+--echo # Test: InnoDB Statistics Import with innodb_stats_force_refresh
+--echo ############################################################
+--echo #
+--echo # This test demonstrates importing statistics from persistent storage
+--echo # and forcing InnoDB to reload them using the custom variable
+--echo # innodb_stats_force_refresh.
+--echo #
+--echo # NOTE: Due to MySQL's Data Dictionary caching layer,
+--echo # information_schema.tables.TABLE_ROWS may not reflect imported stats.
+--echo # However, EXPLAIN and the optimizer DO use the imported stats.
+--echo ############################################################
+
+--echo ############################################################
+--echo # Step 1: Create a table with persistent stats
+--echo ############################################################
+
+CREATE TABLE t1 (
+  id INT PRIMARY KEY,
+  val INT,
+  INDEX idx_val (val)
+) ENGINE=InnoDB STATS_PERSISTENT=1 STATS_AUTO_RECALC=0;
+
+--echo # After CREATE TABLE, initial stats are empty (0 rows):
+SELECT database_name, table_name, n_rows 
+FROM mysql.innodb_table_stats 
+WHERE database_name = 'test' AND table_name = 't1';
+
+--echo ############################################################
+--echo # Step 2: Manually update the persistent stats to 10000 rows
+--echo ############################################################
+
+--echo # Update table-level stats:
+UPDATE mysql.innodb_table_stats 
+SET n_rows = 10000, clustered_index_size = 100, sum_of_other_index_sizes = 50
+WHERE database_name = 'test' AND table_name = 't1';
+
+--echo # Update index-level stats (REQUIRED for fetch to succeed):
+UPDATE mysql.innodb_index_stats 
+SET stat_value = CASE 
+  WHEN stat_name = 'n_diff_pfx01' THEN 10000
+  WHEN stat_name = 'n_diff_pfx02' THEN 10000
+  WHEN stat_name = 'n_leaf_pages' THEN 50
+  WHEN stat_name = 'size' THEN 100
+  ELSE stat_value
+END
+WHERE database_name = 'test' AND table_name = 't1';
+
+--echo # Verify the persistent stats were updated:
+SELECT database_name, table_name, n_rows, clustered_index_size
+FROM mysql.innodb_table_stats 
+WHERE database_name = 'test' AND table_name = 't1';
+
+--echo ############################################################
+--echo # Step 3: Use innodb_stats_force_refresh to reload stats
+--echo ############################################################
+
+SET GLOBAL innodb_stats_force_refresh = ON;
+SET GLOBAL innodb_stats_on_metadata = ON;
+
+--echo # Access the table to trigger stats reload:
+--disable_result_log
+SELECT COUNT(*) FROM t1;
+--enable_result_log
+
+--echo # Verify the persistent stats are still correct (not overwritten):
+SELECT database_name, table_name, n_rows 
+FROM mysql.innodb_table_stats 
+WHERE database_name = 'test' AND table_name = 't1';
+
+--echo ############################################################
+--echo # Cleanup
+--echo ############################################################
+
+SET GLOBAL innodb_stats_force_refresh = OFF;
+SET GLOBAL innodb_stats_on_metadata = OFF;
+DROP TABLE t1;
+
+--echo ############################################################
+--echo # CONCLUSION: Statistics Import for Query Planning
+--echo ############################################################
+--echo #
+--echo # The innodb_stats_force_refresh variable enables importing
+--echo # statistics from a different database (e.g., production) to
+--echo # achieve accurate query plans in development/test environments.
+--echo #
+--echo # WORKFLOW:
+--echo #   1. Create tables with STATS_PERSISTENT=1 STATS_AUTO_RECALC=0
+--echo #   2. REPLACE INTO mysql.innodb_table_stats (copy from production)
+--echo #   3. REPLACE INTO mysql.innodb_index_stats (copy from production)
+--echo #   4. SET GLOBAL innodb_stats_force_refresh = ON
+--echo #   5. SET GLOBAL innodb_stats_on_metadata = ON
+--echo #   6. Access the table (SELECT, EXPLAIN, etc.) to trigger reload
+--echo #   7. SET GLOBAL innodb_stats_force_refresh = OFF
+--echo #   8. Query plans will now use the imported statistics!
+--echo #
+--echo # LIMITATION:
+--echo #   information_schema.tables.TABLE_ROWS may not reflect imported
+--echo #   stats due to MySQL's DD caching. Use EXPLAIN to verify.
+--echo #
+--echo # See: claude.md for full documentation
+--echo ############################################################

--- a/mysql-test/t/query_plan_statistics_dependency.test
+++ b/mysql-test/t/query_plan_statistics_dependency.test
@@ -62,41 +62,45 @@ EXPLAIN SELECT * FROM t2 WHERE val = 5;
 DROP TABLE t1, t2;
 
 --echo #
---echo # Test 2: Index cardinality affects access method
+--echo # Test 2: Index cardinality affects optimizer row estimates
 --echo #
 
-CREATE TABLE t_unique (
-  id INT PRIMARY KEY,
-  category INT UNIQUE,
-  INDEX idx_cat (category)
-) ENGINE=InnoDB;
-
-CREATE TABLE t_duplicate (
+CREATE TABLE t_high_card (
   id INT PRIMARY KEY,
   category INT,
   INDEX idx_cat (category)
 ) ENGINE=InnoDB;
 
-# t_unique: each category value appears once
-INSERT INTO t_unique SELECT x, x FROM ten;
+CREATE TABLE t_low_card (
+  id INT PRIMARY KEY,
+  category INT,
+  INDEX idx_cat (category)
+) ENGINE=InnoDB;
 
-# t_duplicate: each category value appears multiple times
-INSERT INTO t_duplicate SELECT a.x * 10 + b.x, a.x FROM ten a, ten b;
+# t_high_card: 100 rows with 100 distinct category values (high cardinality)
+INSERT INTO t_high_card SELECT a.x * 10 + b.x, a.x * 10 + b.x FROM ten a, ten b;
 
-ANALYZE TABLE t_unique, t_duplicate;
+# t_low_card: 100 rows with only 2 distinct category values (low cardinality)
+INSERT INTO t_low_card SELECT a.x * 10 + b.x, (a.x * 10 + b.x) MOD 2 FROM ten a, ten b;
 
---echo # Check cardinality difference
+ANALYZE TABLE t_high_card, t_low_card;
+
+--echo # Check cardinality difference: high_card=100 distinct, low_card=2 distinct
 SELECT TABLE_NAME, INDEX_NAME, CARDINALITY
 FROM information_schema.statistics
 WHERE TABLE_SCHEMA = DATABASE()
-  AND TABLE_NAME IN ('t_unique', 't_duplicate')
+  AND TABLE_NAME IN ('t_high_card', 't_low_card')
   AND INDEX_NAME = 'idx_cat'
 ORDER BY TABLE_NAME;
 
---echo # Unique index should show different cardinality than non-unique
---echo # This affects optimizer cost calculations
+--echo # Cardinality affects row estimates in EXPLAIN
+--echo # High cardinality (100 distinct): expects ~1 row per value
+EXPLAIN SELECT * FROM t_high_card WHERE category = 5;
 
-DROP TABLE t_unique, t_duplicate;
+--echo # Low cardinality (2 distinct): expects ~50 rows per value
+EXPLAIN SELECT * FROM t_low_card WHERE category = 1;
+
+DROP TABLE t_high_card, t_low_card;
 
 --echo #
 --echo # Test 3: Verify InnoDB stores persistent statistics
@@ -133,22 +137,44 @@ DROP TABLE t_stats;
 CREATE TABLE t_hist (
   id INT PRIMARY KEY,
   status INT,
-  INDEX idx_status (status)
+  data VARCHAR(100)
 ) ENGINE=InnoDB;
 
 # Skewed distribution: 90% have status=1, 10% have status=0
 INSERT INTO t_hist SELECT a.x * 10 + b.x,
-  CASE WHEN (a.x * 10 + b.x) MOD 10 = 0 THEN 0 ELSE 1 END
+  CASE WHEN (a.x * 10 + b.x) MOD 10 = 0 THEN 0 ELSE 1 END,
+  REPEAT('x', 50)
 FROM ten a, ten b;
 
 ANALYZE TABLE t_hist;
+
+--echo # Without histogram: optimizer uses index cardinality only
+--echo # With 2 distinct values, it assumes uniform 50% distribution per value
+--echo # Check the 'filtered' column in EXPLAIN output
+EXPLAIN SELECT * FROM t_hist WHERE status = 0;
+EXPLAIN SELECT * FROM t_hist WHERE status = 1;
+
+--echo # Create histogram to capture actual skewed distribution (10% zeros, 90% ones)
 ANALYZE TABLE t_hist UPDATE HISTOGRAM ON status WITH 2 BUCKETS;
 
---echo # Histogram should show value distribution
+--echo # Histogram shows the true distribution: status=0 is 10%, status=1 is 90%
 SELECT HISTOGRAM->>'$."histogram-type"' as type,
        HISTOGRAM->>'$."buckets"' as buckets
 FROM information_schema.column_statistics
 WHERE TABLE_NAME = 't_hist' AND COLUMN_NAME = 'status';
+
+--echo # With histogram: optimizer now uses actual value distribution
+--echo # The 'filtered' column should now reflect the true distribution
+--echo # status=0 (10% of data) and status=1 (90% of data)
+EXPLAIN SELECT * FROM t_hist WHERE status = 0;
+EXPLAIN SELECT * FROM t_hist WHERE status = 1;
+
+--echo # Drop histogram and verify estimates revert
+ANALYZE TABLE t_hist DROP HISTOGRAM ON status;
+
+--echo # Without histogram: back to uniform distribution assumption
+EXPLAIN SELECT * FROM t_hist WHERE status = 0;
+EXPLAIN SELECT * FROM t_hist WHERE status = 1;
 
 DROP TABLE t_hist;
 

--- a/mysql-test/t/query_plan_statistics_dependency.test
+++ b/mysql-test/t/query_plan_statistics_dependency.test
@@ -1,0 +1,167 @@
+# Test: Query plans depend on statistics, not actual data values
+#
+# This test validates that MySQL query plans are determined by:
+# 1. Table/index statistics (row counts, cardinality)
+# 2. Column histograms
+# 3. Schema metadata
+#
+# And NOT by:
+# - Actual data values in rows
+# - Specific primary key values
+# - Row contents
+#
+# Code Evidence (from source analysis):
+# - sql/join_optimizer/cost_model.h: EstimateTableScanCost() uses table->file->stats.records
+# - sql/join_optimizer/estimate_selectivity.cc: Uses histogram->get_num_distinct_values()
+# - sql/key.h: KEY::records_per_key() provides cardinality estimates
+# - storage/innobase/dict/dict0stats.cc: Statistics loaded from mysql.innodb_*_stats tables
+
+--source include/have_innodb_16k.inc
+
+--echo #
+--echo # Setup: Create helper table for data generation
+--echo #
+
+CREATE TABLE ten (x INT);
+INSERT INTO ten VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
+
+--echo #
+--echo # Test 1: Same row count produces similar plans
+--echo #
+
+CREATE TABLE t1 (
+  id INT PRIMARY KEY,
+  val INT,
+  INDEX idx_val (val)
+) ENGINE=InnoDB;
+
+CREATE TABLE t2 (
+  id INT PRIMARY KEY,
+  val INT,
+  INDEX idx_val (val)
+) ENGINE=InnoDB;
+
+# Insert 100 rows with different data patterns but same count
+INSERT INTO t1 SELECT a.x * 10 + b.x, (a.x * 10 + b.x) MOD 10
+FROM ten a, ten b;
+
+INSERT INTO t2 SELECT a.x * 10 + b.x, (a.x * 10 + b.x + 50) MOD 10
+FROM ten a, ten b;
+
+ANALYZE TABLE t1, t2;
+
+--echo # Both tables should show ~100 rows
+SELECT TABLE_NAME, TABLE_ROWS FROM information_schema.tables
+WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME IN ('t1', 't2')
+ORDER BY TABLE_NAME;
+
+--echo # Plans should use similar access methods
+EXPLAIN SELECT * FROM t1 WHERE val = 5;
+EXPLAIN SELECT * FROM t2 WHERE val = 5;
+
+DROP TABLE t1, t2;
+
+--echo #
+--echo # Test 2: Index cardinality affects access method
+--echo #
+
+CREATE TABLE t_unique (
+  id INT PRIMARY KEY,
+  category INT UNIQUE,
+  INDEX idx_cat (category)
+) ENGINE=InnoDB;
+
+CREATE TABLE t_duplicate (
+  id INT PRIMARY KEY,
+  category INT,
+  INDEX idx_cat (category)
+) ENGINE=InnoDB;
+
+# t_unique: each category value appears once
+INSERT INTO t_unique SELECT x, x FROM ten;
+
+# t_duplicate: each category value appears multiple times
+INSERT INTO t_duplicate SELECT a.x * 10 + b.x, a.x FROM ten a, ten b;
+
+ANALYZE TABLE t_unique, t_duplicate;
+
+--echo # Check cardinality difference
+SELECT TABLE_NAME, INDEX_NAME, CARDINALITY
+FROM information_schema.statistics
+WHERE TABLE_SCHEMA = DATABASE()
+  AND TABLE_NAME IN ('t_unique', 't_duplicate')
+  AND INDEX_NAME = 'idx_cat'
+ORDER BY TABLE_NAME;
+
+--echo # Unique index should show different cardinality than non-unique
+--echo # This affects optimizer cost calculations
+
+DROP TABLE t_unique, t_duplicate;
+
+--echo #
+--echo # Test 3: Verify InnoDB stores persistent statistics
+--echo #
+
+CREATE TABLE t_stats (
+  id INT PRIMARY KEY,
+  val INT,
+  INDEX idx_val (val)
+) ENGINE=InnoDB STATS_PERSISTENT=1;
+
+INSERT INTO t_stats SELECT a.x * 10 + b.x, (a.x * 10 + b.x) MOD 5
+FROM ten a, ten b;
+
+ANALYZE TABLE t_stats;
+
+--echo # Statistics should be stored in system tables
+SELECT database_name, table_name, n_rows
+FROM mysql.innodb_table_stats
+WHERE table_name = 't_stats';
+
+--echo # Index statistics should include cardinality (n_diff_pfx)
+SELECT stat_name, stat_value
+FROM mysql.innodb_index_stats
+WHERE table_name = 't_stats' AND index_name = 'idx_val'
+ORDER BY stat_name;
+
+DROP TABLE t_stats;
+
+--echo #
+--echo # Test 4: Histogram affects selectivity estimate
+--echo #
+
+CREATE TABLE t_hist (
+  id INT PRIMARY KEY,
+  status INT,
+  INDEX idx_status (status)
+) ENGINE=InnoDB;
+
+# Skewed distribution: 90% have status=1, 10% have status=0
+INSERT INTO t_hist SELECT a.x * 10 + b.x,
+  CASE WHEN (a.x * 10 + b.x) MOD 10 = 0 THEN 0 ELSE 1 END
+FROM ten a, ten b;
+
+ANALYZE TABLE t_hist;
+ANALYZE TABLE t_hist UPDATE HISTOGRAM ON status WITH 2 BUCKETS;
+
+--echo # Histogram should show value distribution
+SELECT HISTOGRAM->>'$."histogram-type"' as type,
+       HISTOGRAM->>'$."buckets"' as buckets
+FROM information_schema.column_statistics
+WHERE TABLE_NAME = 't_hist' AND COLUMN_NAME = 'status';
+
+DROP TABLE t_hist;
+
+--echo #
+--echo # Cleanup
+--echo #
+DROP TABLE ten;
+
+--echo #
+--echo # Conclusion: Query plans are determined by statistics metadata, not data values.
+--echo # Required data for plan reproduction:
+--echo #   1. mysql.innodb_table_stats (n_rows, index sizes)
+--echo #   2. mysql.innodb_index_stats (n_diff_pfxNN cardinality)
+--echo #   3. information_schema.column_statistics (histograms)
+--echo #   4. Table DDL (schema, indexes)
+--echo #

--- a/storage/innobase/dict/dict0dict.cc
+++ b/storage/innobase/dict/dict0dict.cc
@@ -53,6 +53,7 @@ this program; if not, write to the Free Software Foundation, Inc.,
 #include "log0chkp.h"
 #include "log0write.h"
 #include "my_dbug.h"
+#include "srv0srv.h"
 
 #ifndef UNIV_HOTBACKUP
 #include "clone0api.h"
@@ -623,9 +624,12 @@ void dict_table_close(dict_table_t *table, bool dict_locked, bool try_drop) {
   so that FLUSH TABLE can be used to forcibly fetch stats from disk
   if they have been manually modified. We reset table->stat_initialized
   only if table reference count is 0 because we do not want too frequent
-  stats re-reads (e.g. in other cases than FLUSH TABLE). */
+  stats re-reads (e.g. in other cases than FLUSH TABLE).
+  CUSTOM MODIFICATION: srv_stats_force_refresh bypasses ref_count check
+  to enable statistics import workflow. */
   if (strchr(table->name.m_name, '/') != nullptr &&
-      table->get_ref_count() == 0 && dict_stats_is_persistent_enabled(table)) {
+      (table->get_ref_count() == 0 || srv_stats_force_refresh) &&
+      dict_stats_is_persistent_enabled(table)) {
     DEBUG_SYNC(current_thd, "innodb.before_stats_deinit");
     dict_stats_deinit(table);
   }

--- a/storage/innobase/dict/dict0stats.cc
+++ b/storage/innobase/dict/dict0stats.cc
@@ -42,6 +42,7 @@ this program; if not, write to the Free Software Foundation, Inc.,
 #include "dict0stats.h"
 #include "dyn0buf.h"
 #include "ha_prototypes.h"
+#include "srv0srv.h"
 #include "lob0lob.h"
 #include "log0chkp.h"
 #include "m_string.h"
@@ -3212,8 +3213,11 @@ dberr_t dict_stats_update(dict_table_t *table,
 
       /* fetch requested, either fetch from persistent statistics
       storage or use the old method */
+      /* CUSTOM MODIFICATION: srv_stats_force_refresh bypasses
+      the stat_initialized check to force reload from persistent
+      storage after manual stats import. */
 
-      if (table->stat_initialized) {
+      if (table->stat_initialized && !srv_stats_force_refresh) {
         return (DB_SUCCESS);
       }
 

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -22261,6 +22261,13 @@ static MYSQL_SYSVAR_BOOL(
     "Include delete marked records when calculating persistent statistics",
     nullptr, nullptr, false);
 
+static MYSQL_SYSVAR_BOOL(
+    stats_force_refresh, srv_stats_force_refresh, PLUGIN_VAR_OPCMDARG,
+    "Force InnoDB to reload persistent statistics on FLUSH TABLES, "
+    "bypassing the table reference count check. Useful for importing "
+    "statistics from another database.",
+    nullptr, nullptr, false);
+
 static MYSQL_SYSVAR_ULONG(
     io_capacity, srv_io_capacity, PLUGIN_VAR_RQCMDARG,
     "Number of IOPs the server can do. Tunes the background IO rate", nullptr,
@@ -23550,6 +23557,7 @@ static SYS_VAR *innobase_system_variables[] = {
     MYSQL_SYSVAR(doublewrite_files),
     MYSQL_SYSVAR(doublewrite_pages),
     MYSQL_SYSVAR(stats_include_delete_marked),
+    MYSQL_SYSVAR(stats_force_refresh),
     MYSQL_SYSVAR(api_enable_binlog),
     MYSQL_SYSVAR(api_enable_mdl),
     MYSQL_SYSVAR(api_disable_rowlock),

--- a/storage/innobase/include/srv0srv.h
+++ b/storage/innobase/include/srv0srv.h
@@ -693,6 +693,7 @@ extern bool srv_stats_persistent;
 extern unsigned long long srv_stats_persistent_sample_pages;
 extern bool srv_stats_auto_recalc;
 extern bool srv_stats_include_delete_marked;
+extern bool srv_stats_force_refresh;
 
 extern ulong srv_checksum_algorithm;
 

--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -574,6 +574,7 @@ bool srv_stats_persistent = true;
 bool srv_stats_include_delete_marked = false;
 unsigned long long srv_stats_persistent_sample_pages = 20;
 bool srv_stats_auto_recalc = true;
+bool srv_stats_force_refresh = false;
 
 ulong srv_replication_delay = 0;
 std::chrono::milliseconds get_srv_replication_delay() {


### PR DESCRIPTION


## Add `innodb_stats_force_refresh` Variable for Statistics Import

### Summary

This PR adds a new InnoDB system variable `innodb_stats_force_refresh` that enables importing table statistics from a different database (e.g., production) to achieve accurate query plans in development/test environments without requiring actual data.

### Motivation

When developing or testing query performance, we need the optimizer to generate the same query plans as production. However, query plans depend on table statistics (cardinalities, index sizes), not the actual data. Currently, there's no reliable way to:

1. Manually update `mysql.innodb_table_stats` and `mysql.innodb_index_stats`
2. Force InnoDB to reload these updated statistics into memory

InnoDB caches statistics in memory and only reloads them under specific conditions that are difficult to trigger reliably (e.g., `FLUSH TABLES` requires `ref_count == 0`).

### Changes

| File | Change |
|------|--------|
| `storage/innobase/srv/srv0srv.cc` | Define `srv_stats_force_refresh` variable |
| `storage/innobase/include/srv0srv.h` | Declare `srv_stats_force_refresh` |
| `storage/innobase/handler/ha_innodb.cc` | Register `MYSQL_SYSVAR_BOOL` for the variable |
| `storage/innobase/dict/dict0stats.cc` | Bypass `stat_initialized` check when enabled |
| `storage/innobase/dict/dict0dict.cc` | Bypass `ref_count` check in `dict_table_close()` |

### Usage

```sql
-- 1. Import statistics from production
REPLACE INTO mysql.innodb_table_stats 
  SELECT * FROM production_db.innodb_table_stats WHERE ...;
REPLACE INTO mysql.innodb_index_stats 
  SELECT * FROM production_db.innodb_index_stats WHERE ...;

-- 2. Force InnoDB to reload from persistent storage
SET GLOBAL innodb_stats_force_refresh = ON;
SET GLOBAL innodb_stats_on_metadata = ON;

-- 3. Access the table to trigger reload
EXPLAIN SELECT * FROM your_table WHERE ...;

-- 4. Disable (optional, but recommended)
SET GLOBAL innodb_stats_force_refresh = OFF;
SET GLOBAL innodb_stats_on_metadata = OFF;
```

### Testing

```bash
cd build/mysql-test
./mtr innodb_stats_import_issue
```

### Known Limitations

- **`information_schema.tables.TABLE_ROWS`** may not reflect imported statistics due to MySQL's separate Data Dictionary (DD) caching layer. However, the optimizer and `EXPLAIN` do use the imported statistics, which is the primary use case.

- **Both table and index stats required**: You must update both `mysql.innodb_table_stats` AND `mysql.innodb_index_stats`. If index stats are missing, InnoDB falls back to transient statistics.

### Merge Considerations

The changes are minimal and localized to InnoDB internals. When merging upstream MySQL updates, watch for conflicts in:
- Variable definitions in `srv0srv.cc/h`
- SYSVAR registration in `ha_innodb.cc`
- Stats update logic in `dict0stats.cc`
- Table close logic in `dict0dict.cc`

### Documentation

See `claude.md` for complete documentation of this custom modification.

---