### PR TITLE
Add missing perl(lib)/openssl Requires to mysql-community-test package

### DIFF
--- a/packaging/rpm-oel/mysql.spec.in
+++ b/packaging/rpm-oel/mysql.spec.in
@@ -481,6 +481,8 @@ Requires:       perl(POSIX)
 Requires:       perl(Sys::Hostname)
 Requires:       perl(Time::HiRes)
 Requires:       perl(Time::localtime)
+Requires:       perl(lib)
+Requires:       openssl
 %if 0%{?cluster}
 Requires:       %{name}-data-node%{?_isa} >= %{min}
 Requires:       %{name}-management-server%{?_isa} >= %{min}


### PR DESCRIPTION
See: https://github.com/mysql/mysql-server/pull/728
- applying to 8.4 branch
- all comments in original PR apply here.