### PR TITLE
InnoDB: Parallel DDL threads race in debug_sync on the shared THD

### DIFF
--- a/mysql-test/suite/innodb/r/ddl_debug_sync_race.result
+++ b/mysql-test/suite/innodb/r/ddl_debug_sync_race.result
@@ -1,0 +1,136 @@
+CREATE TABLE t1 (a INT PRIMARY KEY, b INT, c INT, d INT, e INT) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1,1,1,1,1);
+SET SESSION innodb_ddl_threads = 4;
+#
+# Part 1: two builders of one ALTER wait in one sync point.
+#
+# EXECUTE 2 lets two of the four builders execute the action. On a
+# server that lets them do so concurrently, both wait for ddl_resume,
+# the first one out clears that signal (the default for WAIT_FOR) and
+# the second one waits for it forever: the ALTER below never returns
+# and both waits below run into their TIMEOUT.
+#
+SET DEBUG_SYNC = 'row_log_apply_before SIGNAL ddl_parked WAIT_FOR ddl_resume TIMEOUT 60 EXECUTE 2';
+ALTER TABLE t1 ADD INDEX i1(b), ADD INDEX i2(c), ADD INDEX i3(d), ADD INDEX i4(e), ALGORITHM=INPLACE, LOCK=NONE;
+SET DEBUG_SYNC = 'now WAIT_FOR ddl_parked TIMEOUT 60';
+SET DEBUG_SYNC = 'now SIGNAL ddl_resume';
+SET DEBUG_SYNC = 'now WAIT_FOR ddl_parked TIMEOUT 60';
+SET DEBUG_SYNC = 'now SIGNAL ddl_resume';
+ALTER TABLE t1 DROP INDEX i1, DROP INDEX i2, DROP INDEX i3, DROP INDEX i4;
+SET DEBUG_SYNC = 'RESET';
+#
+# Part 2: several builders of one ALTER meet in one sync point.
+#
+SET DEBUG_SYNC = 'RESET';
+SET DEBUG_SYNC = 'row_log_apply_before SIGNAL ddl_parked WAIT_FOR ddl_resume';
+ALTER TABLE t1 ADD INDEX i1(b), ADD INDEX i2(c), ADD INDEX i3(d), ADD INDEX i4(e), ALGORITHM=INPLACE, LOCK=NONE;
+SET DEBUG_SYNC = 'now WAIT_FOR ddl_parked';
+SET DEBUG_SYNC = 'now SIGNAL ddl_resume';
+ALTER TABLE t1 DROP INDEX i1, DROP INDEX i2, DROP INDEX i3, DROP INDEX i4;
+SET DEBUG_SYNC = 'RESET';
+SET DEBUG_SYNC = 'row_log_apply_before SIGNAL ddl_parked WAIT_FOR ddl_resume';
+ALTER TABLE t1 ADD INDEX i1(b), ADD INDEX i2(c), ADD INDEX i3(d), ADD INDEX i4(e), ALGORITHM=INPLACE, LOCK=NONE;
+SET DEBUG_SYNC = 'now WAIT_FOR ddl_parked';
+SET DEBUG_SYNC = 'now SIGNAL ddl_resume';
+ALTER TABLE t1 DROP INDEX i1, DROP INDEX i2, DROP INDEX i3, DROP INDEX i4;
+SET DEBUG_SYNC = 'RESET';
+SET DEBUG_SYNC = 'row_log_apply_before SIGNAL ddl_parked WAIT_FOR ddl_resume';
+ALTER TABLE t1 ADD INDEX i1(b), ADD INDEX i2(c), ADD INDEX i3(d), ADD INDEX i4(e), ALGORITHM=INPLACE, LOCK=NONE;
+SET DEBUG_SYNC = 'now WAIT_FOR ddl_parked';
+SET DEBUG_SYNC = 'now SIGNAL ddl_resume';
+ALTER TABLE t1 DROP INDEX i1, DROP INDEX i2, DROP INDEX i3, DROP INDEX i4;
+SET DEBUG_SYNC = 'RESET';
+SET DEBUG_SYNC = 'row_log_apply_before SIGNAL ddl_parked WAIT_FOR ddl_resume';
+ALTER TABLE t1 ADD INDEX i1(b), ADD INDEX i2(c), ADD INDEX i3(d), ADD INDEX i4(e), ALGORITHM=INPLACE, LOCK=NONE;
+SET DEBUG_SYNC = 'now WAIT_FOR ddl_parked';
+SET DEBUG_SYNC = 'now SIGNAL ddl_resume';
+ALTER TABLE t1 DROP INDEX i1, DROP INDEX i2, DROP INDEX i3, DROP INDEX i4;
+SET DEBUG_SYNC = 'RESET';
+SET DEBUG_SYNC = 'row_log_apply_before SIGNAL ddl_parked WAIT_FOR ddl_resume';
+ALTER TABLE t1 ADD INDEX i1(b), ADD INDEX i2(c), ADD INDEX i3(d), ADD INDEX i4(e), ALGORITHM=INPLACE, LOCK=NONE;
+SET DEBUG_SYNC = 'now WAIT_FOR ddl_parked';
+SET DEBUG_SYNC = 'now SIGNAL ddl_resume';
+ALTER TABLE t1 DROP INDEX i1, DROP INDEX i2, DROP INDEX i3, DROP INDEX i4;
+SET DEBUG_SYNC = 'RESET';
+SET DEBUG_SYNC = 'row_log_apply_before SIGNAL ddl_parked WAIT_FOR ddl_resume';
+ALTER TABLE t1 ADD INDEX i1(b), ADD INDEX i2(c), ADD INDEX i3(d), ADD INDEX i4(e), ALGORITHM=INPLACE, LOCK=NONE;
+SET DEBUG_SYNC = 'now WAIT_FOR ddl_parked';
+SET DEBUG_SYNC = 'now SIGNAL ddl_resume';
+ALTER TABLE t1 DROP INDEX i1, DROP INDEX i2, DROP INDEX i3, DROP INDEX i4;
+SET DEBUG_SYNC = 'RESET';
+SET DEBUG_SYNC = 'row_log_apply_before SIGNAL ddl_parked WAIT_FOR ddl_resume';
+ALTER TABLE t1 ADD INDEX i1(b), ADD INDEX i2(c), ADD INDEX i3(d), ADD INDEX i4(e), ALGORITHM=INPLACE, LOCK=NONE;
+SET DEBUG_SYNC = 'now WAIT_FOR ddl_parked';
+SET DEBUG_SYNC = 'now SIGNAL ddl_resume';
+ALTER TABLE t1 DROP INDEX i1, DROP INDEX i2, DROP INDEX i3, DROP INDEX i4;
+SET DEBUG_SYNC = 'RESET';
+SET DEBUG_SYNC = 'row_log_apply_before SIGNAL ddl_parked WAIT_FOR ddl_resume';
+ALTER TABLE t1 ADD INDEX i1(b), ADD INDEX i2(c), ADD INDEX i3(d), ADD INDEX i4(e), ALGORITHM=INPLACE, LOCK=NONE;
+SET DEBUG_SYNC = 'now WAIT_FOR ddl_parked';
+SET DEBUG_SYNC = 'now SIGNAL ddl_resume';
+ALTER TABLE t1 DROP INDEX i1, DROP INDEX i2, DROP INDEX i3, DROP INDEX i4;
+SET DEBUG_SYNC = 'RESET';
+SET DEBUG_SYNC = 'row_log_apply_before SIGNAL ddl_parked WAIT_FOR ddl_resume';
+ALTER TABLE t1 ADD INDEX i1(b), ADD INDEX i2(c), ADD INDEX i3(d), ADD INDEX i4(e), ALGORITHM=INPLACE, LOCK=NONE;
+SET DEBUG_SYNC = 'now WAIT_FOR ddl_parked';
+SET DEBUG_SYNC = 'now SIGNAL ddl_resume';
+ALTER TABLE t1 DROP INDEX i1, DROP INDEX i2, DROP INDEX i3, DROP INDEX i4;
+SET DEBUG_SYNC = 'RESET';
+SET DEBUG_SYNC = 'row_log_apply_before SIGNAL ddl_parked WAIT_FOR ddl_resume';
+ALTER TABLE t1 ADD INDEX i1(b), ADD INDEX i2(c), ADD INDEX i3(d), ADD INDEX i4(e), ALGORITHM=INPLACE, LOCK=NONE;
+SET DEBUG_SYNC = 'now WAIT_FOR ddl_parked';
+SET DEBUG_SYNC = 'now SIGNAL ddl_resume';
+ALTER TABLE t1 DROP INDEX i1, DROP INDEX i2, DROP INDEX i3, DROP INDEX i4;
+SET DEBUG_SYNC = 'RESET';
+# The table survived the concurrent builders.
+SELECT COUNT(*) FROM t1;
+COUNT(*)
+1024
+#
+# Part 3: the serialization must not span connections.
+#
+CREATE TABLE t2 (a INT PRIMARY KEY, b INT) ENGINE=InnoDB;
+INSERT INTO t2 SELECT a, b FROM t1;
+SET SESSION innodb_ddl_threads = 4;
+SET DEBUG_SYNC = 'row_log_apply_before SIGNAL ddl1_parked WAIT_FOR ddl1_resume';
+ALTER TABLE t1 ADD INDEX i1(b), ALGORITHM=INPLACE, LOCK=NONE;
+SET DEBUG_SYNC = 'now WAIT_FOR ddl1_parked';
+SET DEBUG_SYNC = 'row_log_apply_before SIGNAL ddl2_parked WAIT_FOR ddl2_resume';
+ALTER TABLE t2 ADD INDEX j1(b), ALGORITHM=INPLACE, LOCK=NONE;
+# ddl1 is parked inside row_log_apply_before. ddl2 has to be able to
+# reach the very same sync point; this times out if the two statements
+# are serialized against each other instead of per THD.
+SET DEBUG_SYNC = 'now WAIT_FOR ddl2_parked';
+SET DEBUG_SYNC = 'now SIGNAL ddl1_resume';
+SET DEBUG_SYNC = 'now SIGNAL ddl2_resume';
+# Both statements completed.
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` int NOT NULL,
+  `b` int DEFAULT NULL,
+  `c` int DEFAULT NULL,
+  `d` int DEFAULT NULL,
+  `e` int DEFAULT NULL,
+  PRIMARY KEY (`a`),
+  KEY `i1` (`b`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SHOW CREATE TABLE t2;
+Table	Create Table
+t2	CREATE TABLE `t2` (
+  `a` int NOT NULL,
+  `b` int DEFAULT NULL,
+  PRIMARY KEY (`a`),
+  KEY `j1` (`b`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SELECT COUNT(*) FROM t1;
+COUNT(*)
+1024
+SELECT COUNT(*) FROM t2;
+COUNT(*)
+1024
+#
+# Cleanup
+#
+SET DEBUG_SYNC = 'RESET';
+DROP TABLE t1, t2;

--- a/mysql-test/suite/innodb/t/ddl_debug_sync_race.test
+++ b/mysql-test/suite/innodb/t/ddl_debug_sync_race.test
@@ -1,0 +1,172 @@
+####################################################################
+# debug_sync race between the parallel DDL threads.
+#
+# The tasks that drive ddl::Builder are taken off a shared queue by
+# whichever DDL thread is free (ddl::Loader::Task_queue::mt_execute()),
+# so an ALTER that builds several indexes runs their
+# setup_sort()/btree_build()/finalize() concurrently - and every one of
+# those threads executes the builder's sync points on the *same* THD,
+# the connection's, since that is what ddl::Context::thd() returns.
+#
+# debug_sync() is not thread safe; it assumes a sync point is only ever
+# hit by the thread owning the THD. Two DDL threads inside one sync
+# point corrupt thd->debug_sync_control: they race on the activation
+# count, on the removal of the action and on the clearing of the signal
+# they woke up on.
+#
+# Part 1 is the deterministic one: two builders of one ALTER wait in
+# row_log_apply_before at the same time, one of them consumes and
+# clears the signal that releases both, and the other is left waiting
+# for a signal that no longer exists - the ALTER never finishes.
+#
+# Part 2 is a stress: four builders repeatedly meet in the same sync
+# point with a single activation armed. This is the interleaving that
+# kills a debug server outright with
+#
+#   sql/debug_sync.cc: Assertion `action->activation_count' failed
+#
+# in debug_sync_execute(), but the window is only the few instructions
+# between debug_sync() testing the count and debug_sync_execute()
+# decrementing it, so it is not reproduced on every run.
+#
+# Part 3 pins down the *shape* of the fix rather than the crash: the
+# serialization has to be per THD. While one connection is parked
+# inside the sync point, another connection's DDL must still be able to
+# reach it. Serializing all statements against each other deadlocks
+# that, and would hang e.g. innodb.innodb-index-online-purge.
+####################################################################
+
+--source include/have_debug.inc
+--source include/have_debug_sync.inc
+
+CREATE TABLE t1 (a INT PRIMARY KEY, b INT, c INT, d INT, e INT) ENGINE=InnoDB;
+
+INSERT INTO t1 VALUES (1,1,1,1,1);
+--disable_query_log
+--let $rows = 10
+while ($rows)
+{
+  INSERT INTO t1 SELECT a + (SELECT MAX(a) FROM t1), b, c, d, e FROM t1;
+  --dec $rows
+}
+--enable_query_log
+
+--connect (ddl1, localhost, root,,)
+# More than one DDL thread is what puts several builders in flight at
+# once; be explicit rather than relying on the default.
+SET SESSION innodb_ddl_threads = 4;
+
+--echo #
+--echo # Part 1: two builders of one ALTER wait in one sync point.
+--echo #
+--echo # EXECUTE 2 lets two of the four builders execute the action. On a
+--echo # server that lets them do so concurrently, both wait for ddl_resume,
+--echo # the first one out clears that signal (the default for WAIT_FOR) and
+--echo # the second one waits for it forever: the ALTER below never returns
+--echo # and both waits below run into their TIMEOUT.
+--echo #
+
+SET DEBUG_SYNC = 'row_log_apply_before SIGNAL ddl_parked WAIT_FOR ddl_resume TIMEOUT 60 EXECUTE 2';
+--send ALTER TABLE t1 ADD INDEX i1(b), ADD INDEX i2(c), ADD INDEX i3(d), ADD INDEX i4(e), ALGORITHM=INPLACE, LOCK=NONE
+
+--connection default
+# One builder at a time: park it, release it, then do the same for the
+# second activation.
+SET DEBUG_SYNC = 'now WAIT_FOR ddl_parked TIMEOUT 60';
+SET DEBUG_SYNC = 'now SIGNAL ddl_resume';
+SET DEBUG_SYNC = 'now WAIT_FOR ddl_parked TIMEOUT 60';
+SET DEBUG_SYNC = 'now SIGNAL ddl_resume';
+
+--connection ddl1
+--reap
+ALTER TABLE t1 DROP INDEX i1, DROP INDEX i2, DROP INDEX i3, DROP INDEX i4;
+
+--connection default
+SET DEBUG_SYNC = 'RESET';
+
+--echo #
+--echo # Part 2: several builders of one ALTER meet in one sync point.
+--echo #
+
+--let $round = 10
+while ($round)
+{
+  --connection default
+  SET DEBUG_SYNC = 'RESET';
+
+  --connection ddl1
+  SET DEBUG_SYNC = 'row_log_apply_before SIGNAL ddl_parked WAIT_FOR ddl_resume';
+  --send ALTER TABLE t1 ADD INDEX i1(b), ADD INDEX i2(c), ADD INDEX i3(d), ADD INDEX i4(e), ALGORITHM=INPLACE, LOCK=NONE
+
+  --connection default
+  # One builder parks here; the other three reach the same sync point
+  # while it does, which is the concurrency being tested.
+  SET DEBUG_SYNC = 'now WAIT_FOR ddl_parked';
+  SET DEBUG_SYNC = 'now SIGNAL ddl_resume';
+
+  --connection ddl1
+  --reap
+  ALTER TABLE t1 DROP INDEX i1, DROP INDEX i2, DROP INDEX i3, DROP INDEX i4;
+
+  --dec $round
+}
+
+--connection default
+SET DEBUG_SYNC = 'RESET';
+
+--echo # The table survived the concurrent builders.
+SELECT COUNT(*) FROM t1;
+
+--echo #
+--echo # Part 3: the serialization must not span connections.
+--echo #
+
+CREATE TABLE t2 (a INT PRIMARY KEY, b INT) ENGINE=InnoDB;
+INSERT INTO t2 SELECT a, b FROM t1;
+
+--connect (ddl2, localhost, root,,)
+SET SESSION innodb_ddl_threads = 4;
+
+--connection ddl1
+SET DEBUG_SYNC = 'row_log_apply_before SIGNAL ddl1_parked WAIT_FOR ddl1_resume';
+--send ALTER TABLE t1 ADD INDEX i1(b), ALGORITHM=INPLACE, LOCK=NONE
+
+--connection default
+SET DEBUG_SYNC = 'now WAIT_FOR ddl1_parked';
+
+--connection ddl2
+SET DEBUG_SYNC = 'row_log_apply_before SIGNAL ddl2_parked WAIT_FOR ddl2_resume';
+--send ALTER TABLE t2 ADD INDEX j1(b), ALGORITHM=INPLACE, LOCK=NONE
+
+--connection default
+--echo # ddl1 is parked inside row_log_apply_before. ddl2 has to be able to
+--echo # reach the very same sync point; this times out if the two statements
+--echo # are serialized against each other instead of per THD.
+SET DEBUG_SYNC = 'now WAIT_FOR ddl2_parked';
+
+SET DEBUG_SYNC = 'now SIGNAL ddl1_resume';
+SET DEBUG_SYNC = 'now SIGNAL ddl2_resume';
+
+--connection ddl1
+--reap
+
+--connection ddl2
+--reap
+
+--connection default
+--echo # Both statements completed.
+SHOW CREATE TABLE t1;
+SHOW CREATE TABLE t2;
+SELECT COUNT(*) FROM t1;
+SELECT COUNT(*) FROM t2;
+
+--echo #
+--echo # Cleanup
+--echo #
+
+--disconnect ddl1
+--disconnect ddl2
+
+--connection default
+SET DEBUG_SYNC = 'RESET';
+DROP TABLE t1, t2;

--- a/storage/innobase/ddl/ddl0builder.cc
+++ b/storage/innobase/ddl/ddl0builder.cc
@@ -30,6 +30,7 @@ this program; if not, write to the Free Software Foundation, Inc.,
 Created 2020-11-01 by Sunny Bains. */
 
 #include <debug_sync.h>
+#include <mutex>
 #include "clone0api.h"
 #include "ddl0fts.h"
 #include "ddl0impl-builder.h"
@@ -45,6 +46,53 @@ Created 2020-11-01 by Sunny Bains. */
 #include "ut0stage.h"
 
 namespace ddl {
+
+#if defined(ENABLED_DEBUG_SYNC)
+/** Execute a sync point on the DDL context's THD, serialized against the other
+DDL threads sharing that THD.
+
+The tasks that run the builder state machine (Task::operator()) are pulled off
+a shared queue by whichever DDL thread is free, see
+Loader::Task_queue::mt_execute(). An ALTER that builds several indexes
+therefore runs setup_sort()/btree_build()/finalize() for different builders at
+the same time, on different threads, and the sort tasks of a single builder
+are parallel by design. All of those threads pass the *same* THD - the owning
+connection's, m_ctx.thd() - to DEBUG_SYNC, and the worker threads do not even
+have a current_thd (Loader::load() clears it).
+
+debug_sync() does no locking of its own: the facility assumes a sync point is
+only ever hit by the thread owning the THD. It tests action->activation_count
+and only then calls debug_sync_execute(), which asserts the very same thing
+before decrementing it, and removes the action, unsynchronized, once the count
+reaches zero. Two DDL threads racing there corrupt thd->debug_sync_control:
+the server either dies on
+
+  sql/debug_sync.cc: Assertion `action->activation_count' failed
+
+or leaves a DDL thread waiting inside a sync point for a signal that has
+already been consumed, hanging the ALTER.
+
+Take the context's mutex, so the first thread executes the action and the
+ones behind it find it already gone and return without touching the control
+block. The lock is per context, i.e. per DDL statement and hence per THD, and
+must stay that way: a DDL parked inside a sync point may only be released by
+a signal that arrives after another connection's DDL has reached the same
+sync point, so a lock shared between statements would deadlock them.
+
+The mutex is only taken when debug sync is armed, mirroring the DEBUG_SYNC
+macro's own fast path, and the whole thing compiles away without DEBUG_SYNC. */
+#define DDL_DEBUG_SYNC(_ctx_, _sync_point_name_)                           \
+  do {                                                                     \
+    if (unlikely(opt_debug_sync_timeout)) {                                \
+      const std::lock_guard<std::mutex> guard{(_ctx_).m_debug_sync_mutex}; \
+      DEBUG_SYNC((_ctx_).thd(), _sync_point_name_);                        \
+    }                                                                      \
+  } while (false)
+#else
+#define DDL_DEBUG_SYNC(_ctx_, _sync_point_name_) \
+  do {                                           \
+  } while (false)
+#endif /* defined(ENABLED_DEBUG_SYNC) */
 
 /** Context for copying cluster index row for the index to being created. */
 struct Copy_ctx {
@@ -1776,7 +1824,7 @@ dberr_t Builder::check_duplicates(Thread_ctxs &dupcheck) noexcept {
 dberr_t Builder::btree_build() noexcept {
   ut_a(!is_skip_file_sort());
 
-  DEBUG_SYNC(m_ctx.thd(), "ddl_btree_build_interrupt");
+  DDL_DEBUG_SYNC(m_ctx, "ddl_btree_build_interrupt");
   if (m_local_stage != nullptr) {
     m_local_stage->begin_phase_insert();
   }
@@ -1991,11 +2039,11 @@ void Builder::finalize() noexcept {
   if (err == DB_SUCCESS) {
     write_redo(m_index);
 
-    DEBUG_SYNC(m_ctx.thd(), "row_log_apply_before");
+    DDL_DEBUG_SYNC(m_ctx, "row_log_apply_before");
 
     err = row_log_apply(m_ctx.m_trx, m_index, m_ctx.m_table, m_local_stage);
 
-    DEBUG_SYNC(m_ctx.thd(), "row_log_apply_after");
+    DDL_DEBUG_SYNC(m_ctx, "row_log_apply_after");
   }
 
   if (err != DB_SUCCESS) {
@@ -2044,7 +2092,7 @@ dberr_t Builder::setup_sort() noexcept {
   ut_a(!is_skip_file_sort());
   ut_a(get_state() == State::SETUP_SORT);
 
-  DEBUG_SYNC(m_ctx.thd(), "ddl_merge_sort_interrupt");
+  DDL_DEBUG_SYNC(m_ctx, "ddl_merge_sort_interrupt");
 
   const auto err = create_merge_sort_tasks();
 

--- a/storage/innobase/include/ddl0ddl.h
+++ b/storage/innobase/include/ddl0ddl.h
@@ -31,6 +31,8 @@ this program; if not, write to the Free Software Foundation, Inc.,
 #ifndef ddl0ddl_h
 #define ddl0ddl_h
 
+#include <mutex>
+
 #include "fts0fts.h"
 #include "lock0types.h"
 #include "os0file.h"
@@ -530,6 +532,23 @@ struct Context {
 
   /** @return the server session/connection context. */
   [[nodiscard]] THD *thd() noexcept;
+
+#if defined(ENABLED_DEBUG_SYNC)
+  /** Serializes the sync points that the builders execute on thd().
+
+  The tasks driving the builder state machine are picked up by whichever DDL
+  thread is free, so an ALTER building several indexes runs them concurrently,
+  and all of those threads hand the same THD - this context's - to
+  DEBUG_SYNC. debug_sync() does no locking of its own; it assumes a sync point
+  is only ever hit by the thread owning the THD.
+
+  This mutex is deliberately per-context, i.e. per DDL statement and hence per
+  THD: threads sharing a THD must not enter debug_sync() together, while
+  concurrent DDLs from other connections must stay independent - one of them
+  may be parked inside a sync point waiting for a signal that only arrives
+  after another connection's DDL has reached the very same sync point. */
+  std::mutex m_debug_sync_mutex{};
+#endif /* defined(ENABLED_DEBUG_SYNC) */
 
   /** Copy the added columns dtuples so that we don't use the same
   column data buffer for the added column across multiple threads.


### PR DESCRIPTION
### What does this change do?

Serializes the four `DEBUG_SYNC` calls in `storage/innobase/ddl/ddl0builder.cc`
with a per-`ddl::Context` mutex, so the parallel DDL threads that share the
connection's `THD` cannot execute one debug sync action at the same time.

### Why is it needed?

The tasks driving `ddl::Builder` are pulled off a shared queue by whichever DDL
thread is free (`ddl::Loader::Task_queue::mt_execute()`), so an online ALTER
building several indexes runs `setup_sort()` / `btree_build()` / `finalize()`
concurrently, and every one of those threads passes the *same* THD -
`ddl::Context::thd()` - to `DEBUG_SYNC`. `debug_sync()` does no locking; it
assumes a sync point is only ever hit by the thread owning the THD.

On a 9.7.2 debug build an ALTER that adds four indexes with
`innodb_ddl_threads = 4`, with `row_log_apply_before` armed, kills the server:

```
mysqld: sql/debug_sync.cc:946: void debug_sync_remove_action(
st_debug_sync_control*, st_debug_sync_action*):
Assertion `dsp_idx < ds_control->ds_active' failed.
 #10 debug_sync_remove_action        sql/debug_sync.cc:946
 #11 debug_sync                      sql/debug_sync.cc:1951
 #12 ddl::Builder::finalize          storage/innobase/ddl/ddl0builder.cc:1994
 #13 ddl::Builder::finish            storage/innobase/ddl/ddl0builder.cc:2086
 #14 ddl::Loader::Task::operator()   storage/innobase/ddl/ddl0builder.cc:2180
 #15 ddl::Loader::Task_queue::mt_execute  storage/innobase/ddl/ddl0loader.cc:178
```

Every step of `debug_sync()` races when two threads share the THD, and each has
its own symptom:

* both threads pass the `action->activation_count` test, then the first consumes
  the last activation while the second is entering `debug_sync_execute()` -
  `Assertion 'action->activation_count' failed`;
* both then find `activation_count == 0` on the way out and both call
  `debug_sync_remove_action()` on the same action - the assertion in the stack
  above;
* `WAIT_FOR` clears the signal it woke up on unless `NO_CLEAR_EVENT` is given,
  so with two threads waiting on one action the first one out clears the event
  and the second waits for a signal that no longer exists - the ALTER hangs.

The commit message contains a DBUG trace
(`--debug=d,debug_sync,debug_sync_exec,debug_sync_point:i:o`) showing two DDL
threads inside the one sync point on the one THD, with the second never
resuming.

The mutex is deliberately per context, i.e. per DDL statement and hence per THD.
A single file-static mutex instead hangs `innodb.innodb-index-online-purge`,
which parks one DDL inside `row_log_apply_before` and only releases it after a
second, independent DDL has reached the same sync point. It is taken only when
debug sync is armed, mirroring the `DEBUG_SYNC` macro's own
`opt_debug_sync_timeout` fast path, and the whole construct compiles away
without `ENABLED_DEBUG_SYNC`, so release builds are unaffected.

### How was it tested?

- [x] Added/updated MTR tests under `mysql-test/`
- [ ] `scripts/ci/mtr.sh` passes locally
- [x] Ran the relevant full suite (name it): every existing test using these
      sync points - `innodb.innodb-alter-varchar-debug`,
      `innodb.innodb-index-online`, `innodb.innodb-index-online-purge`,
      `innodb.virtual_debug`, `innodb.bulk_create_index_online`,
      `innodb.ddl_kill`, `innodb.index-create-dml-rollback`,
      `gcol.gcol_rollback`, plus `innodb.innodb-alter-debug` and
      `innodb.innodb-alter-nullable`

New test `innodb.ddl_debug_sync_race`, in three parts: a reproducer that arms
the sync point with two activations so two builders of one ALTER meet in it, a
stress with a single activation (the shape that hits the
`action->activation_count` assertion in the field), and a check that the
serialization does not span connections.

Measured on a 9.7.2 debug build (gcc 15, `CMAKE_BUILD_TYPE=Debug`): unpatched,
the new test crashed the server with the assertion above 5 times in a
`--repeat=24 --parallel=8` run and hung in others; patched, the same run passes
24/24.

Re-verified on `trunk` (06a5c1c9) after the rebase, same build configuration:
the same `--repeat=24 --parallel=8` run passes 24/24 with the patch, and all
ten existing tests listed above pass. The four sync points and the surrounding
builder code are identical to 9.7.2 there, so the unpatched failure modes apply
unchanged; the crash counts quoted above were measured on the 9.7.2 build.

### Contributor checklist

- [x] I have signed the [OCA](https://oca.opensource.oracle.com) with the email on these commits
- [x] Code is formatted (`scripts/ci/format.sh`)
- [x] Commits are focused with descriptive messages

### AI assistance

- [ ] I did not use AI assistance for this contribution
- [x] I used AI assistance for this contribution

Claude Code was used to reproduce the failure, analyse the debug_sync control
block races, write the MTR test and draft this description. The diagnosis was
confirmed against a DBUG trace of the running server, and every claim about
pass/fail behaviour above comes from actual patched and unpatched builds of
9.7.2 rather than from inspection.

### Areas touched

innodb (DDL), mysql-test
