### PR TITLE
Use public variable name innodb_open_files in open-file timeout error

### DIFF
--- a/share/messages_to_error_log.txt
+++ b/share/messages_to_error_log.txt
@@ -11571,7 +11571,7 @@ ER_IB_WARN_MANY_NON_LRU_FILES_OPENED
   eng "More than 90%% of files opened out of the innodb_open_files limit are files that are not easy to close. The performance of system may degrade. Consider increasing value of the innodb_open_files system variable. There are %zu such files opened out of the total limit for all files opened of %zu."
 
 ER_IB_MSG_TRYING_TO_OPEN_FILE_FOR_LONG_TIME
-  eng "Trying to open a file for %lld seconds. Configuration only allows for %zu open files. Consider setting innobase_open_files higher."
+  eng "Trying to open a file for %lld seconds. Configuration only allows for %zu open files. Consider setting innodb_open_files higher."
 
 ER_GLOBAL_CONN_LIMIT
   eng "Connection closed. Global connection memory limit %llu bytes exceeded. Consumed %llu bytes."


### PR DESCRIPTION
## Description

The error message ER_IB_MSG_TRYING_TO_OPEN_FILE_FOR_LONG_TIME referred to
"innobase_open_files", which is the internal C variable name in ha_innodb.cc,
not a name users can set. The variable is exposed to users as the
innodb_open_files system variable. Update the message to use the public name
so the suggested remediation is actionable, matching the neighboring
ER_IB_WARN_MANY_NON_LRU_FILES_OPENED message which already uses
innodb_open_files.

## Basing the PR against the correct MySQL version

* [x] _This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced._

## Copyright

This contribution is under the OCA signed by Amazon and covering submissions to the MySQL project.