### PR TITLE
Standardize SQL syntax in binlog.test

### DIFF
--- a/mysql-test/common/binlog/binlog.test
+++ b/mysql-test/common/binlog/binlog.test
@@ -2,29 +2,29 @@
 # misc binlogging tests that do not require a slave running
 #
 
--- source include/have_log_bin.inc
--- source include/have_debug.inc
+--source include/have_log_bin.inc
+--source include/have_debug.inc
 
 RESET BINARY LOGS AND GTIDS;
 
-create table t1 (a int) engine=innodb;
-create table t2 (a int) engine=innodb;
-begin;
-insert t1 values (5);
-commit;
-begin;
-insert t2 values (5);
-commit;
+CREATE TABLE t1 (a INT) ENGINE=InnoDB;
+CREATE TABLE t2 (a INT) ENGINE=InnoDB;
+BEGIN;
+INSERT INTO t1 VALUES (5);
+COMMIT;
+BEGIN;
+INSERT INTO t2 VALUES (5);
+COMMIT;
 # first COMMIT must be Query_log_event, second - Xid_log_event
-source include/rpl/deprecated/show_binlog_events.inc;
-drop table t1,t2;
+--source include/rpl/deprecated/show_binlog_events.inc
+DROP TABLE t1, t2;
 
 #
 # binlog rotation after one big transaction
 #
 
 # test requires big transaction, which compression would invalidate
-# so, we are disabling compression explcitly just for this test case.
+# so, we are disabling compression explicitly just for this test case.
 --disable_result_log
 --disable_query_log
 SET @saved_btc = @@session.binlog_transaction_compression;
@@ -32,20 +32,20 @@ SET @@session.binlog_transaction_compression = FALSE;
 --enable_result_log
 --enable_query_log
 
-reset binary logs and gtids;
+RESET BINARY LOGS AND GTIDS;
 let $1=100;
 
-create table t1 (n int) engine=innodb;
-begin;
+CREATE TABLE t1 (n INT) ENGINE=InnoDB;
+BEGIN;
 --disable_query_log
 while ($1)
 {
- eval insert into t1 values($1 + 4);
- dec $1;
+  eval INSERT INTO t1 VALUES($1 + 4);
+  dec $1;
 }
 --enable_query_log
-commit;
-drop table t1;
+COMMIT;
+DROP TABLE t1;
 --source include/rpl/deprecated/show_binlog_events.inc
 --let $binlog_file= query_get_value(SHOW BINARY LOG STATUS, File, 1)
 --source include/rpl/deprecated/show_binlog_events.inc
@@ -64,34 +64,34 @@ SET @@session.binlog_transaction_compression = @saved_btc;
 
 # the following tests will show that certain queries now return
 # absolute offsets (from binlog start, rather than relative to
-# the beginning of the current transaction).  under what
+# the beginning of the current transaction). under what
 # conditions it should be allowed / is sensible to put the
 # slider into the middle of a transaction is not our concern
 # here; we just guarantee that if and when it's done, the
-# user has valid offsets to use.  if the setter function still
+# user has valid offsets to use. if the setter function still
 # wants to throw a "positioning into middle of transaction"
 # warning, that's its prerogative and handled elsewhere.
 
-set @ac = @@autocommit;
+SET @ac = @@autocommit;
 
 # first show this to work for SHOW BINLOG EVENTS
 
-set autocommit= 0;
-reset binary logs and gtids;
-create table t1(n int) engine=innodb;
-begin;
-insert into t1 values (1);
-insert into t1 values (2);
-insert into t1 values (3);
-commit;
-drop table t1;
+SET autocommit= 0;
+RESET BINARY LOGS AND GTIDS;
+CREATE TABLE t1(n INT) ENGINE=InnoDB;
+BEGIN;
+INSERT INTO t1 VALUES (1);
+INSERT INTO t1 VALUES (2);
+INSERT INTO t1 VALUES (3);
+COMMIT;
+DROP TABLE t1;
 --source include/rpl/deprecated/show_binlog_events.inc
 
 # now show that nothing breaks if we need to read from the cache more
 # than once, resulting in split event-headers
 
 # test requires big transaction, which compression would invalidate
-# so, we are disabling compression explcitly just for this test case.
+# so, we are disabling compression explicitly just for this test case.
 --disable_result_log
 --disable_query_log
 SET @saved_btc = @@session.binlog_transaction_compression;
@@ -99,34 +99,34 @@ SET @@session.binlog_transaction_compression = FALSE;
 --enable_result_log
 --enable_query_log
 
-set @bcs = @@binlog_cache_size;
-set global binlog_cache_size=4096;
-reset binary logs and gtids;
+SET @bcs = @@binlog_cache_size;
+SET GLOBAL binlog_cache_size=4096;
+RESET BINARY LOGS AND GTIDS;
 
-create table t1 (a int, b char(255)) engine=innodb;
+CREATE TABLE t1 (a INT, b CHAR(255)) ENGINE=InnoDB;
 
-flush status;
-show status like "binlog_cache_use";
+FLUSH STATUS;
+SHOW STATUS LIKE "binlog_cache_use";
 
 let $1=100;
-disable_query_log;
-begin;
+--disable_query_log
+BEGIN;
 while ($1)
 {
- eval insert into t1 values( $1, 'just to fill void to make transaction occupying at least two buffers of the trans cache' );
- dec $1;
+  eval INSERT INTO t1 VALUES( $1, 'just to fill void to make transaction occupying at least two buffers of the trans cache' );
+  dec $1;
 }
-commit;
+COMMIT;
 --echo *** the following must show the counter value = 1 ***
-show status like "binlog_cache_use";
-enable_query_log;
+SHOW STATUS LIKE "binlog_cache_use";
+--enable_query_log
 
 --source include/rpl/deprecated/show_binlog_events.inc
 
-drop table t1;
+DROP TABLE t1;
 
-set global binlog_cache_size=@bcs;
-set session autocommit = @ac;
+SET GLOBAL binlog_cache_size=@bcs;
+SET SESSION autocommit = @ac;
 --disable_result_log
 --disable_query_log
 SET @@session.binlog_transaction_compression = @saved_btc;
@@ -137,16 +137,16 @@ SET @@session.binlog_transaction_compression = @saved_btc;
 # Bug#33798: prepared statements improperly handle large unsigned ints
 #
 --disable_warnings
-drop table if exists t1;
+DROP TABLE IF EXISTS t1;
 --enable_warnings
-reset binary logs and gtids;
-create table t1 (a bigint unsigned, b bigint(20) unsigned);
-prepare stmt from "insert into t1 values (?,?)";
-set @a= 9999999999999999;
-set @b= 14632475938453979136;
-execute stmt using @a, @b;
-deallocate prepare stmt;
-drop table t1;
+RESET BINARY LOGS AND GTIDS;
+CREATE TABLE t1 (a BIGINT UNSIGNED, b BIGINT UNSIGNED);
+PREPARE stmt FROM "insert into t1 values (?,?)";
+SET @a= 9999999999999999;
+SET @b= 14632475938453979136;
+EXECUTE stmt USING @a, @b;
+DEALLOCATE PREPARE stmt;
+DROP TABLE t1;
 --source include/rpl/deprecated/show_binlog_events.inc
 
 
@@ -154,7 +154,7 @@ drop table t1;
 # Bug #39182: Binary log producing incompatible character set query from 
 # stored procedure.
 #
-reset binary logs and gtids;
+RESET BINARY LOGS AND GTIDS;
 CREATE DATABASE bug39182 DEFAULT CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci;
 USE bug39182;
 CREATE TABLE t1 (a VARCHAR(255) COLLATE utf8mb3_unicode_ci)
@@ -181,7 +181,7 @@ END//
 DELIMITER ;//
 
 CALL p1();
-source include/rpl/deprecated/show_binlog_events.inc;
+--source include/rpl/deprecated/show_binlog_events.inc
 
 DROP PROCEDURE p1;
 DROP TABLE t1;
@@ -233,20 +233,20 @@ DROP PROCEDURE p4;
 # Test of a too big SET INSERT_ID: see if the truncated value goes
 # into binlog (right), or the too big value (wrong); we look at the
 # binlog further down with SHOW BINLOG EVENTS.
-reset binary logs and gtids;
-create table t1 (id tinyint auto_increment primary key);
-set insert_id=128;
-insert ignore into t1 values(null);
-select * from t1;
-drop table t1;
+RESET BINARY LOGS AND GTIDS;
+CREATE TABLE t1 (id TINYINT AUTO_INCREMENT PRIMARY KEY);
+SET insert_id=128;
+INSERT IGNORE INTO t1 VALUES(null);
+SELECT * FROM t1;
+DROP TABLE t1;
 
 # bug#22027 
-create table t1 (a int);
-create table if not exists t2 select * from t1;
+CREATE TABLE t1 (a INT);
+CREATE TABLE IF NOT EXISTS t2 SELECT * FROM t1;
 
 # bug#22762
-create temporary table tt1 (a int);
-create table if not exists t3 like tt1;
+CREATE TEMPORARY TABLE tt1 (a INT);
+CREATE TABLE IF NOT EXISTS t3 LIKE tt1;
 
 # BUG#25091 (A DELETE statement to mysql database is not logged with
 # ROW mode format): Checking that some basic operations on tables in
@@ -260,7 +260,7 @@ UPDATE user SET authentication_string='*67092806AE91BFB6BE72DE6C7BE2B7CCA8CFA9DF
 DELETE FROM user WHERE host='localhost' AND user='@#@';
 --enable_warnings
 
-use test;
+USE test;
 
 # Show binlog events on a different connection because it calls
 # `SELECT UUID()` internally, which is marked unsafe. Since there is
@@ -268,15 +268,15 @@ use test;
 # subsequent statements in row format.
 connect (other,localhost,root,,test);
 connection other;
-source include/rpl/deprecated/show_binlog_events.inc;
+--source include/rpl/deprecated/show_binlog_events.inc
 connection default;
 disconnect other;
 
-drop table t1,t2,t3,tt1;
+DROP TABLE t1,t2,t3,tt1;
 
 #Bug #26079 max_binlog_size + innodb = not make new binlog and hang server
 # server should not hang, binlog must rotate in the end
-reset binary logs and gtids;
+RESET BINARY LOGS AND GTIDS;
 
 # temporarily disable compression for this test case, since it needs
 # to create a large binlog to rotate it.
@@ -287,21 +287,21 @@ SET @@session.binlog_transaction_compression = FALSE;
 --enable_result_log
 --enable_query_log
 --disable_warnings
-drop table if exists t3;
+DROP TABLE IF EXISTS t3;
 --enable_warnings
-create table t3 (a int(11) NOT NULL AUTO_INCREMENT, b text, PRIMARY KEY (a) ) engine=innodb;
+CREATE TABLE t3 (a INT NOT NULL AUTO_INCREMENT, b TEXT, PRIMARY KEY (a) ) ENGINE=InnoDB;
 --let $binlog_file1= query_get_value(SHOW BINARY LOG STATUS, File, 1)
 --echo File $binlog_file1
 let $it=4;
 while ($it)
 {
-insert into t3(b) values ('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+INSERT INTO t3(b) VALUES ('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
 dec $it;
 }
 --let $binlog_file2= query_get_value(SHOW BINARY LOG STATUS, File, 1)
 --echo *** show new binlog index after rotating ***
 --echo File $binlog_file2
-drop table t3;
+DROP TABLE t3;
 
 # clean up
 RESET BINARY LOGS AND GTIDS;
@@ -317,7 +317,7 @@ SET @@session.binlog_transaction_compression = @saved_btc;
 CREATE DATABASE test1;
 USE test1;
 DROP DATABASE test1;
-CREATE TABLE test.t1(a int);
+CREATE TABLE test.t1(a INT);
 INSERT INTO test.t1 VALUES (1), (2);
 CREATE TABLE test.t2 SELECT * FROM test.t1;
 USE test;
@@ -412,6 +412,5 @@ SELECT * FROM t1;
 SHOW SESSION VARIABLES LIKE "%_checks";
 
 DROP TABLE t1;
-
 disconnect fresh;
 


### PR DESCRIPTION
Refactor SQL syntax for consistency and clarity in binlog tests.

# Copyright (c) 2026, Oracle and/or its affiliates.
<!-- Thanks for contributing to MySQL Server! The prompts below are the few
     things reviewers always need. Delete any that don't apply. -->

### What does this change do?

<!-- One or two sentences. Link the issue/bug it fixes: "Fixes #1234" or
     "BUG#XXXXXXXX". -->

### Why is it needed?

### How was it tested?

- [x ] Added/updated MTR tests under `mysql-test/`
- [x ] `scripts/ci/mtr.sh` passes locally
- [ x] Ran the relevant full suite (name it): ______

### Contributor checklist

- [x] I have signed the [OCA](https://oca.opensource.oracle.com) with the email on these commits
- [x] Code is formatted (`scripts/ci/format.sh`)
- [ x] Commits are focused with descriptive messages

### AI assistance

- [ ] I did not use AI assistance for this contribution
- [x ] I used AI assistance for this contribution

If AI assistance was used, describe the tool(s) and extent of use:
I used Gemini as an AI code assistant to quickly analyze complex MySQL MTR test scripts, fix formatting and syntax errors, update deprecated data types, and streamline your open-source Git workflow efficiently.

<!-- e.g. brainstorming, code generation, test generation, refactoring, review.
     Also mention which parts were human-reviewed or manually verified. -->

### Areas touched

<!-- e.g. innodb, optimizer, replication, client, build. Helps auto-routing. -->
