### PR TITLE
Bug#121193 InnoDB: rollback of an interrupted BLOB update frees a still-referenced LOB

### DIFF
--- a/mysql-test/suite/innodb/r/lob_rollback_frees_referenced_zblob.result
+++ b/mysql-test/suite/innodb/r/lob_rollback_frees_referenced_zblob.result
@@ -1,0 +1,18 @@
+CREATE TABLE t1 (id INT PRIMARY KEY, c LONGBLOB)
+ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=8 ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1, REPEAT('a', 80000));
+SELECT id, LENGTH(c) FROM t1;
+id	LENGTH(c)
+1	80000
+SET DEBUG_SYNC = 'blob_write_middle SIGNAL lob_half_written WAIT_FOR go_never';
+UPDATE t1 SET c = REPEAT('b', 4000000);
+SET DEBUG_SYNC = 'now WAIT_FOR lob_half_written';
+# Kill and restart
+ERROR HY000: Lost connection to MySQL server during query
+SELECT id, LENGTH(c) FROM t1;
+id	LENGTH(c)
+1	80000
+include/assert.inc [row 1 must still own its original LOB after recovery]
+DELETE FROM t1 WHERE id = 1;
+DROP TABLE t1;
+SET DEBUG_SYNC = 'RESET';

--- a/mysql-test/suite/innodb/t/lob_rollback_frees_referenced_zblob.test
+++ b/mysql-test/suite/innodb/t/lob_rollback_frees_referenced_zblob.test
@@ -1,0 +1,97 @@
+# Crash-recovery rollback of an interrupted BLOB UPDATE on a
+# ROW_FORMAT=COMPRESSED table frees the OLD, still-referenced LOB.
+#
+# lob::purge() (lob0purge.cc) dispatches on the page type of the page that the
+# LOB reference points at, and only one of the three branches ignores the
+# is_rollback flag:
+#
+#   FIL_PAGE_TYPE_LOB_FIRST         -> lob::rollback()
+#   FIL_PAGE_TYPE_ZLOB_FIRST        -> z_purge() -> z_rollback()
+#   FIL_PAGE_TYPE_ZBLOB/ZBLOB2/BLOB -> Deleter::destroy()   <-- ignores it
+#
+# For a compressed table a LOB of <= Z_CHUNK_SIZE (128K) is stored in the old
+# single-z-stream format, i.e. on FIL_PAGE_TYPE_ZBLOB pages -- see
+# ref_t::use_single_z_stream().  While btr_store_big_rec_extern_fields() stores
+# a NEW value for that field, the record's reference still holds the OLD LOB's
+# page number and only gains BTR_EXTERN_BEING_MODIFIED_FLAG: the Being_modified
+# constructor in lob0lob.cc resets page_no only for OPCODE_INSERT_UPDATE, not
+# for OPCODE_UPDATE.  That state is redo logged by the
+# page_zip_write_blob_ptr() in the same constructor and made durable by the
+# ctx.check_redolog() right after it.
+#
+# Crash in that window and recovery rollback reaches
+# BtrContext::free_updated_extern_fields() -> lob::purge(rollback = true),
+# which destroys the OLD LOB, and btr_cur_pessimistic_update() then restores
+# the record to point at the pages it has just freed.  The row now references
+# free pages: the read below trips the ut_ad() in buf_page_get_gen(), and once
+# those pages have been handed to another row the value itself is gone.
+#
+# What matters is the format of the OLD value, because that is what lob::purge()
+# dispatches on.  The new value only has to be large enough to be stored
+# externally; whether it ends up as a ZBLOB or a ZLOB is immaterial, the crash
+# window opens before that choice is made.
+
+--source include/have_debug.inc
+--source include/have_debug_sync.inc
+--source include/have_innodb_16k.inc
+--source include/not_valgrind.inc
+--source include/not_crashrep.inc
+
+CREATE TABLE t1 (id INT PRIMARY KEY, c LONGBLOB)
+  ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=8 ENGINE=InnoDB;
+
+# 80000 <= Z_CHUNK_SIZE (128K)  =>  old format, FIL_PAGE_TYPE_ZBLOB pages.
+INSERT INTO t1 VALUES (1, REPEAT('a', 80000));
+SELECT id, LENGTH(c) FROM t1;
+
+--connect (con1, localhost, root,,)
+# blob_write_middle fires in BtrContext::check_redolog_normal() right after
+# commit_btr_mtr().  The first hit is the ctx.check_redolog() that immediately
+# follows the Being_modified guard, i.e. exactly when the record on disk
+# carries the OLD LOB page number plus BTR_EXTERN_BEING_MODIFIED_FLAG and not
+# one byte of the new LOB has been written yet.
+SET DEBUG_SYNC = 'blob_write_middle SIGNAL lob_half_written WAIT_FOR go_never';
+--send UPDATE t1 SET c = REPEAT('b', 4000000)
+
+--connection default
+SET DEBUG_SYNC = 'now WAIT_FOR lob_half_written';
+
+--source include/kill_and_restart_mysqld.inc
+
+--connection con1
+--error CR_SERVER_LOST
+--reap
+--disconnect con1
+
+--connection default
+
+# Recovery has rolled the UPDATE back.  The row is back to its old value and
+# still references the old LOB.  Those pages are on the free list now, but they
+# still hold the data, so this read alone cannot show the damage.
+SELECT id, LENGTH(c) FROM t1;
+
+# Hand the freed LOB pages out to other rows.
+--disable_query_log
+let $i = 60;
+while ($i)
+{
+  eval INSERT INTO t1 VALUES (100 + $i, REPEAT('c', 80000));
+  dec $i;
+}
+--enable_query_log
+
+# Without the fix the LOB pages of row 1 have been handed to another row, so the
+# value read back is no longer the one that was inserted.
+--let $lob_intact = `SELECT c = REPEAT('a', 80000) FROM t1 WHERE id = 1`
+--let $assert_text = row 1 must still own its original LOB after recovery
+--let $assert_cond = $lob_intact = 1
+--source include/assert.inc
+
+# Deleting the row makes purge free the LOB a second time; without the fix this
+# aborts on "InnoDB is trying to free page ... though it is already marked as
+# free in the tablespace", or on ut_a(page_type == FIL_PAGE_TYPE_LOB_FIRST) in
+# lob0purge.cc.
+DELETE FROM t1 WHERE id = 1;
+
+DROP TABLE t1;
+SET DEBUG_SYNC = 'RESET';

--- a/storage/innobase/lob/lob0purge.cc
+++ b/storage/innobase/lob/lob0purge.cc
@@ -485,6 +485,27 @@ void purge(DeleteContext *ctx, dict_index_t *index, trx_id_t trxid,
       page_type == FIL_PAGE_TYPE_ZBLOB2 || /* Partially purged ZBLOB */
       page_type == FIL_PAGE_TYPE_BLOB || page_type == FIL_PAGE_SDI_BLOB ||
       page_type == FIL_PAGE_SDI_ZBLOB) {
+    if (is_rollback && uf != nullptr && dfield_is_ext(&uf->new_val)) {
+      /* Never destroy the LOB that row_undo_mod_clust() is about to restore
+      into the record.  btr_store_big_rec_extern_fields() leaves the reference
+      designating the pre-update LOB until the store is far enough along to
+      redirect it, so a crash in that window brings us here with the reference
+      still pointing at the value being restored; freeing it would leave a live
+      row referencing free pages.
+
+      Comparing page numbers rather than testing BTR_EXTERN_BEING_MODIFIED_FLAG
+      keeps this exact: once the reference has been redirected the two differ,
+      so the LOB that was actually being stored is still freed.  There is
+      nothing to undo here -- an old format BLOB is never partially updated,
+      see ref_t::get_lob_page_info() -- so the LOB is simply left alone. */
+      const ref_t restored(uf->new_val.blobref());
+
+      if (restored.space_id() == ref.space_id() &&
+          restored.page_no() == ref.page_no()) {
+        return;
+      }
+    }
+
     lob::Deleter free_blob(*ctx);
     free_blob.destroy();
     return;


### PR DESCRIPTION
<!-- # Copyright (c) 2026, Oracle and/or its affiliates. -->
<!-- Thanks for contributing to MySQL Server! The prompts below are the few
     things reviewers always need. Delete any that don't apply. -->

### What does this change do?

<!-- One or two sentences. Link the issue/bug it fixes: "Fixes #1234" or
     "BUG#XXXXXXXX". -->
Stops `lob::purge()` from destroying an old-format LOB during rollback when the
record's reference still designates the value that `row_undo_mod_clust()` is
about to restore.

Fixes BUG#121193 — https://bugs.mysql.com/bug.php?id=121193

### Why is it needed?

On a compressed table, a crash while an `UPDATE` is storing a new externally
stored BLOB leaves the record's LOB reference still pointing at the pre-update
LOB — `btr_store_big_rec_extern_fields()` does not redirect it until the store
is far enough along. Recovery rollback frees that LOB and then restores the
record to point at the pages it has just freed, so a live row references free
pages.

On a debug build the next read of that row trips the assertion
`ut_ad(is_possibly_freed() || !block->page.file_page_was_freed)` in `buf0buf.cc`.
Once the freed pages have been handed out to another row, the row reads back
data belonging to their new owner. A release build has no equivalent check —
`file_page_was_freed` is itself under `UNIV_DEBUG`.

Reaching the faulty branch requires the OLD value to be in the old format, which
is why a compressed table is needed: there any LOB of at most `Z_CHUNK_SIZE`
(128K) is stored as a ZBLOB, see `ref_t::use_single_z_stream()`. The format of
the NEW value is immaterial.

Of the three branches in `lob::purge()`, only `FIL_PAGE_TYPE_ZBLOB/ZBLOB2/BLOB`
ignores `is_rollback`; `LOB_FIRST` and `ZLOB_FIRST` are rollback aware.

### How was it tested?

- [x] Added/updated MTR tests under `mysql-test/`
- [ ] `scripts/ci/mtr.sh` passes locally
- [x] Ran the relevant full suite (name it): **innodb (via the default MTR selection)**

Added `innodb.lob_rollback_frees_referenced_zblob`: it stops inside the LOB store
at the `blob_write_middle` sync point, kills the server, and checks after recovery
that the row still owns its original LOB.

Verified on debug builds of 8.0.46, 8.4.11, 9.7.2 and 26.7.0 — the bug reproduces
identically on all four.

Ran the default MTR selection (39 suites, 6967 tests) on a 26.7.0 debug build:
107 failures, none related to this change. Most are keyring/encryption tests that
fail under high parallelism on this host and pass in isolation. Two
(`main.skip_records_in_range`, `perfschema.transaction_nested_events`) fail
identically with and without this patch.

The relevant subset was verified by A/B comparison — same tests, same MTR
invocation, only the patch toggled:

| Test | patch reverted | patch applied |
| --- | --- | --- |
| `innodb.lob_rollback_frees_referenced_zblob` | **fail** | **pass** |
| `main.skip_records_in_range` | fail | fail |
| `perfschema.transaction_nested_events` | fail | fail |
| `innodb_undo.truncate_recover_e01`..`e11` | pass (11) | pass (11) |
| `main.histograms`, `innodb.missing_redologs`, `innodb.check_sector_size` | pass | pass |
| `binlog.binlog_error_action 'row'` | pass | pass |

Identical on both sides except the new test, which flips from fail to pass. All
`innodb` tests whose name contains `lob` or `blob` pass.

### Contributor checklist

- [x] Code is formatted (`scripts/ci/format.sh`)
- [x] Commits are focused with descriptive messages

### AI assistance

- [ ] I did not use AI assistance for this contribution
- [x] I used AI assistance for this contribution

If AI assistance was used, describe the tool(s) and extent of use:

Tool: Claude Code (Anthropic).

Extent: substantial. AI assistance was used to locate the root cause in
`lob::purge()`, to draft the fix and its explanatory comment, to write the MTR
test case, and to draft the commit message.

Manually verified: the reproduction was run against unmodified debug builds of
8.0.46, 8.4.11, 9.7.2 and 26.7.0 and the resulting corruption observed directly.
The claim that the old value is stored as a ZBLOB was checked by reading the
`FIL_PAGE_TYPE` of every page in the `.ibd` file, after
`INFORMATION_SCHEMA.INNODB_BUFFER_PAGE` turned out not to report compressed BLOB
pages. Three variants of the test (small new value; ZLOB old value;
non-compressed table) were run to establish which parts of the reproduction are
actually load-bearing. The A/B comparison above was run to confirm that no other
test changes behaviour. The fix, the test and the commit message were reviewed
line by line and revised several times before submission.

### Areas touched

innodb

