### PR TITLE
 Fix excessive generation of histogram background update errors 

### DIFF
--- a/mysql-test/r/histogram_background_error.result
+++ b/mysql-test/r/histogram_background_error.result
@@ -11,4 +11,15 @@ INSERT INTO t1 VALUES (1), (2), (3);
 # Wait for an error to show up in the error log.
 # Verify that the error comes from the background histogram update.
 include/assert_error_log.inc [server: 1, pattern: Background histogram update on test.t1: Unable to build histogram statistics for column 'field' in table 'schema'.'table']
+#
+# Bug#118999: Stale diagnostic area conditions should not be re-logged
+#             after subsequent background histogram updates.
+#
+SET GLOBAL DEBUG = '-d,update_histograms_failure';
+include/save_error_log_position.inc
+INSERT INTO t1 VALUES (4), (5), (6);
+# Wait for the background histogram update to complete successfully.
+# Verify that no stale errors were re-logged.
+include/assert_error_log.inc [server: 1, pattern: NONE]
+SET GLOBAL DEBUG = '+d,update_histograms_failure';
 DROP TABLE t1;

--- a/mysql-test/r/histogram_background_error.result
+++ b/mysql-test/r/histogram_background_error.result
@@ -8,8 +8,8 @@ Table	Op	Msg_type	Msg_text
 test.t1	histogram	status	Histogram statistics created for column 'x'.
 include/save_error_log_position.inc
 INSERT INTO t1 VALUES (1), (2), (3);
-# Wait for an error to show up in the error log.
-# Verify that the error comes from the background histogram update.
+# Wait for a warning to show up in the error log.
+# Verify that the warning comes from the background histogram update.
 include/assert_error_log.inc [server: 1, pattern: Background histogram update on test.t1: Unable to build histogram statistics for column 'field' in table 'schema'.'table']
 #
 # Bug#118999: Stale diagnostic area conditions should not be re-logged

--- a/mysql-test/t/histogram_background_error.test
+++ b/mysql-test/t/histogram_background_error.test
@@ -16,12 +16,12 @@ ANALYZE TABLE t1 UPDATE HISTOGRAM ON x AUTO UPDATE;
 --source include/save_error_log_position.inc
 INSERT INTO t1 VALUES (1), (2), (3);
 
--- echo # Wait for an error to show up in the error log.
-let $wait_condition = SELECT COUNT(*) > 0 FROM performance_schema.error_log WHERE Prio = 'Error';
+-- echo # Wait for a warning to show up in the error log.
+let $wait_condition = SELECT COUNT(*) > 0 FROM performance_schema.error_log WHERE Prio = 'Warning';
 let $wait_timeout = 15;
 --source include/wait_condition.inc
 
--- echo # Verify that the error comes from the background histogram update.
+-- echo # Verify that the warning comes from the background histogram update.
 --let $error_pattern = Background histogram update on test.t1: Unable to build histogram statistics for column 'field' in table 'schema'.'table'
 --source include/assert_error_log.inc
 

--- a/mysql-test/t/histogram_background_error.test
+++ b/mysql-test/t/histogram_background_error.test
@@ -24,5 +24,36 @@ let $wait_timeout = 15;
 -- echo # Verify that the error comes from the background histogram update.
 --let $error_pattern = Background histogram update on test.t1: Unable to build histogram statistics for column 'field' in table 'schema'.'table'
 --source include/assert_error_log.inc
-DROP TABLE t1;
 
+-- echo #
+-- echo # Bug#118999: Stale diagnostic area conditions should not be re-logged
+-- echo #             after subsequent background histogram updates.
+-- echo #
+
+# Disable the debug point so subsequent background histogram updates succeed.
+SET GLOBAL DEBUG = '-d,update_histograms_failure';
+
+# Give time for background thread to pick up new debug settings
+-- sleep 5
+
+# Save the current histogram last-updated timestamp.
+let $last_updated = `SELECT histogram->>'$."last-updated"' FROM INFORMATION_SCHEMA.COLUMN_STATISTICS WHERE table_name = 't1'`;
+
+--source include/save_error_log_position.inc
+
+# Insert more data to trigger another background histogram update.
+INSERT INTO t1 VALUES (4), (5), (6);
+
+-- echo # Wait for the background histogram update to complete successfully.
+let $wait_condition = SELECT histogram->>'\\$."last-updated"' <> '$last_updated' FROM INFORMATION_SCHEMA.COLUMN_STATISTICS WHERE table_name = 't1';
+let $wait_timeout = 15;
+--source include/wait_condition.inc
+
+-- echo # Verify that no stale errors were re-logged.
+--let $error_pattern = NONE
+--source include/assert_error_log.inc
+
+# Restore the debug point for MTR's internal check.
+SET GLOBAL DEBUG = '+d,update_histograms_failure';
+
+DROP TABLE t1;

--- a/sql/histograms/histogram.cc
+++ b/sql/histograms/histogram.cc
@@ -1690,6 +1690,7 @@ static void write_diagnostics_area_to_error_log(THD *thd, std::string db_name,
 */
 static void prepare_session_context(THD *thd) {
   thd->reset_for_next_command();
+  thd->get_stmt_da()->reset_condition_info(thd);
   lex_start(thd);
 }
 

--- a/sql/histograms/histogram.cc
+++ b/sql/histograms/histogram.cc
@@ -1864,8 +1864,6 @@ bool auto_update_table_histograms_from_background_thread(
   Table_ref table(db_name.c_str(), table_name.c_str(), thr_lock_type::TL_UNLOCK,
                   enum_mdl_type::MDL_SHARED_READ);
   if (open_and_lock_tables(thd, &table, MYSQL_OPEN_HAS_MDL_LOCK)) return true;
-  error_handler_guard.release();
-  thd->pop_internal_handler();
 
   if (!supports_histogram_updates(thd, &table)) return false;
 
@@ -1888,6 +1886,8 @@ bool auto_update_table_histograms_from_background_thread(
                      false);
     return true;
   }
+  error_handler_guard.release();
+  thd->pop_internal_handler();
   rollback_guard.release();
 
   // The update succeeded and has been committed. Mark cached TABLE objects for


### PR DESCRIPTION
## Description

When errors/warnings occur during background histogram updates, the conditions
in the diagnostic area are not cleared. This leads to future background
histogram updates emitting the same stale conditions to the error log which is
mis-leading at best.

We now clear the diagnostic area conditions in `prepare_session_context` to clear the
conditions from prior sessions.

This addresses Bug [#118999](https://bugs.mysql.com/bug.php?id=118999).


Additionally, there are paths for background histogram updates to still emit
errors. In particular, when an error occurs after the background_error_handler
is popped. This prevents certain errors during background histogram updates
from being throttled. Throttling of error messages regarding background histogram
updates was added in 1e39733b to prevent the error log from
being flooded with background histogram update warnings.

We now pop the error handler at a later stage in the background histogram
update to ensure errors are downgraded to warnings to ensure log throttling applies.


## How can this PR be tested?

The MTR `histogram_background_error` has been updated with test cases.


## Basing the PR against the correct MySQL version

* [x] _This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced._

## Copyright

This contribution is under the OCA signed by Amazon and covering submissions to the MySQL project.