### PR TITLE
Bug#120706: Crash on SP reprepare of aggregate inside EXISTS subquery

### DIFF
--- a/mysql-test/r/bug120706.result
+++ b/mysql-test/r/bug120706.result
@@ -1,0 +1,49 @@
+# Setup
+CREATE DATABASE IF NOT EXISTS bug_test;
+USE bug_test;
+DROP TABLE IF EXISTS test_table;
+Warnings:
+Note	1051	Unknown table 'bug_test.test_table'
+CREATE TABLE test_table (
+id       INT UNSIGNED NOT NULL AUTO_INCREMENT,
+value    VARCHAR(20) DEFAULT NULL,
+modified INT UNSIGNED NOT NULL,
+status   INT UNSIGNED NOT NULL,
+PRIMARY KEY (id),
+UNIQUE KEY (value)
+) ENGINE=InnoDB
+CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+DROP PROCEDURE IF EXISTS bug_test.test_proc2;
+Warnings:
+Note	1305	PROCEDURE bug_test.test_proc2 does not exist
+CREATE PROCEDURE bug_test.test_proc2()
+BEGIN
+IF NOT EXISTS (
+SELECT GROUP_CONCAT(value) FROM test_table
+) THEN
+SELECT 1;
+ELSE
+SELECT 2;
+END IF;
+END$$
+# 1st call: prepares & caches the IF expression (group_concat_max_len = 1500)
+SET SESSION group_concat_max_len = 1500;
+CALL bug_test.test_proc2;
+2
+2
+# 2nd call: changed metadata forces a reprepare of the cached statement.
+# Before the fix this crashed the server (use-after-free); it must now
+# complete and return the same result.
+SET SESSION group_concat_max_len = 16384;
+CALL bug_test.test_proc2;
+2
+2
+# Sanity: the connection survived the reprepare.
+SELECT 'server alive' AS status;
+status
+server alive
+# Cleanup
+DROP PROCEDURE bug_test.test_proc2;
+DROP TABLE test_table;
+DROP DATABASE bug_test;
+SET SESSION group_concat_max_len = DEFAULT;

--- a/mysql-test/t/bug120706.test
+++ b/mysql-test/t/bug120706.test
@@ -1,0 +1,49 @@
+--echo # Setup
+CREATE DATABASE IF NOT EXISTS bug_test;
+USE bug_test;
+
+DROP TABLE IF EXISTS test_table;
+CREATE TABLE test_table (
+    id       INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    value    VARCHAR(20) DEFAULT NULL,
+    modified INT UNSIGNED NOT NULL,
+    status   INT UNSIGNED NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY (value)
+) ENGINE=InnoDB
+  CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+
+DROP PROCEDURE IF EXISTS bug_test.test_proc2;
+
+DELIMITER $$;
+CREATE PROCEDURE bug_test.test_proc2()
+BEGIN
+    IF NOT EXISTS (
+        SELECT GROUP_CONCAT(value) FROM test_table
+    ) THEN
+        SELECT 1;
+    ELSE
+        SELECT 2;
+    END IF;
+END$$
+DELIMITER ;$$
+
+--echo # 1st call: prepares & caches the IF expression (group_concat_max_len = 1500)
+SET SESSION group_concat_max_len = 1500;
+CALL bug_test.test_proc2;
+
+--echo # 2nd call: changed metadata forces a reprepare of the cached statement.
+--echo # Before the fix this crashed the server (use-after-free); it must now
+--echo # complete and return the same result.
+SET SESSION group_concat_max_len = 16384;
+CALL bug_test.test_proc2;
+
+--echo # Sanity: the connection survived the reprepare.
+SELECT 'server alive' AS status;
+
+--echo # Cleanup
+DROP PROCEDURE bug_test.test_proc2;
+DROP TABLE test_table;
+DROP DATABASE bug_test;
+SET SESSION group_concat_max_len = DEFAULT;
+

--- a/sql/sp_instr.cc
+++ b/sql/sp_instr.cc
@@ -365,7 +365,8 @@ bool sp_lex_instr::execute_expression(THD *thd, uint *nextp) {
     return true;
   }
 
-  if (m_arena.get_state() != Query_arena::STMT_INITIALIZED_FOR_SP) {
+  if (!m_first_execution &&
+      m_arena.get_state() != Query_arena::STMT_INITIALIZED_FOR_SP) {
     m_lex->restore_cmd_properties();
     bind_fields(m_arena.item_list());
   }


### PR DESCRIPTION
## Description

A stored procedure that caches a statement containing an aggregate inside an EXISTS subquery crashes with SIGSEGV in Item_sum::add_used_tables_for_aggr_func() whenever that cached statement is forced to reprepare between executions (for example, after changing a session variable that affects the statement's prepare-time metadata, such as group_concat_max_len).

### Root cause:
A forced reprepare makes validate_lex_and_execute_core() call free_lex() --
releasing the old item arena including the aggregate Item -- and re-parse the
expression. The new query block is parsed but never resolved: m_first_execution
is true, m_saved_base_items is empty and leaf_tables is nullptr. Despite that,
sp_lex_instr::execute_expression() still calls
Query_block::restore_cmd_properties(), which recurses into the unresolved
EXISTS subquery and runs update_used_tables() over a field list still
referencing the freed aggregate Item -- a use-after-free that faults when
Item_sum::add_used_tables_for_aggr_func() dereferences base_query_block.

### Solution:
Guard restore_cmd_properties()/bind_fields() with !m_first_execution in
sp_lex_instr::execute_expression(). When m_first_execution is true, exec_core()
has not run on this LEX, so nothing was saved by save_cmd_properties() and there
is nothing to restore. Skipping restore lets exec_core() resolve the reparsed
statement from scratch -- the same safe path taken on a genuine first execution.

## How can this PR be tested?

Added MTR test mysql mtr suite covering the reprepare path with exact reproducible steps mention in the bug report.

Execute the following tests in `mysql-test-run`:
```
bug120706
```

## Copyright

This contribution is under the OCA signed by Amazon and covering submissions to the MySQL project.