### PR TITLE
Fix typos in sql/ comments and diagnostic messages

### DIFF
--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -2242,7 +2242,7 @@ class Binlog_cache_compressor {
   /// Size after compression, if compression succeeded. Otherwise,
   /// size before compression.
   size_t m_compressed_size;
-  /// Compression algorithm, if compression succeded; otherwise NONE.
+  /// Compression algorithm, if compression succeeded; otherwise NONE.
   mysql::binlog::event::compression::type m_compression_type;
 };
 
@@ -2315,7 +2315,7 @@ int binlog_cache_data::finalize(THD *thd, Log_event *end_event, XID_STATE *xs) {
 ///   @param thd Thread variable
 ///
 ///   @retval 0 Success.
-///   @retval non-zero Error occured writing to cache
+///   @retval non-zero Error occurred writing to cache
 ///
 ///   @note This function handles previous error while writing to the cache by
 ///   attempting to write (something hopefully smaller) to the cache and thus it

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -6210,7 +6210,7 @@ int Xid_apply_log_event::do_apply_event(Relay_log_info const *rli) {
     rli_ptr->set_group_relay_log_name(new_group_relay_log_name);
     rli_ptr->set_group_relay_log_pos(new_group_relay_log_pos);
 
-    DBUG_PRINT("info", ("Updating positions on succesful commit to group source"
+    DBUG_PRINT("info", ("Updating positions on successful commit to group source"
                         " %s %llu  group relay %s %llu\n",
                         rli_ptr->get_group_master_log_name(),
                         rli_ptr->get_group_master_log_pos(),

--- a/sql/signal_handler.cc
+++ b/sql/signal_handler.cc
@@ -178,7 +178,7 @@ static void print_extra_signal_information(int sig, siginfo_t *info) {
           extra_info = "Invalid address alignment";
           break;
         case BUS_ADRERR:
-          extra_info = "Non-existant physical address";
+          extra_info = "Non-existent physical address";
           break;
         case BUS_OBJERR:
           extra_info = "Object specific hardware error";


### PR DESCRIPTION

**Repo:** mysql/mysql-server (⭐ 11000)
**Type:** docs
**Files changed:** 3
**Lines:** +4/-4

## What
Fixes four English spelling errors in `sql/` code: `succesful` → `successful`
in a `DBUG_PRINT` message in `log_event.cc`; `succeded` → `succeeded` and
`occured` → `occurred` in Doxygen comments in `binlog.cc`; and
`Non-existant` → `Non-existent` in the user-facing `BUS_ADRERR` crash
diagnostic string in `signal_handler.cc`.

## Why
The `signal_handler.cc` string is printed to users and DBAs when a server
crashes on a bus error, so the misspelling is externally visible. The
remaining fixes improve Doxygen output and debug traces. All changes are
comment/string-only, behavior-preserving, and low-risk.

## Testing
No functional changes — comments, a `DBUG_PRINT` format string, and a crash
diagnostic string literal. Verified via `git diff` that no code paths were
altered. No build or test run is required beyond a normal compile.

## Risk
Low — comment and string-literal edits only; no logic, ABI, or format
specifier changes.
