### PR TITLE
fix(rpl): add clock_diff_with_master to sql_delay_event commit-timestamps path

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_sql_delay_clock_diff.result
+++ b/mysql-test/suite/rpl/r/rpl_sql_delay_clock_diff.result
@@ -1,0 +1,26 @@
+include/rpl/init_source_replica.inc
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the connection metadata repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START REPLICA; see the 'START REPLICA Syntax' in the MySQL Manual for more information.
+[connection master]
+[connection master]
+# Adding debug point 'sql_delay_dec_master_clock_10s' to @@GLOBAL.debug
+[connection slave]
+CHANGE REPLICATION SOURCE TO SOURCE_DELAY= 5;
+include/rpl/start_replica.inc
+include/assert.inc [Assert that SQL_Delay matches the configured delay]
+[connection master]
+CREATE TABLE t1 (a INT);
+include/rpl/sync_to_replica.inc
+[connection master]
+[connection slave]
+include/assert.inc [The replica must wait at least SOURCE_DELAY seconds (clock_diff_with_master must be accounted for)]
+include/assert.inc [The delay should not be excessively long]
+include/rpl/stop_replica.inc
+CHANGE REPLICATION SOURCE TO SOURCE_DELAY= 0;
+include/rpl/start_replica.inc
+[connection master]
+# Removing debug point 'sql_delay_dec_master_clock_10s' from @@GLOBAL.debug
+DROP TABLE t1;
+include/rpl/sync_to_replica.inc
+include/rpl/deinit.inc

--- a/mysql-test/suite/rpl/t/rpl_sql_delay_clock_diff.test
+++ b/mysql-test/suite/rpl/t/rpl_sql_delay_clock_diff.test
@@ -1,0 +1,120 @@
+#
+# ==== Purpose ====
+#
+# Verify that sql_delay_event correctly accounts for
+# clock_diff_with_master when immediate_commit_timestamp is
+# available.  This is a regression test for the fix that added
+# clock_diff_with_master to the commit-timestamps code path,
+# making it consistent with the fallback (when+exec_time) path.
+#
+# ==== Implementation ====
+#
+# A single debug point 'sql_delay_dec_master_clock_10s' is set on
+# the source to simulate a source clock that is 10 seconds behind
+# the replica.  It shifts three time values consistently on the
+# source:
+#
+#   1. UNIX_TIMESTAMP()           (item_timefunc.cc)
+#   2. immediate_commit_timestamp (binlog.cc)
+#   3. event header when.tv_sec   (log_event.cc)
+#
+# The replica IO thread computes clock_diff_with_master using
+# SELECT UNIX_TIMESTAMP() from the source, so it naturally gets
+# clock_diff_with_master = 10 without any replica-side debug point.
+#
+# With SOURCE_DELAY=5, the replica should wait approximately 5
+# seconds.  Without the fix (missing clock_diff_with_master in the
+# commit-timestamps path), the replica would compute:
+#   sql_delay_end = ict(-10s) + 5 = now - 10 + 5 = now - 5
+# which is already in the past, so it would apply the event
+# immediately instead of waiting 5 seconds.
+#
+# The delay is verified by comparing the immediate_commit_timestamp
+# of the same GTID on source and replica, consistent with
+# check_replica_delay.inc.
+#
+# ==== References ====
+#
+# Bug: sql_delay_event missing clock_diff_with_master when using
+#      immediate_commit_timestamp
+
+--source include/have_debug.inc
+--source include/have_mta.inc
+
+--let $rpl_skip_start_slave= 1
+--source include/rpl/init_source_replica.inc
+
+--let $delay= 5
+
+#
+# Set up the source debug point: simulate source clock 10 seconds
+# behind.  This shifts UNIX_TIMESTAMP(), immediate_commit_timestamp,
+# and event header when.tv_sec all by -10 seconds consistently.
+#
+--source include/rpl/connection_source.inc
+--let $debug_point= sql_delay_dec_master_clock_10s
+--source include/add_debug_point.inc
+
+#
+# Configure delayed replication on the replica.
+#
+--source include/rpl/connection_replica.inc
+--eval CHANGE REPLICATION SOURCE TO SOURCE_DELAY= $delay
+--source include/rpl/start_replica.inc
+
+--let $sql_delay= query_get_value(SHOW REPLICA STATUS,SQL_Delay,1)
+--let $assert_text= Assert that SQL_Delay matches the configured delay
+--let $assert_cond= $sql_delay = $delay
+--source include/assert.inc
+
+#
+# Execute a transaction on the source and verify the replica waits
+# at least $delay seconds.  The ICT on the replica should be at
+# least $delay seconds after the ICT on the source.
+#
+--source include/rpl/connection_source.inc
+CREATE TABLE t1 (a INT);
+--let $trx_num= 1
+--let $server_uuid= query_get_value(SELECT @@global.server_uuid, @@global.server_uuid, 1)
+
+--source include/rpl/sync_to_replica.inc
+
+--source include/rpl/connection_source.inc
+--let $gtid= $server_uuid:$trx_num
+--source include/rpl/get_immediate_commit_timestamp.inc
+--let $master_immediate_commit_timestamp= $immediate_commit_timestamp
+
+--source include/rpl/connection_replica.inc
+--let $gtid= $server_uuid:$trx_num
+--source include/rpl/get_immediate_commit_timestamp.inc
+--let $slave_immediate_commit_timestamp= $immediate_commit_timestamp
+--let $timestamp_diff_ms= `SELECT $slave_immediate_commit_timestamp-$master_immediate_commit_timestamp`
+--let $timestamp_diff_sec= `SELECT CEILING($timestamp_diff_ms / 1000000)`
+
+# The source ICT is shifted -10s by the debug point, so the ICT
+# difference = actual_delay + 10.  With the fix, actual_delay ~= 5,
+# so ICT diff ~= 15.  Without the fix, actual_delay ~= 0, so ICT
+# diff ~= 10.  Assert ICT diff >= delay + clock_diff - 1 to catch
+# the missing clock_diff_with_master.
+--let $assert_text= The replica must wait at least SOURCE_DELAY seconds (clock_diff_with_master must be accounted for)
+--let $assert_cond= $timestamp_diff_sec >= $delay + 10 - 1
+--source include/assert.inc
+
+--let $assert_text= The delay should not be excessively long
+--let $assert_cond= $timestamp_diff_sec <= $delay + 10 + 5
+--source include/assert.inc
+
+#
+# Cleanup
+#
+--source include/rpl/stop_replica.inc
+CHANGE REPLICATION SOURCE TO SOURCE_DELAY= 0;
+--source include/rpl/start_replica.inc
+
+--source include/rpl/connection_source.inc
+--let $debug_point= sql_delay_dec_master_clock_10s
+--source include/remove_debug_point.inc
+DROP TABLE t1;
+--source include/rpl/sync_to_replica.inc
+
+--source include/rpl/deinit.inc

--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -3334,8 +3334,7 @@ static bool is_number(const char *str, ulong *res, bool allow_wildcards) {
 
   flag = 0;
   start = str;
-  while (*str++ == ' ')
-    ;
+  while (*str++ == ' ');
   if (*--str == '-' || *str == '+') str++;
   while (my_isdigit(files_charset_info, *str) ||
          (allow_wildcards && (*str == wild_many || *str == wild_one))) {
@@ -3345,8 +3344,7 @@ static bool is_number(const char *str, ulong *res, bool allow_wildcards) {
   if (*str == '.') {
     for (str++; my_isdigit(files_charset_info, *str) ||
                 (allow_wildcards && (*str == wild_many || *str == wild_one));
-         str++, flag = 1)
-      ;
+         str++, flag = 1);
   }
   if (*str != 0 || flag == 0) return false;
   if (res) *res = atol(start);

--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -1376,6 +1376,8 @@ bool MYSQL_BIN_LOG::write_transaction(THD *thd, binlog_cache_data *cache_data,
     log).
   */
   ulonglong immediate_commit_timestamp = my_micro_time();
+  DBUG_EXECUTE_IF("sql_delay_dec_master_clock_10s",
+                  immediate_commit_timestamp -= 10 * 1000000ULL;);
 
   /*
     When the original_commit_timestamp session variable is set to a value

--- a/sql/item_timefunc.cc
+++ b/sql/item_timefunc.cc
@@ -2105,6 +2105,8 @@ bool Item_func_unix_timestamp::val_timeval(my_timeval *tm) {
   if (arg_count == 0) {
     tm->m_tv_sec = current_thd->query_start_in_secs();
     tm->m_tv_usec = 0;
+    DBUG_EXECUTE_IF("sql_delay_dec_master_clock_10s",
+                    tm->m_tv_sec -= 10;);
     // no args: null_value is set in constructor and is always false.
     return false;
   }

--- a/sql/item_timefunc.cc
+++ b/sql/item_timefunc.cc
@@ -2105,8 +2105,7 @@ bool Item_func_unix_timestamp::val_timeval(my_timeval *tm) {
   if (arg_count == 0) {
     tm->m_tv_sec = current_thd->query_start_in_secs();
     tm->m_tv_usec = 0;
-    DBUG_EXECUTE_IF("sql_delay_dec_master_clock_10s",
-                    tm->m_tv_sec -= 10;);
+    DBUG_EXECUTE_IF("sql_delay_dec_master_clock_10s", tm->m_tv_sec -= 10;);
     // no args: null_value is set in constructor and is always false.
     return false;
   }

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -1230,6 +1230,8 @@ uint32 Log_event::write_header_to_memory(uchar *buf) {
   } else {
     DBUG_EXECUTE_IF("inc_event_time_by_1_hour", timestamp = timestamp + 3600;);
     DBUG_EXECUTE_IF("dec_event_time_by_1_hour", timestamp = timestamp - 3600;);
+    DBUG_EXECUTE_IF("sql_delay_dec_master_clock_10s",
+                    timestamp = timestamp - 10;);
   }
 #endif
 

--- a/sql/rpl_replica.cc
+++ b/sql/rpl_replica.cc
@@ -4403,11 +4403,17 @@ static int sql_delay_event(Log_event *ev, THD *thd, Relay_log_info *rli) {
           The immediate master timestamp is expressed in microseconds.
           Delayed replication is defined in seconds.
           Hence convert immediate_commit_timestamp to seconds here.
+
+          immediate_commit_timestamp is in the master's clock, but
+          nap_time is computed against time(nullptr) which is the
+          replica's clock. Add clock_diff_with_master to convert
+          the master timestamp into the replica's clock domain,
+          consistent with the fallback path below.
         */
         sql_delay_end = ceil((static_cast<Gtid_log_event *>(ev)
                                   ->immediate_commit_timestamp) /
                              1000000.00) +
-                        sql_delay;
+                        rli->mi->clock_diff_with_master + sql_delay;
       }
     } else {
       /*


### PR DESCRIPTION
fix(rpl): add clock_diff_with_master to sql_delay_event commit-timestamps path

PROBLEM
=======

In sql_delay_event(), when immediate_commit_timestamp is available from the GTID event, the calculated sql_delay_end does not include clock_diff_with_master:

  sql_delay_end = ceil(immediate_commit_timestamp / 1000000.00) + sql_delay;

However, the fallback path (when commit timestamps are unavailable) correctly adds clock_diff_with_master:

  sql_delay_end = when.tv_sec + clock_diff_with_master + sql_delay;

Since immediate_commit_timestamp is in the master's clock domain but nap_time is computed against time(nullptr) (the replica's clock), the missing clock_diff_with_master causes the delay calculation to be off by the clock difference between master and replica.  For example, if the master clock is 60 seconds ahead of the replica, the replica will wait 60 seconds less than the configured SOURCE_DELAY.

FIX
===

Add clock_diff_with_master to the commit-timestamps code path, making it consistent with the fallback path:

  sql_delay_end = ceil(immediate_commit_timestamp / 1000000.00)
                  + clock_diff_with_master + sql_delay;

This ensures correct delayed replication behavior when master and replica clocks are not synchronized.

The fix is backward compatible: when clock_diff_with_master is 0 (master and replica clocks are synchronized), behavior is unchanged.

<!-- # Copyright (c) 2026, Oracle and/or its affiliates. -->
<!-- Thanks for contributing to MySQL Server! The prompts below are the few
     things reviewers always need. Delete any that don't apply. -->

### What does this change do?

<!-- One or two sentences. Link the issue/bug it fixes: "Fixes #1234" or
     "BUG#XXXXXXXX". -->

### Why is it needed?

### How was it tested?

- [x] Added/updated MTR tests under `mysql-test/`
- [ ] `scripts/ci/mtr.sh` passes locally
- [ ] Ran the relevant full suite (name it): ______

### Contributor checklist

- [x] Code is formatted (`scripts/ci/format.sh`)
- [x] Commits are focused with descriptive messages

### AI assistance

- [ ] I did not use AI assistance for this contribution
- [x] I used AI assistance for this contribution

If AI assistance was used, describe the tool(s) and extent of use:

<!-- e.g. brainstorming, code generation, test generation, refactoring, review.
     Also mention which parts were human-reviewed or manually verified. -->

### Areas touched

<!-- e.g. innodb, optimizer, replication, client, build. Helps auto-routing. -->
