### PR TITLE
Add client TCP port and TLS version to audit plugin connection events

### DIFF
--- a/include/mysql/components/services/defs/event_tracking_connection_defs.h
+++ b/include/mysql/components/services/defs/event_tracking_connection_defs.h
@@ -90,6 +90,10 @@ struct mysql_event_tracking_connection_data {
         - 5 Shared memory
   */
   int connection_type;
+  /** Client TCP port number. */
+  unsigned int port;
+  /** TLS version used for this connection. */
+  mysql_cstring_with_length tls_version;
 };
 
 #endif  // !COMPONENTS_SERVICES_DEFS_EVENT_TRACKING_CONNECTION_DEFS_H

--- a/include/mysql/plugin_audit.h
+++ b/include/mysql/plugin_audit.h
@@ -185,6 +185,10 @@ struct mysql_event_connection {
         - 5 Shared memory
   */
   int connection_type;
+  /** Client TCP port number. */
+  unsigned int port;
+  /** TLS version used for this connection. */
+  MYSQL_LEX_CSTRING tls_version;
 };
 
 /**

--- a/include/mysql/plugin_audit.h.pp
+++ b/include/mysql/plugin_audit.h.pp
@@ -424,6 +424,8 @@ struct mysql_event_connection {
   MYSQL_LEX_CSTRING ip;
   MYSQL_LEX_CSTRING database;
   int connection_type;
+  unsigned int port;
+  MYSQL_LEX_CSTRING tls_version;
 };
 typedef enum {
   MYSQL_AUDIT_PARSE_PREPARSE = 1 << 0,

--- a/sql/server_component/mysql_server_event_tracking_bridge_imp.cc
+++ b/sql/server_component/mysql_server_event_tracking_bridge_imp.cc
@@ -989,6 +989,8 @@ DEFINE_BOOL_METHOD(Event_connection_bridge_implementation::notify,
     plugin_data.ip = TO_LEXCSTRING(data->ip);
     plugin_data.database = TO_LEXCSTRING(data->database);
     plugin_data.connection_type = data->connection_type;
+    plugin_data.port = data->port;
+    plugin_data.tls_version = TO_LEXCSTRING(data->tls_version);
 
     return event_class_dispatch(thd, MYSQL_AUDIT_CONNECTION_CLASS,
                                 &plugin_data);

--- a/sql/sql_audit.cc
+++ b/sql/sql_audit.cc
@@ -23,6 +23,7 @@
 
 #include "sql/sql_audit.h"
 
+#include <openssl/ssl.h>
 #include <sys/types.h>
 
 #include "lex_string.h"
@@ -935,6 +936,15 @@ int mysql_event_tracking_connection_notify(
   event.ip = {ip.str, ip.length};
   event.database = {db.str, db.length};
   event.connection_type = thd->get_vio_type();
+  event.port = thd->peer_port;
+  event.tls_version.str = "";
+  event.tls_version.length = 0;
+
+  if (thd->get_net()->vio && thd->get_net()->vio->ssl_arg) {
+    event.tls_version.str =
+        SSL_get_version((SSL *)(thd->get_net()->vio->ssl_arg));
+    event.tls_version.length = strlen(event.tls_version.str);
+  }
 
   struct st_mysql_event_generic event_generic;
   event_generic.event = &event;


### PR DESCRIPTION
## Description

In MariaDB 12.3, new features were introduced in Server Audit Plugin. This change extends the audit plugin connection event structures to expose additional connection metadata: the client TCP port number and the TLS version used for encrypted connections.
    
Changes referred from similar changes in MariaDB:
- Logging the port number: https://github.com/MariaDB/server/commit/1aba30b8f990148ac23f0069b59976920acd3d61
- Logging the TLS version: https://github.com/MariaDB/server/commit/2b464774f240a18e1ff43cd18938a72a2d042e1f

The new fields will be available to audit plugins in MySQL.

## Release Notes

N/A

## How can this PR be tested?

This change has no impact to the server without Server Audit Plugin. All MTR tests should pass. Plugin related changes will be evaluated separately in MTR tests for the plugin.


## Basing the PR against the correct MySQL version

* [x] _This is a minor struct change for new plugin features, and the PR is based against the earliest maintained branch in which the bug can be reproduced._

## Copyright

This contribution is under the OCA signed by Amazon and covering submissions to the MySQL project.