### PR TITLE
Fix output of HELP statement in MySQL Client for 1 item categories

### DIFF
--- a/client/mysql.cc
+++ b/client/mysql.cc
@@ -2814,14 +2814,12 @@ static bool add_line(String &buffer, char *line, size_t line_length,
               discard all characters in the comment after the macro (that is,
               until the end of the comment rather than the next delimiter)
             */
-            for (pos++; *pos && (*pos != '*' || *(pos + 1) != '/'); pos++)
-              ;
+            for (pos++; *pos && (*pos != '*' || *(pos + 1) != '/'); pos++);
             pos--;
           } else {
             for (pos++; *pos && (*pos != *delimiter ||
                                  !is_prefix(pos + 1, delimiter + 1));
-                 pos++)
-              ;  // Remove parameters
+                 pos++);  // Remove parameters
             if (!*pos)
               pos--;
             else
@@ -3495,8 +3493,9 @@ static int com_server_help(String *buffer [[maybe_unused]],
   if (result) {
     const unsigned int num_fields = mysql_num_fields(result);
     const uint64_t num_rows = mysql_num_rows(result);
-    mysql_fetch_fields(result);
-    if (num_fields == 3 && num_rows == 1) {
+    MYSQL_FIELD *fields = mysql_fetch_fields(result);
+    if (num_fields == 3 && num_rows == 1 &&
+        strcmp(fields[0].name, "name") == 0) {
       cur = mysql_fetch_row(result);
       if (!cur) {
         error = -1;
@@ -4901,8 +4900,7 @@ char *get_arg(char *line, bool get_next_arg) {
 
   ptr = line;
   if (get_next_arg) {
-    for (; *ptr; ptr++)
-      ;
+    for (; *ptr; ptr++);
     if (*(ptr + 1)) ptr++;
   } else {
     /* skip leading white spaces */


### PR DESCRIPTION


<!-- # Copyright (c) 2026, Oracle and/or its affiliates. -->
<!-- Thanks for contributing to MySQL Server! The prompts below are the few
     things reviewers always need. Delete any that don't apply. -->

### What does this change do?

<!-- One or two sentences. Link the issue/bug it fixes: "Fixes #1234" or
     "BUG#XXXXXXXX". -->
For categories with only one item in it like 'Storage Engines' it displayed the category with the formatting of a topic leading to incorrect and confusing formatting.

Partly fixes https://bugs.mysql.com/bug.php?id=121230

### Why is it needed?

### How was it tested?

- [ ] Added/updated MTR tests under `mysql-test/`
- [ ] `scripts/ci/mtr.sh` passes locally
- [ ] Ran the relevant full suite (name it): ______

### Contributor checklist

- [x] Code is formatted (`scripts/ci/format.sh`)
- [x] Commits are focused with descriptive messages

### AI assistance

- [ ] I did not use AI assistance for this contribution
- [x] I used AI assistance for this contribution

If AI assistance was used, describe the tool(s) and extent of use:

<!-- e.g. brainstorming, code generation, test generation, refactoring, review.
     Also mention which parts were human-reviewed or manually verified. -->

### Areas touched

<!-- e.g. innodb, optimizer, replication, client, build. Helps auto-routing. -->
client


### Other info

For categories with only one item in it like 'Storage Engines' it displayed the category with the formatting of a topic leading to incorrect and confusing formatting.

The MySQL client has logic to format the result of the HELP statement in two ways:

- format it as category with a list of topics
- format it as single topic

Without this commit:
```
mysql> HELP 'Storage Engines'
Name: 'Storage Engines'
Description:
MERGEExamples:
N
```

With this commit:
```
mysql> HELP 'Storage Engines'
You asked for help about help category: "Storage Engines"
For more information, type 'help <item>', where <item> is one of the following
topics:
   MERGE

```

This commit checks for the name of the first column that is returned.

Help categories with only a single item that are affected:

```
mysql> SELECT hc.name FROM mysql.help_topic ht
    -> INNER JOIN mysql.help_category hc USING(help_category_id)
    -> GROUP BY hc.name HAVING COUNT(*)=1;
+-----------------+
| name            |
+-----------------+
| MBR             |
| WKT             |
| Plugins         |
| Storage Engines |
+-----------------+
4 rows in set (0.001 sec)
```