### PR TITLE
Bug#121063 Members of one group assign different GNOs to the same transaction

### DIFF
--- a/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/xcom_base.cc
+++ b/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/xcom_base.cc
@@ -1756,6 +1756,15 @@ static void push_msg_3p(site_def const *site, pax_machine *p, pax_msg *msg,
              STRLIT(pax_op_to_str(msg->op)));
 }
 
+/* A reserved synode is only ours while we still hold the node index it was
+   reserved under. A view change that renumbers us hands that slot to another
+   node, which may reserve it as well. */
+static bool_t reservation_is_stale(synode_no msgno) {
+  site_def const *site = find_site_def(msgno);
+  node_no me = site ? get_nodeno(site) : VOID_NODE_NO;
+  return me != VOID_NODE_NO && me != msgno.node;
+}
+
 /* Brand client message with unique ID */
 static void brand_client_msg(pax_msg *msg, synode_no msgno) {
   assert(!synode_eq(msgno, null_synode));
@@ -2519,6 +2528,13 @@ static int proposer_task(task_arg arg) {
     }
 
     brand_client_msg(ep->client_msg->p, ep->msgno);
+
+    /* Only a locally allocated synode carries our own node index; a remote or
+       global allocation carries the allocating leader's, by design. */
+    if (ep->synode_allocation == synode_allocation_type::local &&
+        reservation_is_stale(ep->msgno)) {
+      GOTO(retry_new);
+    }
 
     for (;;) { /* Loop until the client message has been learned */
       /* Get a Paxos instance to send the client message */

--- a/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/xcom_base.cc
+++ b/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/xcom_base.cc
@@ -2529,13 +2529,6 @@ static int proposer_task(task_arg arg) {
 
     brand_client_msg(ep->client_msg->p, ep->msgno);
 
-    /* Only a locally allocated synode carries our own node index; a remote or
-       global allocation carries the allocating leader's, by design. */
-    if (ep->synode_allocation == synode_allocation_type::local &&
-        reservation_is_stale(ep->msgno)) {
-      GOTO(retry_new);
-    }
-
     for (;;) { /* Loop until the client message has been learned */
       /* Get a Paxos instance to send the client message */
 
@@ -2546,8 +2539,8 @@ static int proposer_task(task_arg arg) {
         goto retry_new;
       }
 
-      /* Checked again after wait_for_cache: that call can suspend, and a view
-         change during the wait leaves the reservation stale. */
+      /* wait_for_cache can suspend, and a view change during the wait leaves
+         the reservation stale. */
       if (ep->synode_allocation == synode_allocation_type::local &&
           reservation_is_stale(ep->msgno)) {
         GOTO(retry_new);

--- a/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/xcom_base.cc
+++ b/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/xcom_base.cc
@@ -1759,7 +1759,7 @@ static void push_msg_3p(site_def const *site, pax_machine *p, pax_msg *msg,
 /* A reserved synode is only ours while we still hold the node index it was
    reserved under. A view change that renumbers us hands that slot to another
    node, which may reserve it as well. */
-static bool_t reservation_is_stale(synode_no msgno) {
+bool_t reservation_is_stale(synode_no msgno) {
   site_def const *site = find_site_def(msgno);
   node_no me = site ? get_nodeno(site) : VOID_NODE_NO;
   return me != VOID_NODE_NO && me != msgno.node;
@@ -2544,6 +2544,13 @@ static int proposer_task(task_arg arg) {
         G_INFO("Could not get a pax_machine for msgno %lu. Retrying",
                (unsigned long)ep->msgno.msgno);
         goto retry_new;
+      }
+
+      /* Checked again after wait_for_cache: that call can suspend, and a view
+         change during the wait leaves the reservation stale. */
+      if (ep->synode_allocation == synode_allocation_type::local &&
+          reservation_is_stale(ep->msgno)) {
+        GOTO(retry_new);
       }
 
       assert(ep->p);

--- a/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/xcom_base.h
+++ b/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/xcom_base.h
@@ -70,6 +70,8 @@ void *xcom_thread_main(void *cp);
 
 synode_no incr_synode(synode_no synode);
 
+bool_t reservation_is_stale(synode_no msgno);
+
 synode_no decr_synode(synode_no synode);
 
 char *dbg_pax_msg(pax_msg const *p);

--- a/unittest/gunit/libmysqlgcs/CMakeLists.txt
+++ b/unittest/gunit/libmysqlgcs/CMakeLists.txt
@@ -75,6 +75,7 @@ SET(GCS_XCOM_TESTS
   xcom/gcs_xcom_xcom_transport
   xcom/gcs_xcom_communication_protocol_changer
   xcom/gcs_xcom_xcom_cache
+  xcom/gcs_xcom_stale_reservation
   xcom/gcs_xcom_control_interface
   xcom/gcs_xcom_view_identifier
   xcom/gcs_message_stage_fragmentation

--- a/unittest/gunit/libmysqlgcs/xcom/gcs_xcom_stale_reservation-t.cc
+++ b/unittest/gunit/libmysqlgcs/xcom/gcs_xcom_stale_reservation-t.cc
@@ -35,46 +35,39 @@ namespace xcom_stale_reservation_unittest {
 class XcomStaleReservation : public GcsBaseTest {
  protected:
   void SetUp() override {
-    m_addr = new std::string("127.0.0.1:12345");
-    char const *names[]{m_addr->c_str()};
-    m_na = new_node_address(1, names);
-
     /* The view in force when the synode is reserved: this member is node 1. */
-    m_before = new_site_def();
-    init_site_def(1, m_na, m_before);
-    m_before->start = m_synode_before;
-    m_before->nodeno = 1;
-    push_site_def(m_before);
+    char const *names[]{"127.0.0.1:12341", "127.0.0.1:12342",
+                        "127.0.0.1:12343"};
+    node_address *na = new_node_address(3, names);
 
-    /* The view installed while the reservation is held: the member is now
-       node 0. */
-    m_after = new_site_def();
-    init_site_def(1, m_na, m_after);
-    m_after->start = m_synode_after;
-    m_after->nodeno = 0;
-    push_site_def(m_after);
+    site_def *before = new_site_def();
+    init_site_def(3, na, before);
+    before->start = synode_no{1, 10, 0};
+    before->nodeno = 1;
+    push_site_def(before);
+    delete_node_address(3, na);
   }
 
-  void TearDown() override {
-    push_site_def(nullptr);
-    free_site_defs();
-    delete_node_address(1, m_na);
-    delete m_addr;
+  /* The view installed while the reservation is held: the first member is
+     gone, so this one is now node 0. */
+  void install_new_view() {
+    char const *names[]{"127.0.0.1:12342", "127.0.0.1:12343"};
+    node_address *na = new_node_address(2, names);
+
+    site_def *after = new_site_def();
+    init_site_def(2, na, after);
+    after->start = synode_no{1, 20, 0};
+    after->nodeno = 0;
+    push_site_def(after);
+    delete_node_address(2, na);
   }
 
-  std::string *m_addr{nullptr};
-  node_address *m_na{nullptr};
-  site_def *m_before{nullptr};
-  site_def *m_after{nullptr};
-
-  /* A view is active from its start synode on, so a slot below 20 falls under
-     the old view and one at or above it under the new one. */
-  synode_no const m_synode_before{1, 10, 0};
-  synode_no const m_synode_after{1, 20, 0};
+  void TearDown() override { free_site_defs(); }
 };
 
 /* Under the view it was taken in, the reservation is ours. */
 TEST_F(XcomStaleReservation, reservation_under_the_current_index_is_fresh) {
+  install_new_view();
   synode_no const reserved{1, 15, 1};
   ASSERT_FALSE(reservation_is_stale(reserved));
 }
@@ -82,18 +75,21 @@ TEST_F(XcomStaleReservation, reservation_under_the_current_index_is_fresh) {
 /* After the renumbering, the same index belongs to another node. */
 TEST_F(XcomStaleReservation, reservation_outliving_a_renumbering_is_stale) {
   synode_no const reserved{1, 25, 1};
+  ASSERT_FALSE(reservation_is_stale(reserved));
+  install_new_view();
   ASSERT_TRUE(reservation_is_stale(reserved));
 }
 
 /* A slot that carries the index this member holds now is usable. */
 TEST_F(XcomStaleReservation, slot_matching_the_new_index_is_fresh) {
+  install_new_view();
   synode_no const reserved{1, 25, 0};
   ASSERT_FALSE(reservation_is_stale(reserved));
 }
 
 /* Without a site there is nothing to compare against. */
 TEST_F(XcomStaleReservation, unknown_site_is_not_reported_stale) {
-  synode_no const other_group{99, 25, 1};
+  synode_no const other_group{99, 25, 0};
   ASSERT_FALSE(reservation_is_stale(other_group));
 }
 

--- a/unittest/gunit/libmysqlgcs/xcom/gcs_xcom_stale_reservation-t.cc
+++ b/unittest/gunit/libmysqlgcs/xcom/gcs_xcom_stale_reservation-t.cc
@@ -1,0 +1,100 @@
+/* Copyright (c) 2026, Oracle and/or its affiliates.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License, version 2.0,
+   as published by the Free Software Foundation.
+
+   This program is designed to work with certain software (including
+   but not limited to OpenSSL) that is licensed under separate terms,
+   as designated in a particular file or component or in included license
+   documentation.  The authors of MySQL hereby grant you an additional
+   permission to link the program and your derivative works with the
+   separately licensed software that they have either included with
+   the program or referenced in the documentation.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License, version 2.0, for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
+
+#include <xcom/xcom_profile.h>
+#include <xcom_vp.h>
+#include "gcs_base_test.h"
+
+#include "site_def.h"
+#include "xcom_base.h"
+
+namespace xcom_stale_reservation_unittest {
+
+/* Bug#121063: a synode reserved under one node index must be recognised as no
+   longer ours once a view change gives this member a different index. */
+class XcomStaleReservation : public GcsBaseTest {
+ protected:
+  void SetUp() override {
+    m_addr = new std::string("127.0.0.1:12345");
+    char const *names[]{m_addr->c_str()};
+    m_na = new_node_address(1, names);
+
+    /* The view in force when the synode is reserved: this member is node 1. */
+    m_before = new_site_def();
+    init_site_def(1, m_na, m_before);
+    m_before->start = m_synode_before;
+    m_before->nodeno = 1;
+    push_site_def(m_before);
+
+    /* The view installed while the reservation is held: the member is now
+       node 0. */
+    m_after = new_site_def();
+    init_site_def(1, m_na, m_after);
+    m_after->start = m_synode_after;
+    m_after->nodeno = 0;
+    push_site_def(m_after);
+  }
+
+  void TearDown() override {
+    push_site_def(nullptr);
+    free_site_defs();
+    delete_node_address(1, m_na);
+    delete m_addr;
+  }
+
+  std::string *m_addr{nullptr};
+  node_address *m_na{nullptr};
+  site_def *m_before{nullptr};
+  site_def *m_after{nullptr};
+
+  /* A view is active from its start synode on, so a slot below 20 falls under
+     the old view and one at or above it under the new one. */
+  synode_no const m_synode_before{1, 10, 0};
+  synode_no const m_synode_after{1, 20, 0};
+};
+
+/* Under the view it was taken in, the reservation is ours. */
+TEST_F(XcomStaleReservation, reservation_under_the_current_index_is_fresh) {
+  synode_no const reserved{1, 15, 1};
+  ASSERT_FALSE(reservation_is_stale(reserved));
+}
+
+/* After the renumbering, the same index belongs to another node. */
+TEST_F(XcomStaleReservation, reservation_outliving_a_renumbering_is_stale) {
+  synode_no const reserved{1, 25, 1};
+  ASSERT_TRUE(reservation_is_stale(reserved));
+}
+
+/* A slot that carries the index this member holds now is usable. */
+TEST_F(XcomStaleReservation, slot_matching_the_new_index_is_fresh) {
+  synode_no const reserved{1, 25, 0};
+  ASSERT_FALSE(reservation_is_stale(reserved));
+}
+
+/* Without a site there is nothing to compare against. */
+TEST_F(XcomStaleReservation, unknown_site_is_not_reported_stale) {
+  synode_no const other_group{99, 25, 1};
+  ASSERT_FALSE(reservation_is_stale(other_group));
+}
+
+}  // namespace xcom_stale_reservation_unittest


### PR DESCRIPTION
Bug#121063: https://bugs.mysql.com/bug.php?id=121063

## What happens

Two members of the same group assign different GNOs to the same transaction, in multi-primary mode, when a member leaves and rejoins during a rolling restart under write load. The group splits into internally consistent sets that disagree on the GTID of the same transaction. It can surface on the `group_replication_applier` channel as Error_code 1032 or 1062, or stay silent with every member ONLINE and the disagreement present only in the binary logs.

Reproduced on 8.4.8, 8.4.11 and 9.7.2. A self contained reproducer is attached to the bug.

## Where it starts

A reserved synode is only ours while we still hold the node index it was reserved under.

`local_synode_allocator` stamps the member's current index into the synode, `synode.node = my_nodeno`. Still inside `reserve_synode_number`, the task yields in the `while (too_far(*msgno))` loop at `TIMED_TASK_WAIT`. During that yield, `site_install_action` reassigns `site->nodeno`. The reservation still carries the old index, so `proposer_task` brands and proposes into a slot that now belongs to another node.

The header comment of `xcom_base.cc` states the rule at line 107: only node N may propose a value for synode {X N}. With two proposers on the same slot at `cnt=0`, `acceptor.promise` is never raised, since it is assigned in exactly one place, inside `handle_simple_prepare`, which is the phase 1 decision. Both proposals are accepted, both are learned, and `handle_learn` keeps whichever LEARN arrived first because of the `/* Avoid re-learn */` guard. Members that heard different values first deliver different payloads.

A bpftrace trace of one such slot followed from ACCEPT through LEARN to DELIVER is in the bug, posted 28 Aug 2026.

## The change

Before proposing, verify the reservation still carries the member's own node index. If it does not, drop it through `retry_new` and take a new one.

This is the same check `incr_msgno` (`xcom_base.cc:668`) already makes whenever it advances, with the comment `In case site and node number has changed`. The client transaction is not lost, it goes out in a slot that does belong to the member.

## Testing

In the lab the anomaly goes to zero: 0 stale proposals out of 15,523,048, against 993 predicted from the unpatched rate, and 0 divergences out of 5,667,504 transactions, against 17.1 expected. No run carrying the patch has reproduced the divergence, on two hosts.

Performance: 12 runs per arm across two hosts, load only, no restarts, no emulated latency, comparing the patched plugin against the same source built without the patch and against the stock image. Ratio of median successful operations per 10 s window, bootstrap over runs: patched over unpatched [0.9998, 1.0004], patched over stock [0.9994, 1.0003]. A positive control with a known throttle was detected at [0.9944, 0.9953], so the method resolves differences of about 0.5%. The workload is rate limited, so this measures behaviour under a production-like load and not peak capacity.

I do not have an MTR test for this. The reproduction needs seven members, rolling restarts and sustained write load, which does not fit the standard framework. The reproducer attached to the bug builds that environment and decides the verdict by decoding every member's binary log and comparing all 21 pairs.
