### PR TITLE
Add missing perl(lib)/openssl Requires to mysql-community-test package

### DIFF
--- a/packaging/rpm-oel/mysql.spec.in
+++ b/packaging/rpm-oel/mysql.spec.in
@@ -481,6 +481,8 @@ Requires:       perl(POSIX)
 Requires:       perl(Sys::Hostname)
 Requires:       perl(Time::HiRes)
 Requires:       perl(Time::localtime)
+Requires:       perl(lib)
+Requires:       openssl
 %if 0%{?cluster}
 Requires:       %{name}-data-node%{?_isa} >= %{min}
 Requires:       %{name}-management-server%{?_isa} >= %{min}


### PR DESCRIPTION
## Problem

`packaging/rpm-oel/mysql.spec.in`'s `%package test` does not declare
`Requires: perl(lib)` or `Requires: openssl`. A minimal install of
`mysql-community-test` cannot run its own test harness:

```
$ perl mysql-test-run.pl --help
Can't locate lib.pm in @INC (you may need to install the lib module)
at mysql-test-run.pl line 41.
BEGIN failed--compilation aborted at mysql-test-run.pl line 41.
```

`mysql-test-run.pl` uses `perl(lib)` (`use lib`) at compile time and
shells out to the `openssl` CLI for feature detection. `rpm -qR
mysql-community-test` confirms neither is declared; only library
soname requires are present.

## Fix

```diff
--- a/packaging/rpm-oel/mysql.spec.in
+++ b/packaging/rpm-oel/mysql.spec.in
@@ -481,6 +481,8 @@
 Requires:       perl(Sys::Hostname)
 Requires:       perl(Time::HiRes)
 Requires:       perl(Time::localtime)
+Requires:       perl(lib)
+Requires:       openssl
 %if 0%{?cluster}
 Requires:       %{name}-data-node%{?_isa} >= %{min}
 Requires:       %{name}-management-server%{?_isa} >= %{min}
```

`perl(lib)` is a capability, not a literal package name, so it
resolves correctly on el8, el9, and el10 alike. `openssl` is the
correct package name on all three.

**This must also be applied to the 9.7 and 8.4 LTS trees.**

Question: Am I expected to create a PR for each branch? That workflow is not 100% clear to me.
It would be good to answer this so I know expected contributor behaviour.

## What does this change do?

Add both missing packages as explicit Requires: in RPM packaging.

## Testing

Tested RPM build on OL10. With this patch the missing dependency is
resolved.  OL8, OL9 exhibit the same behaviour and the same fix there will resolve it there.

Used https://github.com/sjmudd/mysql-rpm-builder tooling to do this.

## Why is it needed?

RPM packaging should explicitly define dependencies. This is not done here.

## Contributor checklist

- [N/A] Code is formatted (`scripts/ci/format.sh`)
- [X] Commits are focused with descriptive messages

## AI assistance

- [ ] I did not use AI assistance for this contribution
- [X] I used AI assistance for this contribution

Other work I was doing noticed the missing packages. AI saved me doing some of the work.

## Areas touched

RPM Packaging for RHEL/OL variants. Not touched others.