### PR TITLE
Bug#120895: Add missing BuildRequires: for el8/el9 (libfido2-devel, libudev-devel, cpp)

### DIFF
--- a/packaging/rpm-oel/mysql.spec.in
+++ b/packaging/rpm-oel/mysql.spec.in
@@ -159,6 +159,14 @@ Source7:        %{compatsrc}
 BuildRequires:  cmake >= 3.14.6
 BuildRequires:  libtirpc-devel
 BuildRequires:  rpcgen
+# rpcgen shells out to the system C preprocessor to generate
+# xdr_gen/xcom_vp.h. Without it rpcgen fails silently and xcom
+# fails to compile.
+# cpp is not declared explicitly in BuildRequires.
+# On el9/el10 yum-builddep's resolution pulls in gcc as a side effect,
+# and gcc itself requires cpp. On el8 this does not happen so it must
+# be declared explicitly.
+%{?el8:BuildRequires:  cpp}
 %else
 BuildRequires:  cmake3 >= 3.14.6
 %endif
@@ -195,12 +203,16 @@ BuildRequires:  binutils
 BuildRequires:  dwz
 BuildRequires:  gcc-c++
 BuildRequires:  gcc
-BuildRequires:  libfido2-devel
 %ifnarch aarch64
 BuildRequires:  libquadmath-devel
 %endif
-BuildRequires:  libudev-devel
 %endif # el10
+%if 0%{?rhel} >= 8
+# Needed to build the FIDO2/WebAuthn client plugin, configured similarly to
+# add_fido_plugins above to avoid configuration drift.
+BuildRequires:  libfido2-devel
+BuildRequires:  libudev-devel
+%endif # add_fido_plugins deps (el8+)
 BuildRequires:  bison >= 3.0.4
 BuildRequires:  elfutils
 BuildRequires:  patchelf


### PR DESCRIPTION
### What does this change do?

See: https://bugs.mysql.com/120895

mysql.spec.in's BuildRequires: doesn't fully capture what a clean, minimal-container build actually needs on el8/el9:

### Why is it needed?

Reproducible rpm builds from a minimal setup. As far as I'm aware the full RPM build process is not shared publicly.

- The FIDO2/WebAuthn client plugin (add_fido_plugins) is enabled on el8 and later, but libfido2-devel/libudev-devel were only ever declared as BuildRequires for el10, so el8/el9 builds silently skip compiling the plugin, causing the rpm build to fail.

- rpcgen shells out to the system C preprocessor to generate xdr_gen/xcom_vp.h; without it rpcgen fails silently and xcom fails to compile. cpp is not declared explicitly in BuildRequires. On el9/el10 yum-builddep's resolution pulls in gcc as a side effect, and gcc itself requires cpp. On el8 this does not happen so it must be declared explicitly.

Fix:
- Move libfido2-devel/libudev-devel out of the el10-only BuildRequires: section into a shared section using the same condition as add_fido_plugins (%if 0%{?rhel} >= 8).
- Add an explicit BuildRequires: cpp for el8 only.

### How was it tested?

I will update this with full information shortly as I'm just collecting the final details.

You do not have a public process for building rpms or for building src rpms required to build the binary rpms at least from scratch. So I built a repo to allow me to confirm that rpms can be built from their declared dependencies. See: https://github.com/sjmudd/mysql-rpm-builder/

With that I verified the builds failed and reported the bug (9.7.0 is also affected for el8/el9)

And recently I added functionality to build the src rpm directly from the git tree. With that and a patch in my own forked mysql-server repo I can build the src rpm for a "patched 26.7.0" version for el8/el9/el10, and confirm the src rpm has the corrected spec file and then with that confirm that the src rpm can be built with no missing package dependencies.

I'm updating my own builder repo with the past/failures to give a full test case showing the builds will work correctly with the patch even though I don't know exactly how you build rpms and importantly sometimes your build environment appears to include packages which are not explicitly referenced.

### Contributor checklist

- [X] I have signed the [OCA](https://oca.opensource.oracle.com) with the email on these commits
- [N/A] Code is formatted (`scripts/ci/format.sh`). - this is patch against the mysql.spec.in file. I don't think you manage formatting of this.
- [X] Commits are focused with descriptive messages

### AI assistance

- [ ] I did not use AI assistance for this contribution
- [X] I used AI assistance for this contribution

If AI assistance was used, describe the tool(s) and extent of use:

A lot of everything. The mysql-rpm-builder setup is now much more sophisticated than a few months ago and is able to accurately build and verify builds for a number of scenarios. Building from git required some poking as you have most of the things there but again from a "reproducible builds" perspective no process is shared explicitly.
I also used it with this specific bug as it was reported some time ago and not actioned. So this hopes to fix it properly.

Note: not checked against el7. That's something to look at later.

### Areas touched

rpm packaging.

### Notes

- 9.7 is a different branch with the same issue.  This fix is against 26.7.0. I can prepare if needed a patch against 9.7 LTS though most likely the same patch will work there.
- as previously requested a fully transparent build process would be good for others to be able to use. I've "re-engineered" as I have found multiple cases where I was not able to "rebuild rpms" from the given rpm spec file. That file should provide full build dependency information but often that's been missed.  Ensuring the packaging dependencies are correct for multiple OS versions is tricky but it can be done.