### PR TITLE
Defer Memory Allocation of AHI Hash Tables Until AHI Is Enabled

### DIFF
--- a/mysql-test/suite/innodb/include/get_ahi_hash_table_status.inc
+++ b/mysql-test/suite/innodb/include/get_ahi_hash_table_status.inc
@@ -1,0 +1,6 @@
+# The AHI hash table cell count and node heap usage are not exposed through a
+# status variable or Performance Schema. SHOW ENGINE INNODB STATUS is the only
+# SQL-visible source for these values, so extract both from its Status text.
+--let $AHI_STATUS=query_get_value(SHOW ENGINE INNODB STATUS, Status, 1)
+--let $AHI_SIZE_VALUE=`SELECT CAST(SUBSTRING_INDEX(SUBSTRING_INDEX("$AHI_STATUS", "Hash table size ", -1), ",", 1) AS UNSIGNED)`
+--let $AHI_NODE_HEAP_USED=`SELECT REGEXP_LIKE("$AHI_STATUS", "node heap has [1-9][0-9]* buffer[(]s[)]")`

--- a/mysql-test/suite/innodb/r/defer_ahi_memory_allocation_until_enable.result
+++ b/mysql-test/suite/innodb/r/defer_ahi_memory_allocation_until_enable.result
@@ -1,0 +1,104 @@
+#
+# AHI starts disabled with minimal hash tables.
+#
+include/assert.inc [AHI hash tables are minimal at startup when AHI is disabled]
+#
+# Prepare a multi-page table while AHI remains disabled.
+#
+CREATE TABLE t1 (
+id INT PRIMARY KEY
+);
+INSERT INTO t1 (id) VALUES (1);
+INSERT INTO t1 (id) SELECT (SELECT MAX(id) FROM t1) + id FROM t1;
+INSERT INTO t1 (id) SELECT (SELECT MAX(id) FROM t1) + id FROM t1;
+INSERT INTO t1 (id) SELECT (SELECT MAX(id) FROM t1) + id FROM t1;
+INSERT INTO t1 (id) SELECT (SELECT MAX(id) FROM t1) + id FROM t1;
+CREATE TABLE t2 (
+id INT PRIMARY KEY,
+c1 CHAR(250) NOT NULL DEFAULT 'a',
+c2 CHAR(250) NOT NULL DEFAULT 'a',
+c3 CHAR(250) NOT NULL DEFAULT 'a',
+c4 CHAR(250) NOT NULL DEFAULT 'a',
+c5 CHAR(250) NOT NULL DEFAULT 'a',
+c6 CHAR(250) NOT NULL DEFAULT 'a',
+c7 CHAR(250) NOT NULL DEFAULT 'a',
+c8 CHAR(250) NOT NULL DEFAULT 'a',
+c9 CHAR(250) NOT NULL DEFAULT 'a'
+);
+INSERT INTO t2 (id) SELECT id FROM t1;
+#
+# Enabling AHI allocates full-sized hash tables.
+#
+SET GLOBAL innodb_adaptive_hash_index = ON;
+include/assert.inc [AHI hash tables expand when AHI is enabled]
+#
+# Enabling AHI again leaves the full-sized hash tables unchanged.
+#
+SET GLOBAL innodb_adaptive_hash_index = ON;
+include/assert.inc [AHI hash tables remain full-sized after repeated enable]
+#
+# Restored hash tables accept entries and serve point lookups.
+#
+SELECT id FROM t2 WHERE id = 8;
+id
+8
+include/assert.inc [Restored AHI hash tables contain hash entries]
+#
+# Disabling a populated AHI releases its node heaps and hash buckets.
+#
+SET GLOBAL innodb_adaptive_hash_index = OFF;
+include/assert.inc [Disabling the populated AHI releases all hash node heaps]
+include/assert.inc [Disabling the populated AHI minimizes its hash tables]
+#
+# Re-enabling AHI after the functional cycle restores its hash tables.
+#
+SET GLOBAL innodb_adaptive_hash_index = ON;
+include/assert.inc [AHI hash tables expand after the functional test cycle]
+#
+# Resizing the buffer pool while AHI is enabled resizes the hash tables.
+#
+SET GLOBAL innodb_buffer_pool_size =
+@@innodb_buffer_pool_size * 2 + @@innodb_buffer_pool_chunk_size;
+include/assert.inc [AHI hash tables resize with the buffer pool when AHI is enabled]
+#
+# Disabling AHI releases the hash table buckets.
+#
+SET GLOBAL innodb_adaptive_hash_index = OFF;
+include/assert.inc [AHI hash tables shrink when AHI is disabled]
+#
+# Disabling AHI again leaves the minimal hash tables unchanged.
+#
+SET GLOBAL innodb_adaptive_hash_index = OFF;
+include/assert.inc [AHI hash tables remain minimal after repeated disable]
+#
+# Repeated AHI state assignments do not report resize failures.
+#
+include/assert_grep.inc [Repeated AHI state assignments do not report resize failures]
+#
+# Resizing the buffer pool while AHI is disabled keeps minimal tables.
+#
+SET GLOBAL innodb_buffer_pool_size = @old_innodb_buffer_pool_size;
+include/assert.inc [AHI hash tables remain minimal after buffer pool resize]
+#
+# Enabling AHI during buffer pool resize restores the hash tables after resize.
+#
+SET GLOBAL debug = '+d,ib_buf_pool_resize_after_disable_ahi';
+SET GLOBAL innodb_buffer_pool_size =
+@@innodb_buffer_pool_size * 2 + @@innodb_buffer_pool_chunk_size;
+SET GLOBAL innodb_adaptive_hash_index = ON;
+include/assert.inc [AHI is requested to be enabled during buffer pool resize]
+include/assert.inc [AHI hash tables remain minimal while buffer pool resize is in progress]
+SET GLOBAL debug = '-d,ib_buf_pool_resize_after_disable_ahi';
+include/assert.inc [AHI hash tables are restored after buffer pool resize completes]
+#
+# Disabling AHI during buffer pool resize minimizes the hash tables after resize.
+#
+SET GLOBAL debug = '+d,ib_buf_pool_resize_after_disable_ahi';
+SET GLOBAL innodb_buffer_pool_size = @old_innodb_buffer_pool_size;
+SET GLOBAL innodb_adaptive_hash_index = OFF;
+include/assert.inc [AHI is requested to be disabled during buffer pool resize]
+include/assert.inc [AHI hash tables remain full-sized while buffer pool resize is in progress]
+SET GLOBAL debug = '-d,ib_buf_pool_resize_after_disable_ahi';
+include/assert.inc [AHI hash tables are minimized after buffer pool resize completes]
+DROP TABLE t1;
+DROP TABLE t2;

--- a/mysql-test/suite/innodb/t/defer_ahi_memory_allocation_until_enable-master.opt
+++ b/mysql-test/suite/innodb/t/defer_ahi_memory_allocation_until_enable-master.opt
@@ -1,0 +1,1 @@
+--innodb-adaptive-hash-index=OFF --innodb-adaptive-hash-index-parts=8 --innodb-buffer-pool-size=24M --innodb-buffer-pool-chunk-size=24M --innodb-buffer-pool-instances=1

--- a/mysql-test/suite/innodb/t/defer_ahi_memory_allocation_until_enable.test
+++ b/mysql-test/suite/innodb/t/defer_ahi_memory_allocation_until_enable.test
@@ -1,0 +1,224 @@
+################################################################################
+# Verify that AHI hash tables use their minimal size while AHI is disabled and
+# are allocated at their normal size only when AHI is enabled. Check the exact
+# per-partition hash table size after startup, AHI state changes, and buffer pool
+# resize operations performed with AHI enabled and disabled.
+################################################################################
+
+--source include/have_innodb_max_16k.inc
+--source include/have_debug.inc
+
+--disable_query_log
+SET @old_innodb_buffer_pool_size = @@innodb_buffer_pool_size;
+--enable_query_log
+
+--echo #
+--echo # AHI starts disabled with minimal hash tables.
+--echo #
+--source suite/innodb/include/get_ahi_hash_table_status.inc
+# ut::find_prime() rounds the requested one cell per partition up to 103 cells.
+--let $assert_text=AHI hash tables are minimal at startup when AHI is disabled
+--let $assert_cond=$AHI_SIZE_VALUE = 103
+--source include/assert.inc
+
+--echo #
+--echo # Prepare a multi-page table while AHI remains disabled.
+--echo #
+CREATE TABLE t1 (
+  id INT PRIMARY KEY
+);
+INSERT INTO t1 (id) VALUES (1);
+INSERT INTO t1 (id) SELECT (SELECT MAX(id) FROM t1) + id FROM t1;
+INSERT INTO t1 (id) SELECT (SELECT MAX(id) FROM t1) + id FROM t1;
+INSERT INTO t1 (id) SELECT (SELECT MAX(id) FROM t1) + id FROM t1;
+INSERT INTO t1 (id) SELECT (SELECT MAX(id) FROM t1) + id FROM t1;
+
+CREATE TABLE t2 (
+  id INT PRIMARY KEY,
+  c1 CHAR(250) NOT NULL DEFAULT 'a',
+  c2 CHAR(250) NOT NULL DEFAULT 'a',
+  c3 CHAR(250) NOT NULL DEFAULT 'a',
+  c4 CHAR(250) NOT NULL DEFAULT 'a',
+  c5 CHAR(250) NOT NULL DEFAULT 'a',
+  c6 CHAR(250) NOT NULL DEFAULT 'a',
+  c7 CHAR(250) NOT NULL DEFAULT 'a',
+  c8 CHAR(250) NOT NULL DEFAULT 'a',
+  c9 CHAR(250) NOT NULL DEFAULT 'a'
+);
+INSERT INTO t2 (id) SELECT id FROM t1;
+
+--echo #
+--echo # Enabling AHI allocates full-sized hash tables.
+--echo #
+SET GLOBAL innodb_adaptive_hash_index = ON;
+--source suite/innodb/include/get_ahi_hash_table_status.inc
+--let $assert_text=AHI hash tables expand when AHI is enabled
+--let $assert_cond=$AHI_SIZE_VALUE = 6329
+--source include/assert.inc
+
+--echo #
+--echo # Enabling AHI again leaves the full-sized hash tables unchanged.
+--echo #
+SET GLOBAL innodb_adaptive_hash_index = ON;
+--source suite/innodb/include/get_ahi_hash_table_status.inc
+--let $assert_text=AHI hash tables remain full-sized after repeated enable
+--let $assert_cond=$AHI_SIZE_VALUE = 6329
+--source include/assert.inc
+
+--echo #
+--echo # Restored hash tables accept entries and serve point lookups.
+--echo #
+--disable_query_log
+--disable_result_log
+--let $i=0
+while ($i < 3000) {
+  SELECT id FROM t2 WHERE id = 8;
+  --inc $i
+}
+--enable_result_log
+--enable_query_log
+SELECT id FROM t2 WHERE id = 8;
+
+--source suite/innodb/include/get_ahi_hash_table_status.inc
+--let $assert_text=Restored AHI hash tables contain hash entries
+--let $assert_cond=$AHI_NODE_HEAP_USED = 1
+--source include/assert.inc
+
+--echo #
+--echo # Disabling a populated AHI releases its node heaps and hash buckets.
+--echo #
+SET GLOBAL innodb_adaptive_hash_index = OFF;
+--source suite/innodb/include/get_ahi_hash_table_status.inc
+--let $assert_text=Disabling the populated AHI releases all hash node heaps
+--let $assert_cond=$AHI_NODE_HEAP_USED = 0
+--source include/assert.inc
+--let $assert_text=Disabling the populated AHI minimizes its hash tables
+--let $assert_cond=$AHI_SIZE_VALUE = 103
+--source include/assert.inc
+
+--echo #
+--echo # Re-enabling AHI after the functional cycle restores its hash tables.
+--echo #
+SET GLOBAL innodb_adaptive_hash_index = ON;
+--source suite/innodb/include/get_ahi_hash_table_status.inc
+--let $assert_text=AHI hash tables expand after the functional test cycle
+--let $assert_cond=$AHI_SIZE_VALUE = 6329
+--source include/assert.inc
+
+--echo #
+--echo # Resizing the buffer pool while AHI is enabled resizes the hash tables.
+--echo #
+SET GLOBAL innodb_buffer_pool_size =
+  @@innodb_buffer_pool_size * 2 + @@innodb_buffer_pool_chunk_size;
+
+--let $wait_timeout=60
+--let $wait_condition=SELECT SUBSTR(variable_value, 1, 9) = 'Completed' FROM performance_schema.global_status WHERE LOWER(variable_name) = 'innodb_buffer_pool_resize_status'
+--source include/wait_condition.inc
+
+--source suite/innodb/include/get_ahi_hash_table_status.inc
+--let $assert_text=AHI hash tables resize with the buffer pool when AHI is enabled
+--let $assert_cond=$AHI_SIZE_VALUE = 18787
+--source include/assert.inc
+
+--echo #
+--echo # Disabling AHI releases the hash table buckets.
+--echo #
+SET GLOBAL innodb_adaptive_hash_index = OFF;
+--source suite/innodb/include/get_ahi_hash_table_status.inc
+--let $assert_text=AHI hash tables shrink when AHI is disabled
+--let $assert_cond=$AHI_SIZE_VALUE = 103
+--source include/assert.inc
+
+--echo #
+--echo # Disabling AHI again leaves the minimal hash tables unchanged.
+--echo #
+SET GLOBAL innodb_adaptive_hash_index = OFF;
+--source suite/innodb/include/get_ahi_hash_table_status.inc
+--let $assert_text=AHI hash tables remain minimal after repeated disable
+--let $assert_cond=$AHI_SIZE_VALUE = 103
+--source include/assert.inc
+
+--echo #
+--echo # Repeated AHI state assignments do not report resize failures.
+--echo #
+--let $assert_file=$MYSQLTEST_VARDIR/log/mysqld.1.err
+--let $assert_select=btr_search_sys_resize failed because
+--let $assert_count=0
+--let $assert_text=Repeated AHI state assignments do not report resize failures
+--source include/assert_grep.inc
+
+--echo #
+--echo # Resizing the buffer pool while AHI is disabled keeps minimal tables.
+--echo #
+SET GLOBAL innodb_buffer_pool_size = @old_innodb_buffer_pool_size;
+
+--let $wait_timeout=60
+--let $wait_condition=SELECT SUBSTR(variable_value, 1, 9) = 'Completed' FROM performance_schema.global_status WHERE LOWER(variable_name) = 'innodb_buffer_pool_resize_status'
+--source include/wait_condition.inc
+
+--source suite/innodb/include/get_ahi_hash_table_status.inc
+--let $assert_text=AHI hash tables remain minimal after buffer pool resize
+--let $assert_cond=$AHI_SIZE_VALUE = 103
+--source include/assert.inc
+
+--echo #
+--echo # Enabling AHI during buffer pool resize restores the hash tables after resize.
+--echo #
+SET GLOBAL debug = '+d,ib_buf_pool_resize_after_disable_ahi';
+SET GLOBAL innodb_buffer_pool_size =
+  @@innodb_buffer_pool_size * 2 + @@innodb_buffer_pool_chunk_size;
+
+--let $wait_timeout=60
+--let $wait_condition=SELECT variable_value = 2 FROM performance_schema.global_status WHERE LOWER(variable_name) = 'innodb_buffer_pool_resize_status_code'
+--source include/wait_condition.inc
+
+SET GLOBAL innodb_adaptive_hash_index = ON;
+--let $assert_text=AHI is requested to be enabled during buffer pool resize
+--let $assert_cond=@@global.innodb_adaptive_hash_index = 1
+--source include/assert.inc
+--source suite/innodb/include/get_ahi_hash_table_status.inc
+--let $assert_text=AHI hash tables remain minimal while buffer pool resize is in progress
+--let $assert_cond=$AHI_SIZE_VALUE = 103
+--source include/assert.inc
+
+SET GLOBAL debug = '-d,ib_buf_pool_resize_after_disable_ahi';
+--let $wait_timeout=60
+--let $wait_condition=SELECT SUBSTR(variable_value, 1, 9) = 'Completed' FROM performance_schema.global_status WHERE LOWER(variable_name) = 'innodb_buffer_pool_resize_status'
+--source include/wait_condition.inc
+
+--source suite/innodb/include/get_ahi_hash_table_status.inc
+--let $assert_text=AHI hash tables are restored after buffer pool resize completes
+--let $assert_cond=$AHI_SIZE_VALUE = 18787
+--source include/assert.inc
+
+--echo #
+--echo # Disabling AHI during buffer pool resize minimizes the hash tables after resize.
+--echo #
+SET GLOBAL debug = '+d,ib_buf_pool_resize_after_disable_ahi';
+SET GLOBAL innodb_buffer_pool_size = @old_innodb_buffer_pool_size;
+
+--let $wait_timeout=60
+--let $wait_condition=SELECT variable_value = 2 FROM performance_schema.global_status WHERE LOWER(variable_name) = 'innodb_buffer_pool_resize_status_code'
+--source include/wait_condition.inc
+
+SET GLOBAL innodb_adaptive_hash_index = OFF;
+--let $assert_text=AHI is requested to be disabled during buffer pool resize
+--let $assert_cond=@@global.innodb_adaptive_hash_index = 0
+--source include/assert.inc
+--source suite/innodb/include/get_ahi_hash_table_status.inc
+--let $assert_text=AHI hash tables remain full-sized while buffer pool resize is in progress
+--let $assert_cond=$AHI_SIZE_VALUE = 18787
+--source include/assert.inc
+
+SET GLOBAL debug = '-d,ib_buf_pool_resize_after_disable_ahi';
+--let $wait_timeout=60
+--let $wait_condition=SELECT SUBSTR(variable_value, 1, 9) = 'Completed' FROM performance_schema.global_status WHERE LOWER(variable_name) = 'innodb_buffer_pool_resize_status'
+--source include/wait_condition.inc
+
+--source suite/innodb/include/get_ahi_hash_table_status.inc
+--let $assert_text=AHI hash tables are minimized after buffer pool resize completes
+--let $assert_cond=$AHI_SIZE_VALUE = 103
+--source include/assert.inc
+
+DROP TABLE t1;
+DROP TABLE t2;

--- a/storage/innobase/btr/btr0sea.cc
+++ b/storage/innobase/btr/btr0sea.cc
@@ -311,7 +311,7 @@ static void btr_search_await_no_reference(dict_table_t *table) {
   }
 }
 
-bool btr_search_disable() {
+bool btr_search_disable(bool minimize_hash_tables) {
   mutex_enter(&btr_search_enabled_mutex);
   if (!btr_search_enabled) {
     mutex_exit(&btr_search_enabled_mutex);
@@ -350,12 +350,19 @@ bool btr_search_disable() {
     mem_heap_empty(hash_table->heap);
   }
 
+  if (minimize_hash_tables) {
+    /* Release the hash buckets while AHI is disabled. Request one cell per
+    partition so that the hash table objects remain valid; ut::find_prime()
+    rounds this up to 103 cells (~824 bytes) per partition. */
+    btr_search_sys_resize(btr_ahi_parts);
+  }
+
   mutex_exit(&btr_search_enabled_mutex);
 
   return true;
 }
 
-bool btr_search_enable() {
+bool btr_search_enable(bool restore_hash_tables) {
   os_rmb;
   /* Don't allow enabling AHI if buffer pool resize is happening.
   Ignore it silently. */
@@ -366,14 +373,33 @@ bool btr_search_enable() {
   re-enable AHI again. */
   mutex_enter(&btr_search_enabled_mutex);
 
-  /* srv_btr_search_enabled stores the desired user-visible sysvar state.
-  Re-check it while holding btr_search_enabled_mutex so buffer pool resize
-  completion cannot re-enable AHI after a concurrent SET GLOBAL ... = OFF. */
-  if (!srv_btr_search_enabled) {
+  /* Make enabling idempotent because repeated SET GLOBAL ... = ON invokes the
+  update callback. This also handles a concurrent SET ... = ON in the window
+  between buffer pool resize publishing its completion and re-enabling AHI. */
+  if (btr_search_enabled) {
     mutex_exit(&btr_search_enabled_mutex);
     return false;
   }
 
+  /* srv_btr_search_enabled stores the desired user-visible sysvar state.
+  Re-check it while holding btr_search_enabled_mutex so buffer pool resize
+  completion cannot re-enable AHI after a concurrent SET GLOBAL ... = OFF. */
+  if (!srv_btr_search_enabled) {
+    if (!restore_hash_tables) {
+      /* If AHI was disabled during buffer pool resizing, request one cell per
+      partition; ut::find_prime() rounds this up to 103 cells (~824 bytes) per
+      partition. */
+      btr_search_sys_resize(btr_ahi_parts);
+    }
+    mutex_exit(&btr_search_enabled_mutex);
+    return false;
+  }
+
+  if (restore_hash_tables) {
+    /* Recreate the full-sized tables immediately before making AHI visible to
+    other threads. */
+    btr_search_sys_resize(buf_pool_get_curr_size() / sizeof(void *) / 64);
+  }
   btr_search_enabled = true;
   mutex_exit(&btr_search_enabled_mutex);
   return true;

--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -1591,7 +1591,12 @@ dberr_t buf_pool_init(ulint total_size, ulint n_instances) {
   buf_pool_set_sizes();
   buf_LRU_old_ratio_update(100 * 3 / 8, false);
 
-  btr_search_sys_create(buf_pool_get_curr_size() / sizeof(void *) / 64);
+  /* Request one cell per AHI partition until AHI is enabled; ut::find_prime()
+  rounds this up to 103 cells (~824 bytes) per partition. */
+  const ulint ahi_hash_size =
+      srv_btr_search_enabled ? buf_pool_get_curr_size() / sizeof(void *) / 64
+                             : btr_ahi_parts;
+  btr_search_sys_create(ahi_hash_size);
 
   buf_stat_per_index = ut::new_withkey<buf_stat_per_index_t>(
       ut::make_psi_memory_key(mem_key_buf_stat_per_index_t));
@@ -2230,8 +2235,10 @@ static void buf_pool_resize() {
   buf_resize_status(BUF_POOL_RESIZE_DISABLE_AHI,
                     "Disabling adaptive hash index.");
 
-  /* disable AHI if needed */
-  if (btr_search_disable()) {
+  /* Keep full-sized AHI hash tables during buffer pool resize. If AHI was
+  enabled, they can be reused or resized once before AHI is re-enabled. */
+  const bool btr_search_was_enabled = btr_search_disable(false);
+  if (btr_search_was_enabled) {
     ib::info(ER_IB_MSG_60) << "disabled adaptive hash index.";
   }
 
@@ -2636,14 +2643,16 @@ withdraw_retry:
     srv_lock_table_size = 5 * (srv_buf_pool_size / UNIV_PAGE_SIZE);
     lock_sys_resize(srv_lock_table_size);
 
-    /* normalize btr_search_sys */
-    btr_search_sys_resize(buf_pool_get_curr_size() / sizeof(void *) / 64);
+    /* Resize the hash tables only when AHI was enabled. */
+    if (btr_search_was_enabled) {
+      btr_search_sys_resize(buf_pool_get_curr_size() / sizeof(void *) / 64);
+
+      ib::info(ER_IB_MSG_68) << "Resized hash tables at lock_sys,"
+                                " adaptive hash index, dictionary.";
+    }
 
     /* normalize dict_sys */
     dict_resize();
-
-    ib::info(ER_IB_MSG_68) << "Resized hash tables at lock_sys,"
-                              " adaptive hash index, dictionary.";
   }
 
   /* normalize ibuf->max_size */
@@ -2658,7 +2667,7 @@ withdraw_retry:
   }
 
   /* enable AHI if needed */
-  if (btr_search_enable()) {
+  if (btr_search_enable(!btr_search_was_enabled)) {
     ib::info(ER_IB_MSG_70) << "Re-enabled adaptive hash index.";
   }
 

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -20988,10 +20988,10 @@ static void innodb_adaptive_hash_index_update(
 {
   if (*(bool *)save) {
     srv_btr_search_enabled = true;
-    btr_search_enable();
+    btr_search_enable(true);
   } else {
     srv_btr_search_enabled = false;
-    btr_search_disable();
+    btr_search_disable(true);
   }
 }
 

--- a/storage/innobase/include/btr0sea.h
+++ b/storage/innobase/include/btr0sea.h
@@ -134,12 +134,16 @@ void btr_search_sys_resize(ulint hash_size);
 void btr_search_sys_free();
 
 /** Disable the adaptive hash search system and empty the index.
+@param[in]      minimize_hash_tables    whether to replace the full-sized hash
+                                        tables with minimal ones
 @returns true if the AHI system was enabled and became disabled. */
-bool btr_search_disable();
+bool btr_search_disable(bool minimize_hash_tables);
 /** Enable the adaptive hash search system if buffer pool resize is not in
 progress and the AHI sysvar is ON.
+@param[in]      restore_hash_tables     whether to restore the hash tables to
+                                        their normal size before enabling AHI
 @returns true if enable was actually performed. */
-bool btr_search_enable();
+bool btr_search_enable(bool restore_hash_tables);
 
 /** Creates and initializes a search info struct.
 @param[in]      heap            heap where created.

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -2830,7 +2830,7 @@ void srv_shutdown() {
 
   /* This must be disabled before closing the buffer pool
   and closing the data dictionary.  */
-  btr_search_disable();
+  btr_search_disable(false);
 
   ibuf_close();
   ddl_log_close();


### PR DESCRIPTION
Problem
=======
The AHI hash tables are initialized at startup even when AHI is disabled. They are initialized with
buf_pool_get_curr_size()/sizeof(void *)/64 cells. Each cell takes 8 bytes. So the total memory they occupy is approximately equal to 1/64 of the buffer pool size. The memory is wasted if AHI is disabled. On large servers, initializing large hash tables slows startup.

Solution
========
This commit initializes the AHI hash tables with one cell per AHI partition if AHI is disabled. The hash tables are restored to their normal size before AHI is enabled.

With one slot existing, the AHI system is fully initialized. This preserves the invariant that the per-partition hash table objects always exist.

During a buffer pool resizing, AHI is temporarily disabled. If AHI was enabled when the resize started, its full-sized hash tables are retained and resized only when necessary, avoiding an unnecessary shrink-and-restore cycle.

<!-- # Copyright (c) 2026, Oracle and/or its affiliates. -->
<!-- Thanks for contributing to MySQL Server! The prompts below are the few
     things reviewers always need. Delete any that don't apply. -->

### What does this change do?

<!-- One or two sentences. Link the issue/bug it fixes: "Fixes #1234" or
     "BUG#XXXXXXXX". -->

https://bugs.mysql.com/bug.php?id=112223

### Why is it needed?
This patch reduces memory usage and startup time when AHI is disabled. AHI has been disabled by default since 8.4 and AHI is not recommended for production use. Therefore, without this commit, most of the server would wastes an amount of memory  approximately equal to 1/64 of buffer pool size.

### How was it tested?

- [X] Added/updated MTR tests under `mysql-test/`
- [X] `scripts/ci/mtr.sh` passes locally
- [ ] Ran the relevant full suite (name it): ______

### Contributor checklist

- [X] Code is formatted (`scripts/ci/format.sh`)
- [X] Commits are focused with descriptive messages

### AI assistance

- [ ] I did not use AI assistance for this contribution
- [X] I used AI assistance for this contribution

If AI assistance was used, describe the tool(s) and extent of use: Port the patch, added more testcases.

<!-- e.g. brainstorming, code generation, test generation, refactoring, review.
     Also mention which parts were human-reviewed or manually verified. -->

### Areas touched

<!-- e.g. innodb, optimizer, replication, client, build. Helps auto-routing. -->
InnoDB