### PR TITLE
Fix ut_error() at ENABLE INNODB REDO_LOG when  innodb_checkpoint_disabled is set

### DIFF
--- a/mysql-test/suite/innodb/r/redo_log_enable_checkpoint_disabled.result
+++ b/mysql-test/suite/innodb/r/redo_log_enable_checkpoint_disabled.result
@@ -1,0 +1,25 @@
+#
+# Bug: ALTER INSTANCE ENABLE INNODB REDO_LOG hits ut_error in debug build
+#      when innodb_checkpoint_disabled is set.
+#
+# Repro steps:
+#   ALTER INSTANCE DISABLE INNODB REDO_LOG;
+#   SET GLOBAL innodb_checkpoint_disabled=1;
+#   ALTER INSTANCE ENABLE INNODB REDO_LOG;  -- crashed here
+#
+# Disable redo logging
+ALTER INSTANCE DISABLE INNODB REDO_LOG;
+SHOW STATUS LIKE 'Innodb_redo_log_enabled';
+Variable_name	Value
+Innodb_redo_log_enabled	OFF
+# Disable checkpointing (debug-only)
+SET GLOBAL innodb_checkpoint_disabled = ON;
+# Re-enable redo logging while checkpoint is disabled.
+# This used to hit ut_error in log_request_latest_checkpoint().
+ALTER INSTANCE ENABLE INNODB REDO_LOG;
+# Verify redo logging is now enabled
+SHOW STATUS LIKE 'Innodb_redo_log_enabled';
+Variable_name	Value
+Innodb_redo_log_enabled	ON
+# Cleanup
+SET GLOBAL innodb_checkpoint_disabled = OFF;

--- a/mysql-test/suite/innodb/t/redo_log_enable_checkpoint_disabled.test
+++ b/mysql-test/suite/innodb/t/redo_log_enable_checkpoint_disabled.test
@@ -1,0 +1,34 @@
+--echo #
+--echo # Bug: ALTER INSTANCE ENABLE INNODB REDO_LOG hits ut_error in debug build
+--echo #      when innodb_checkpoint_disabled is set.
+--echo #
+--echo # Repro steps:
+--echo #   ALTER INSTANCE DISABLE INNODB REDO_LOG;
+--echo #   SET GLOBAL innodb_checkpoint_disabled=1;
+--echo #   ALTER INSTANCE ENABLE INNODB REDO_LOG;  -- crashed here
+--echo #
+
+# innodb_checkpoint_disabled is a debug-only variable
+--source include/have_debug.inc
+
+--disable_query_log
+call mtr.add_suppression("\\[Warning\\] .*MY-\\d+.* InnoDB redo logging is disabled. All data could be lost in case of a server crash");
+call mtr.add_suppression("\\[Warning\\] .*MY-\\d+.* InnoDB redo logging is enabled. Data is now safe and can be recovered in case of a server crash.");
+--enable_query_log
+
+--echo # Disable redo logging
+ALTER INSTANCE DISABLE INNODB REDO_LOG;
+SHOW STATUS LIKE 'Innodb_redo_log_enabled';
+
+--echo # Disable checkpointing (debug-only)
+SET GLOBAL innodb_checkpoint_disabled = ON;
+
+--echo # Re-enable redo logging while checkpoint is disabled.
+--echo # This used to hit ut_error in log_request_latest_checkpoint().
+ALTER INSTANCE ENABLE INNODB REDO_LOG;
+
+--echo # Verify redo logging is now enabled
+SHOW STATUS LIKE 'Innodb_redo_log_enabled';
+
+--echo # Cleanup
+SET GLOBAL innodb_checkpoint_disabled = OFF;

--- a/storage/innobase/log/log0chkp.cc
+++ b/storage/innobase/log/log0chkp.cc
@@ -605,6 +605,12 @@ void log_request_checkpoint(log_t &log, bool sync) {
 bool log_request_latest_checkpoint(log_t &log, lsn_t &requested_lsn) {
   const lsn_t lsn = log_get_lsn(log);
 
+#ifdef UNIV_DEBUG
+  if (srv_checkpoint_disabled) {
+    return false;
+  }
+#endif
+
   if (lsn <= log.last_checkpoint_lsn.load()) {
     return false;
   }


### PR DESCRIPTION
### Summary

Fix a debug-build crash (`ut_error`) triggered by the following sequence:

```sql
ALTER INSTANCE DISABLE INNODB REDO_LOG;
SET GLOBAL innodb_checkpoint_disabled=1;
ALTER INSTANCE ENABLE INNODB REDO_LOG;
```

### Problem

`ALTER INSTANCE ENABLE INNODB REDO_LOG` calls `log_make_latest_checkpoint()` internally. When `srv_checkpoint_disabled` is set in debug builds, the inner helper method `log_request_checkpoint_validate()` returns `false`, but `log_request_latest_checkpoint()` treats that as an unrecoverable error and hits `ut_error`.

### Fix

Add an early-return guard in `log_request_latest_checkpoint()` (inside `#ifdef UNIV_DEBUG`) that returns `false` immediately when `srv_checkpoint_disabled` is set, before reaching the `ut_error` path.

### Test

Added redo_log_enable_checkpoint_disabled.test (debug-only) that reproduces the exact crash sequence and verifies that `ENABLE INNODB REDO_LOG` completes successfully.
